### PR TITLE
docs: Add some consistency to function descriptions

### DIFF
--- a/src/List.mo
+++ b/src/List.mo
@@ -524,7 +524,7 @@ module {
     };
 
   /**
-  Creates an array from a list.
+  Create an array from a list.
   */
   public let toArray : <A> List<A> -> [A] =
     func<A>(xs : List<A>) : [A] {
@@ -538,7 +538,7 @@ module {
     };
 
   /**
-  Creates a mutable array from a list.
+  Create a mutable array from a list.
   */
   public let toArrayMut : <A> List<A> -> [var A] =
     func<A>(xs : List<A>) : [var A] {


### PR DESCRIPTION
The List.mo module documentation seems to be one of the most complete examples in the base lib, so I took a stab at applying a sentence pattern to the descriptions and fixing a few typos.

But the bad news is that I might have inadvertently mangled some of the content because it wasn't completely clear (to me anyway) what we were trying to say.