### PR TITLE
Renames `apply` to `forEach`

### DIFF
--- a/doc/design.md
+++ b/doc/design.md
@@ -124,7 +124,7 @@
 
   - `compare`: compare collections over ordered values (where polymorphic, takes ordering function for values)
 
-  - `forEach`: map unit function over container (a.k.a. `iter`)
+  - `iterate`: map unit function over container (a.k.a. `iter` or `forEach`)
 
   - `map`: map function over container (may change type for polymorphic containers)
 
@@ -138,7 +138,7 @@
 
 * In addition to the above higher-order functions, keyed collections can provide variants where the parameter function takes a `(key, value)` pair:
 
-  - `forEachEntries`
+  - `iterateEntries`
   - `mapEntries`
   - `foldEntries`, `foldEntriesLeft`, `foldEntriesRight`
   - `filterEntries`

--- a/src/Iter.mo
+++ b/src/Iter.mo
@@ -50,7 +50,7 @@ module {
   /// });
   /// assertEquals(6, sum)
   /// ```
-  public func forEach<A>(
+  public func iterate<A>(
     xs : Iter<A>,
     f : (A, Nat) -> ()
   ) {
@@ -73,7 +73,7 @@ module {
   /// (discarding them in the process).
   public func size<A>(xs : Iter<A>) : Nat {
     var len = 0;
-    forEach<A>(xs, func (x, i) { len += 1; });
+    iterate<A>(xs, func (x, i) { len += 1; });
     len;
   };
 
@@ -171,7 +171,7 @@ module {
   /// Like [`toArray`](#value.toArray) but for Lists.
   public func toList<A>(xs : Iter<A>) : List.List<A> {
     var result = List.nil<A>();
-    forEach<A>(xs, func (x, _i) {
+    iterate<A>(xs, func (x, _i) {
       result := List.push<A>(x, result);
     });
     List.reverse<A>(result);

--- a/src/List.mo
+++ b/src/List.mo
@@ -82,10 +82,10 @@ module {
   ///
   /// This function is equivalent to the `app` function in Standard ML Basis,
   /// and the `iter` function in OCaml.
-  public func forEach<T>(l : List<T>, f : T -> ()) {
+  public func iterate<T>(l : List<T>, f : T -> ()) {
     switch l {
       case null     { () };
-      case (?(h,t)) { f(h) ; forEach<T>(t, f) };
+      case (?(h,t)) { f(h) ; iterate<T>(t, f) };
     }
   };
 

--- a/test/iterTest.mo
+++ b/test/iterTest.mo
@@ -25,14 +25,14 @@ Debug.print("Iter");
 };
 
 {
-  Debug.print("  forEach");
+  Debug.print("  iterate");
 
   let xs = [ "a", "b", "c", "d", "e", "f" ];
 
   var y = "";
   var z = 0;
 
-  Iter.forEach<Text>(xs.vals(), func (x : Text, i : Nat) {
+  Iter.iterate<Text>(xs.vals(), func (x : Text, i : Nat) {
     y := y # x;
     z += i;
   });
@@ -50,7 +50,7 @@ Debug.print("Iter");
 
   let _actual = Iter.map<Nat, Bool>([ 1, 2, 3 ].vals(), isEven);
   let actual = [var true, false, true];
-  Iter.forEach<Bool>(_actual, func (x, i) { actual[i] := x; });
+  Iter.iterate<Bool>(_actual, func (x, i) { actual[i] := x; });
 
   let expected = [false, true, false];
 
@@ -78,7 +78,7 @@ Debug.print("Iter");
   let _actual = Iter.fromArray<Nat>(expected);
   let actual = [var 0, 0, 0];
 
-  Iter.forEach<Nat>(_actual, func (x, i) { actual[i] := x; });
+  Iter.iterate<Nat>(_actual, func (x, i) { actual[i] := x; });
 
   for (i in actual.keys()) {
     assert(actual[i] == expected[i]);
@@ -92,7 +92,7 @@ Debug.print("Iter");
   let _actual = Iter.fromArrayMut<Nat>(expected);
   let actual = [var 0, 0, 0];
 
-  Iter.forEach<Nat>(_actual, func (x, i) { actual[i] := x; });
+  Iter.iterate<Nat>(_actual, func (x, i) { actual[i] := x; });
 
   for (i in actual.keys()) {
     assert(actual[i] == expected[i]);
@@ -107,7 +107,7 @@ Debug.print("Iter");
   let actual = [var 0, 0, 0];
   let expected = [1, 2, 3];
 
-  Iter.forEach<Nat>(_actual, func (x, i) { actual[i] := x; });
+  Iter.iterate<Nat>(_actual, func (x, i) { actual[i] := x; });
 
   for (i in actual.keys()) {
     assert(actual[i] == expected[i]);


### PR DESCRIPTION
The remaining `apply`'s in Array and Option are actually `apply` in the Applicative Functor sense, not sure if we want to get rid of those? They are a little arcane in Motoko I'd say (without pervasive currying).