### PR TITLE
Push built documentation to GH pages

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,11 +39,7 @@ jobs:
       run: pushd doc && ./make_docs.sh && popd
     - name: Upload docs
       uses: JamesIves/github-pages-deploy-action@releases/v3
-      on:
-        push:
-          branches:
-            - master
-      if: env.HEAD_TAG != ''
+      if: env.HEAD_TAG != '' && github.ref == 'refs/heads/master'
       with:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         BRANCH: gh-pages

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,8 +35,13 @@ jobs:
     - name: "docs"
       if: github.ref != 'refs/heads/next-moc' && github.base_ref != 'refs/heads/next-moc'
       run: pushd doc && ./make_docs.sh && popd
-    # - name: Upload docs
-    #   uses: actions/upload-artifact@v1
-    #   with:
-    #     name: reference documentation
-    #     path: doc/_out/
+    - name: Upload docs
+      uses: JamesIves/github-pages-deploy-action@releases/v3
+#     on:
+#       push:
+#         branches:
+#           - master
+      with:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        BRANCH: gh-pages # The branch the action should deploy to.
+        FOLDER: docs/_out/html # The folder the action should deploy.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,8 @@ jobs:
     runs-on: ubuntu-18.04
     steps:
     - uses: actions/checkout@v1
+    - name: Check if Git tag exists
+      run: echo "::set-env name=HEAD_TAG::$(git tag --points-at HEAD)"
     - uses: cachix/install-nix-action@v10
     - name: "install dependencies"
       run: |
@@ -37,11 +39,12 @@ jobs:
       run: pushd doc && ./make_docs.sh && popd
     - name: Upload docs
       uses: JamesIves/github-pages-deploy-action@releases/v3
-#     on:
-#       push:
-#         branches:
-#           - master
+      on:
+        push:
+          branches:
+            - master
+      if: env.HEAD_TAG != ''
       with:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        BRANCH: gh-pages # The branch the action should deploy to.
-        FOLDER: doc/_out/html/ # The folder the action should deploy.
+        BRANCH: gh-pages
+        FOLDER: doc/_out/html/

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,4 +44,4 @@ jobs:
       with:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         BRANCH: gh-pages # The branch the action should deploy to.
-        FOLDER: docs/_out/html # The folder the action should deploy.
+        FOLDER: docs/_out/html/ # The folder the action should deploy.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,4 +44,4 @@ jobs:
       with:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         BRANCH: gh-pages # The branch the action should deploy to.
-        FOLDER: docs/_out/html/ # The folder the action should deploy.
+        FOLDER: doc/_out/html/ # The folder the action should deploy.


### PR DESCRIPTION
Looks like I'll need someone with the right permissions to activate GH pages for this repo. And I'll probably also need to create a detached `gh-pages` branch. Opening anyway just to see what happens.