### PR TITLE
Fixes the Bool module summary

### DIFF
--- a/src/Bool.mo
+++ b/src/Bool.mo
@@ -1,5 +1,5 @@
 /// Boolean type and operations.
-
+///
 /// While boolean operators `_ and _` and `_ or _` are short-circuiting,
 /// avoiding computation of the right argument when possible, the functions
 /// `logand(_, _)` and `logor(_, _)` are *strict* and will always evaluate *both*


### PR DESCRIPTION
Avoids the long summary for the Boolean module here:
![grafik](https://user-images.githubusercontent.com/6189397/85903843-9c03d480-b807-11ea-9ec6-2d623cdb8008.png)
