### PR TITLE
Renames `Buf` to `Buffer`

### DIFF
--- a/src/Array.mo
+++ b/src/Array.mo
@@ -2,7 +2,7 @@
 
 import Prim "mo:prim";
 import I "IterType";
-import Buf "Buf";
+import Buffer "Buffer";
 
 module {
   public func equal<A>(a : [A], b : [A], eq : (A, A) -> Bool) : Bool {
@@ -53,7 +53,7 @@ module {
   };
 
   public func filter<A>(xs : [A], f : A -> Bool) : [A] {
-    let ys : Buf.Buf<A> = Buf.Buf(xs.size());
+    let ys : Buffer.Buffer<A> = Buffer.Buffer(xs.size());
     for (x in xs.vals()) {
       if (f(x)) {
         ys.add(x);
@@ -63,7 +63,7 @@ module {
   };
 
   public func filterMap<A, B>(xs : [A], f : A -> ?B) : [B] {
-    let ys : Buf.Buf<B> = Buf.Buf(xs.size());
+    let ys : Buffer.Buffer<B> = Buffer.Buffer(xs.size());
     for (x in xs.vals()) {
       switch (f(x)) {
         case null {};

--- a/src/Buffer.mo
+++ b/src/Buffer.mo
@@ -28,7 +28,7 @@ module {
 /// The argument `initCapacity` gives the initial capacity.  Under the
 /// interface, the mutable array grows by doubling when this initial
 /// capacity is exhausted.
-public class Buf<X> (initCapacity : Nat) {
+public class Buffer<X> (initCapacity : Nat) {
   var count : Nat = 0;
   var elems : [var X] = [var]; // initially empty; allocated upon first `add`
 
@@ -64,7 +64,7 @@ public class Buf<X> (initCapacity : Nat) {
   };
 
   /// Adds all elements in buffer `b` to this buffer.
-  public func append(b : Buf<X>) {
+  public func append(b : Buffer<X>) {
     let i = b.vals();
     loop {
       switch (i.next()) {
@@ -83,8 +83,8 @@ public class Buf<X> (initCapacity : Nat) {
     count := 0;
 
   /// Returns a copy of this buffer.
-  public func clone() : Buf<X> {
-    let c = Buf<X>(elems.size());
+  public func clone() : Buffer<X> {
+    let c = Buffer<X>(elems.size());
     var i = 0;
     label l loop {
       if (i >= count) break l;

--- a/src/Iter.mo
+++ b/src/Iter.mo
@@ -1,7 +1,7 @@
 /// Iterators
 
 import Array "Array";
-import Buffer "Buf";
+import Buffer "Buffer";
 import List "List";
 
 module {
@@ -161,7 +161,7 @@ module {
   /// assertEquals([1, 2, 3], toArray(iter));
   /// ```
   public func toArray<A>(xs : Iter<A>) : [A] {
-    let buffer = Buffer.Buf<A>(8);
+    let buffer = Buffer.Buffer<A>(8);
     iterate(xs, func(x : A, ix : Nat) { buffer.add(x) });
     return buffer.toArray()
   };

--- a/test/bufTest.mo
+++ b/test/bufTest.mo
@@ -1,10 +1,10 @@
 import Prim "mo:prim";
-import B "mo:base/Buf";
+import B "mo:base/Buffer";
 import I "mo:base/Iter";
 import O "mo:base/Option";
 
 // test repeated growing
-let a = B.Buf<Nat>(3);
+let a = B.Buffer<Nat>(3);
 for (i in I.range(0, 123)) {
   a.add(i);
 };
@@ -14,7 +14,7 @@ for (i in I.range(0, 123)) {
 
 
 // test repeated appending
-let b = B.Buf<Nat>(3);
+let b = B.Buffer<Nat>(3);
 for (i in I.range(0, 123)) {
   b.append(a);
 };
@@ -67,7 +67,7 @@ func natIterEq(a:I.Iter<Nat>, b:I.Iter<Nat>) : Bool {
 {
   let bigLen = 100;
   let len = 3;
-  let c = B.Buf<Nat>(bigLen);
+  let c = B.Buffer<Nat>(bigLen);
   assert (len < bigLen);
   for (i in I.range(0, len - 1)) {
     Prim.debugPrint(debug_show(i));
@@ -82,7 +82,7 @@ func natIterEq(a:I.Iter<Nat>, b:I.Iter<Nat>) : Bool {
 
 // regression test: initially-empty buffers grow, element-by-element
 {
-  let c = B.Buf<Nat>(0);
+  let c = B.Buffer<Nat>(0);
   assert (c.toArray().size() == 0);
   assert (c.toVarArray().size() == 0);
   c.add(0);


### PR DESCRIPTION
I think there's no need to abbreviate here, and given that we've also changed `Ord` to `Order` this seems like the right thing to do.