### PR TITLE
Document more of Trie module; clean up.

### DIFF
--- a/src/Trie.mo
+++ b/src/Trie.mo
@@ -1,3 +1,4 @@
+/// Functional maps
 ///
 /// Functional maps (and sets) whose representation is "canonical", and
 /// independent of their operation history (unlike other popular search trees).
@@ -92,7 +93,7 @@ public type Key<K> = {
   key: K;
 };
 
-public type List<T> = List.List<T>;
+type List<T> = List.List<T>;
 
 /// Equality function for two `Key<K>`s, in terms of equality of `K`'s.
 public func equalKey<K>(keq:(K,K) -> Bool) : ((Key<K>,Key<K>) -> Bool) = {


### PR DESCRIPTION
Revises all method/function comments to comply with mo-doc format.

@kritzcreek Unresolved issue with `mo-doc` --- I found that mo-doc (from SDK 0.5.11) doesn't place internal (public) modules into the html output.  So, the `Build` module has doc comments, but they do not show up.