### PR TITLE
Claudio/next moc char props

### DIFF
--- a/src/Char.mo
+++ b/src/Char.mo
@@ -13,10 +13,28 @@ module {
   /// Convert a character to text.
   public let toText : Char -> Text = Prim.charToText;
 
+  // not exposed pendig multi-char implementation.
+  private let toUpper : (c : Char) -> Char = Prim.charToUpper;
+
+  // not exposed pending multi-char implementation.
+  private let toLower : (c : Char) -> Char = Prim.charToLower;
+
   /// Is a character a digit between 0 and 9.
   public func isDigit(char : Char) : Bool {
     Prim.charToWord32(char) - Prim.charToWord32('0') <= (9 : Word32)
   };
+
+  /// Returns the Unicode _White_Space_ property of `c`.
+  public let isWhitespace : (c : Char) -> Bool = Prim.charIsWhitespace;
+
+  /// Returns the Unicode _Lowercase_ property of `c`.
+  public let isLowercase : (c : Char) -> Bool = Prim.charIsLowercase;
+
+  /// Returns the Unicode _Uppercase_ property of `c`.
+  public let isUppercase : (c : Char) -> Bool = Prim.charIsUppercase;
+
+  /// Returns the Unicode _Alphabetic_ property of `c`.
+  public let isAlphabetic : (c : Char) -> Bool = Prim.charIsAlphabetic;
 
   /// Returns `x == y`.
   public func equal(x : Char, y : Char) : Bool { x == y };
@@ -42,23 +60,5 @@ module {
     else if (x == y) #equal
     else #greater
   };
-
-  // not exposed pendig multi-char implementation.
-  private let toUpper : (c : Char) -> Char = Prim.charToUpper;
-
-  // not exposed pending multi-char implementation.
-  private let toLower : (c : Char) -> Char = Prim.charToLower;
-
-  /// Returns the Unicode _White_Space_ property of `c`.
-  public let isWhitespace : (c : Char) -> Bool = Prim.charIsWhitespace;
-
-  /// Returns the Unicode _Lowercase_ property of `c`.
-  public let isLowercase : (c : Char) -> Bool = Prim.charIsLowercase;
-
-  /// Returns the Unicode _Uppercase_ property of `c`.
-  public let isUppercase : (c : Char) -> Bool = Prim.charIsUppercase;
-
-  /// Returns the Unicode _Alphabetic_ property of `c`.
-  public let isAlphabetic : (c : Char) -> Bool = Prim.charIsAlphabetic;
 
 }

--- a/src/Char.mo
+++ b/src/Char.mo
@@ -43,4 +43,22 @@ module {
     else #greater
   };
 
+  // not exposed pendig multi-char implementation.
+  private let toUpper : (c : Char) -> Char = Prim.charToUpper;
+
+  // not exposed pending multi-char implementation.
+  private let toLower : (c : Char) -> Char = Prim.charToLower;
+
+  /// Returns the Unicode _White_Space_ property of `c`.
+  public let isWhitespace : (c : Char) -> Bool = Prim.charIsWhitespace;
+
+  /// Returns the Unicode _Lowercase_ property of `c`.
+  public let isLowercase : (c : Char) -> Bool = Prim.charIsLowercase;
+
+  /// Returns the Unicode _Uppercase_ property of `c`.
+  public let isUppercase : (c : Char) -> Bool = Prim.charIsUppercase;
+
+  /// Returns the Unicode _Alphabetic_ property of `c`.
+  public let isAlphabetic : (c : Char) -> Bool = Prim.charIsAlphabetic;
+
 }

--- a/src/Char.mo
+++ b/src/Char.mo
@@ -2,26 +2,26 @@
 import Prim "mo:prim";
 module {
 
-  /// Convert a character to a word.
-  public let toWord32 : Char -> Word32 = Prim.charToWord32;
+  /// Convert character `c` to a word containing its Unicode scalar value.
+  public let toWord32 : (c : Char) -> Word32 = Prim.charToWord32;
 
-  /// Convert a word to a character.
+  /// Convert word `w` to a character.
   /// Traps if `w` is not a valid Unicode scalar value.
   /// Value `w` is valid if, and only if, `w < 0xD800 or (0xE000 <= w and w <= 0x10FFFF)`.
   public let fromWord32 : (w : Word32)-> Char = Prim.word32ToChar;
 
-  /// Convert a character to text.
-  public let toText : Char -> Text = Prim.charToText;
+  /// Convert character `c` to single character text.
+  public let toText : (c : Char) -> Text = Prim.charToText;
 
-  // not exposed pendig multi-char implementation.
+  // Not exposed pending multi-char implementation.
   private let toUpper : (c : Char) -> Char = Prim.charToUpper;
 
-  // not exposed pending multi-char implementation.
+  // Not exposed pending multi-char implementation.
   private let toLower : (c : Char) -> Char = Prim.charToLower;
 
-  /// Is a character a digit between 0 and 9.
-  public func isDigit(char : Char) : Bool {
-    Prim.charToWord32(char) - Prim.charToWord32('0') <= (9 : Word32)
+  /// Returns `true` when `c` is a decimal digit between `0` and `9`, otherwise `false`.
+  public func isDigit(c : Char) : Bool {
+    Prim.charToWord32(c) - Prim.charToWord32('0') <= (9 : Word32)
   };
 
   /// Returns the Unicode _White_Space_ property of `c`.

--- a/test/charTest.mo
+++ b/test/charTest.mo
@@ -1,0 +1,64 @@
+import Debug "mo:base/Debug";
+import Char "mo:base/Char";
+import Prim "mo:prim";
+
+/*
+//
+// Char.toUpper
+//
+
+assert(Char.toUpper('ö') == 'Ö');
+assert(Char.toUpper('σ') == 'Σ');
+assert(Char.toUpper('💩') == '💩');
+
+//
+// Char.toLower
+//
+
+assert(Char.toLower('Ö') == 'ö');
+assert(Char.toLower('Σ') == 'σ');
+assert(Char.toLower('💩') == '💩');
+*/
+
+//
+// Char.isWhitespace
+//
+
+assert(Char.isWhitespace(' '));
+
+assert(not Char.isWhitespace('x'));
+
+// 12288 (U+3000) = ideographic space
+assert(Char.isWhitespace(Prim.word32ToChar(12288)));
+
+assert(Char.isWhitespace('\t'));
+
+// Vertical tab ('\v')
+assert(Char.isWhitespace(Prim.word32ToChar(0x0B)));
+
+// Form feed ('\f')
+assert(Char.isWhitespace(Prim.word32ToChar(0x0C)));
+
+assert(Char.isWhitespace('\r'));
+
+//
+// Char.isLowercase
+//
+
+assert(Char.isLowercase('x'));
+assert(not Char.isLowercase('X'));
+
+//
+// Char.isUppercase
+//
+
+assert(Char.isUppercase('X'));
+assert(not Char.isUppercase('x'));
+
+//
+// Char.isAlphabetic
+//
+
+assert(Char.isAlphabetic('a'));
+assert(Char.isAlphabetic('京'));
+assert(not Char.isAlphabetic('㋡'));


### PR DESCRIPTION
Exposing new Char primitives implemented by Omer. Some table based ones still missing (eg. IsPunctuation) but better than the wasteland we had before.

I've deliberately chosen the long names to correspond to Unicode properties - Rust does the same and its probably wise.

Although CI fails, these have been checked to pass against Motoko master 