### PR TITLE
Finish documentation for AssocList module

### DIFF
--- a/src/AssocList.mo
+++ b/src/AssocList.mo
@@ -1,7 +1,7 @@
-/// Association Lists, a la functional programming, in Motoko.
+/// Lists of key-value entries ("associations").
 ///
-/// Implements the same interface as `Trie`, but as a linked-list of key-value
-/// pairs.
+/// Implements the same operations as [`Trie`](Trie.html), but uses as a
+/// linked-list of entries and no hashing.
 
 import List "List";
 
@@ -66,7 +66,7 @@ public type AssocList<K,V> = List.List<(K,V)>;
     rec(al)
   };
 
-  /// The key-value pairs of the final list consist of those pairs of
+  /// The entries of the final list consist of those pairs of
   /// the left list whose keys are not present in the right list; the
   /// values of the right list are irrelevant.
   public func diff<K,V,W>(al1: AssocList<K,V>,
@@ -88,6 +88,7 @@ public type AssocList<K,V> = List.List<(K,V)>;
     rec(al1)
   };
 
+  /// Transform and combine the entries of two association lists.
   public func mapAppend<K,V,W,X>(al1:AssocList<K,V>,
                           al2:AssocList<K,W>,
                           vbin:(?V,?W)->X)
@@ -104,6 +105,7 @@ public type AssocList<K,V> = List.List<(K,V)>;
     rec(al1, al2)
   };
 
+  /// Specialied version of [`disj`](AssocList.html#value.disj), optimized for disjoint sub-spaces of keyspace (no matching keys).
   public func disjDisjoint<K,V,W,X>(al1:AssocList<K,V>,
                              al2:AssocList<K,W>,
                              vbin:(?V,?W)->X)
@@ -116,7 +118,7 @@ public type AssocList<K,V> = List.List<(K,V)>;
   /// Produces a "disjunctive image" of the two lists, where the values of
   /// matching keys are combined with the given binary operator.
   ///
-  /// For unmatched key-value pairs, the operator is still applied to
+  /// For unmatched entries, the operator is still applied to
   /// create the value in the image.  To accomodate these various
   /// situations, the operator accepts optional values, but is never
   /// applied to (null, null).
@@ -156,7 +158,7 @@ public type AssocList<K,V> = List.List<(K,V)>;
   /// This operation generalizes the notion of "set intersection" to
   /// finite maps.  Produces a "conjuctive image" of the two lists, where
   /// the values of matching keys are combined with the given binary
-  /// operator, and unmatched key-value pairs are not present in the output.
+  /// operator, and unmatched entries are not present in the output.
   public func join<K,V,W,X>(al1 : AssocList<K,V>,
                      al2:AssocList<K,W>,
                      keq:(K,K)->Bool,
@@ -177,6 +179,7 @@ public type AssocList<K,V> = List.List<(K,V)>;
     rec(al1)
   };
 
+  /// Fold the entries based on the recursive list structure.
   public func fold<K,V,X>(al:AssocList<K,V>,
                    nil:X,
                    cons:(K,V,X)->X)


### PR DESCRIPTION
- Better summary line for the module (better conforms to the rest of the base package).
- Adds missing comments for some functions.
- "key-value pairs" ~> "entries" (to use style guide language more closely)