### PR TITLE
Fix: Support self application of `Buffer.append`

### DIFF
--- a/src/Buffer.mo
+++ b/src/Buffer.mo
@@ -97,8 +97,9 @@ public class Buffer<X> (initCapacity : Nat) {
   /// Returns an [Iter](Iter.html#type.Iter) over the elements of this buffer.
   public func vals() : { next : () -> ?X } = object {
     var pos = 0;
+    var valsCount = count;
     public func next() : ?X {
-      if (pos == count) { null } else {
+      if (pos == valsCount) { null } else {
         let elem = ?elems[pos];
         pos += 1;
         elem

--- a/test/bufTest.mo
+++ b/test/bufTest.mo
@@ -2,6 +2,7 @@ import Prim "mo:prim";
 import B "mo:base/Buffer";
 import I "mo:base/Iter";
 import O "mo:base/Option";
+import Debug "mo:base/Debug";
 
 // test repeated growing
 let a = B.Buffer<Nat>(3);
@@ -91,4 +92,22 @@ func natIterEq(a:I.Iter<Nat>, b:I.Iter<Nat>) : Bool {
   c.add(0);
   assert (c.toArray().size() == 2);
   assert (c.toVarArray().size() == 2);
+};
+
+// regression test: self-append does not diverge
+{
+  let c = B.Buffer<Nat>(0);
+  let d = B.Buffer<Nat>(0);
+
+  c.add(1); d.add(1);
+  c.add(2); d.add(2);
+  c.add(3); d.add(3);
+
+  Debug.print "append test 1: cloning avoids the issue"
+  d.append(d.clone());
+  Debug.print "append test 2: cloning not necessary"
+  c.append(c);
+  Debug.print "success"
+
+  // to do -- two buffers are equal
 };


### PR DESCRIPTION
Appending a buffer with itself causes divergence, which may surprise or disappoint some developers.

Possible fixes:
 1. Keep same behavior (diverge)
 2. Check for this case and trap, failing fast, with an assertion failure within `Buffer.append`
 3. Iterators keep their own state about when to stop, copying it from the `Buffer`'s internal variables (same outcome as first cloning arg before using it for appending, but more efficient).

This PR uses solution 3.

Rationale: The current "problem" is that there's a read-write dependency between the buffer's size when appearing as an argument, and when (also) appearing as the receiver of the `append` invocation.  To permit this call with the expected functional behavior, we just need to break this dependency (copying the number of buffer elements to read before increasing this variable).  This PR does that with a minor remedy to the code.

