### PR TITLE
Update List.mo

### DIFF
--- a/src/List.mo
+++ b/src/List.mo
@@ -175,7 +175,7 @@ module {
     }
   };
 
-  /// Drop all but the first `n` elements from the given list.
+  /// Drop the first `n` elements from the given list.
   public func drop<T>(l : List<T>, n:Nat) : List<T> {
     switch (l, n) {
       case (l_,     0) { l_ };


### PR DESCRIPTION
I believe this actually drops the first `n` elements from the list and not "all but the first `n`" elements, assuming the head is considered the first element (which is done in other methods of `List.mo`).