### PR TITLE
Don't use a package import to reference ourself

### DIFF
--- a/src/Stack.mo
+++ b/src/Stack.mo
@@ -3,7 +3,7 @@
 /// Minimal LIFO (last in first out) implementation, as a class.
 /// See [deque](Deque.html) for mixed LIFO/FIFO behavior.
 ///
-import List "mo:base/List";
+import List "List";
 module {
   public class Stack<T>() {
     var stack : List.List<T> = List.nil<T>();


### PR DESCRIPTION
Tripped over this when running `vessel verify`. Think it would be worth trying to catch this one in CI?