### PR TITLE
Various Result improvements

### DIFF
--- a/src/Array.mo
+++ b/src/Array.mo
@@ -3,6 +3,7 @@
 import Prim "mo:prim";
 import I "IterType";
 import Buffer "Buffer";
+import Result "Result";
 
 module {
   /// Test if two arrays contain equal values
@@ -120,6 +121,43 @@ module {
       f(xs[i], i);
     });
   };
+
+  /// Maps a Result-returning function over an Array and returns either
+  /// the first error or an array of successful values.
+  ///
+  /// ```motoko
+  /// func makeNatural(x : Int) : Result.Result<Nat, Text> =
+  ///   if (x >= 0) {
+  ///     #ok(Int.abs(x))
+  ///   } else {
+  ///     #err(Int.toText(x) # " is not a natural number.")
+  ///   };
+  ///
+  /// mapResult([0, 1, 2], makeNatural) = #ok([0, 1, 2]);
+  /// mapResult([-1, 0, 1], makeNatural) = #err("-1 is not a natural number.");
+  /// ```
+  public func mapResult<A, R, E>(xs : [A], f : A -> Result.Result<R, E>) : Result.Result<[R], E> {
+    let len : Nat = xs.size();
+    var target : [var R] = [var];
+    var i : Nat = 0;
+    var isInit = false;
+    while (i < len) {
+      switch (f(xs[i])) {
+        case (#err err) return #err(err);
+        case (#ok ok) {
+          if (not isInit) {
+            isInit := true;
+            target := init(len, ok);
+          } else {
+            target[i] := ok
+          }
+        };
+      };
+      i += 1;
+    };
+    #ok(freeze(target))
+  };
+
   /// Make an array from a single value.
   public func make<A>(x: A) : [A] {
     [x];

--- a/src/List.mo
+++ b/src/List.mo
@@ -3,6 +3,7 @@
 import Array "Array";
 import Option "Option";
 import Order "Order";
+import Result "Result";
 
 module {
 
@@ -144,6 +145,23 @@ module {
         }
       };
     };
+  };
+
+  /// Maps a Result-returning function over a List and returns either
+  /// the first error or a list of successful values.
+  public func mapResult<A, R, E>(xs : List<A>, f : A -> Result.Result<R, E>) : Result.Result<List<R>, E> {
+    func go(xs : List<A>, acc : List<R>) : Result.Result<List<R>, E> {
+      switch xs {
+        case null #ok(acc);
+        case (?(head, tail)) {
+          switch (f(head)) {
+            case (#err err) #err(err);
+            case (#ok ok) go(tail, ?(ok, acc));
+          };
+        };
+      }
+    };
+    Result.mapOk(go(xs, null), func (xs : List<R>) : List<R> = reverse(xs))
   };
 
   /// Append the elements from one list to another list.

--- a/src/Result.mo
+++ b/src/Result.mo
@@ -162,6 +162,23 @@ public func toArrayOk<R,E>(x:[Result<R,E>]) : Result<[R],E> {
   #ok(Array.tabulate<R>(x.size(), func (i:Nat):R {unwrapOk(x[i]) }))
 };
 
+/// Applies a function to a successful value, but discards the result. Use
+/// `iterate` if you're only interested in the side effect `f` produces.
+///
+/// ```
+/// var counter : Nat = 0;
+/// iterate<Nat, Text>(#ok(5), func (x : Nat) { counter += x });
+/// assert(counter == 5);
+/// iterate<Nat, Text>(#err("Wrong"), func (x : Nat) { counter += x });
+/// assert(counter == 5);
+/// ```
+public func iterate<Ok, Err>(res : Result<Ok, Err>, f : Ok -> ()) {
+  switch res {
+    case (#ok ok) f(ok);
+    case _ ();
+  }
+};
+
 /// Extract and return the value `v` of an `#ok v` result.
 /// Traps if its argument is an `#err` result.
 /// Recommended for testing only, not for production code.

--- a/src/Result.mo
+++ b/src/Result.mo
@@ -134,6 +134,18 @@ public func fromOption<R, E>(x : ?R, err : E) : Result<R, E> {
   }
 };
 
+/// Create an option from a result, turning all #err into `null`.
+/// ```
+/// fromOption(#ok(x)) = ?x
+/// fromOption(#err(e)) = null
+/// ```
+public func toOption<R, E>(r : Result<R, E>) : ?R {
+  switch r {
+    case (#ok x) {?x};
+    case (#err _) {null};
+  }
+};
+
 /// Applies a function to a successful value, but discards the result. Use
 /// `iterate` if you're only interested in the side effect `f` produces.
 ///

--- a/src/Result.mo
+++ b/src/Result.mo
@@ -2,6 +2,7 @@
 
 import P "Prelude";
 import Array "Array";
+import Order "Order";
 
 module {
 
@@ -22,6 +23,36 @@ module {
 public type Result<Ok, Err> = {
   #ok : Ok;
   #err : Err;
+};
+
+// Compares two Result's for equality.
+public func equal<Ok, Err>(
+  eqOk : (Ok, Ok) -> Bool,
+  eqErr : (Err, Err) -> Bool,
+  r1 : Result<Ok, Err>,
+  r2 : Result<Ok, Err>
+) : Bool {
+  switch (r1, r2) {
+    case (#ok ok1, #ok ok2) eqOk(ok1, ok2);
+    case (#err err1, #err err2) eqErr(err1, err2);
+    case _ false;
+  };
+};
+
+// Compares two Results. `#ok` is larger than `#err`. This ordering is
+// arbitrary, but it lets you for example use Results as keys in ordered maps.
+public func compare<Ok, Err>(
+  compareOk : (Ok, Ok) -> Order.Order,
+  compareErr : (Err, Err) -> Order.Order,
+  r1 : Result<Ok, Err>,
+  r2 : Result<Ok, Err>
+) : Order.Order {
+  switch (r1, r2) {
+    case (#ok ok1, #ok ok2) compareOk(ok1, ok2);
+    case (#err err1, #err err2) compareErr(err1, err2);
+    case (#ok _, _) #greater;
+    case (#err _, _) #less;
+  };
 };
 
 /// Allows sequencing of `Result` values and functions that return

--- a/src/Result.mo
+++ b/src/Result.mo
@@ -2,8 +2,6 @@
 
 import Prim "mo:prim";
 import P "Prelude";
-import Array "Array";
-import List "List";
 import Order "Order";
 
 module {
@@ -161,58 +159,6 @@ public func iterate<Ok, Err>(res : Result<Ok, Err>, f : Ok -> ()) {
     case (#ok ok) f(ok);
     case _ ();
   }
-};
-
-/// Maps a Result-returning function over an Array and returns either
-/// the first error or an array of successful values.
-///
-/// ```motoko
-/// func makeNatural(x : Int) : Result<Nat, Text> =
-///   if (x >= 0) {
-///     #ok(Int.abs(x))
-///   } else {
-///     #err(Int.toText(x) # " is not a natural number.")
-///   };
-///
-/// traverseArray([0, 1, 2], makeNatural) = #ok([0, 1, 2]);
-/// traverseArray([-1, 0, 1], makeNatural) = #err("-1 is not a natural number.");
-/// ```
-public func traverseArray<A, R, E>(xs : [A], f : A -> Result<R, E>) : Result<[R], E> {
-  let len : Nat = xs.size();
-  var target : [var R] = [var];
-  var i : Nat = 0;
-  var init = false;
-  while (i < len) {
-    switch (f(xs[i])) {
-      case (#err err) return #err(err);
-      case (#ok ok) {
-        if (not init) {
-          init := true;
-          target := Array.init(len, ok);
-        } else {
-          target[i] := ok
-        }
-      };
-    };
-    i += 1;
-  };
-  #ok(Array.freeze(target))
-};
-
-/// Like [`traverseArray`](#value.traverseArray) but for Lists.
-public func traverseList<A, R, E>(xs : List.List<A>, f : A -> Result<R, E>) : Result<List.List<R>, E> {
-  func go(xs : List.List<A>, acc : List.List<R>) : Result<List.List<R>, E> {
-    switch xs {
-      case null #ok(acc);
-      case (?(head, tail)) {
-        switch (f(head)) {
-          case (#err err) #err(err);
-          case (#ok ok) go(tail, ?(ok, acc));
-        };
-      };
-    }
-  };
-  mapOk(go(xs, null), func (xs : List.List<R>) : List.List<R> = List.reverse(xs))
 };
 
 // Whether this Result is an `#ok`

--- a/src/Result.mo
+++ b/src/Result.mo
@@ -143,14 +143,6 @@ public func fromSomeMap<R1, R2, E>(x:?R1, f:R1->R2, err:E):Result<R2,E> {
   }
 };
 
-/// asserts that the option is Some(_) form.
-public func fromSome<Ok>(o:?Ok):Result<Ok,None> {
-  switch(o) {
-    case (?o) (#ok o);
-    case _ P.unreachable();
-  }
-};
-
 /// Applies a function to a successful value, but discards the result. Use
 /// `iterate` if you're only interested in the side effect `f` produces.
 ///
@@ -220,31 +212,11 @@ public func traverseList<A, R, E>(xs : List.List<A>, f : A -> Result<R, E>) : Re
   mapOk(go(xs, null), func (xs : List.List<R>) : List.List<R> = List.reverse(xs))
 };
 
-/// Extract and return the value `v` of an `#ok v` result.
-/// Traps if its argument is an `#err` result.
-/// Recommended for testing only, not for production code.
-public func unwrapOk<Ok,Error>(r:Result<Ok,Error>):Ok {
-  switch(r) {
-    case (#err e) P.unreachable();
-    case (#ok r) r;
-  }
-};
-
 // Whether this Result is an `#ok`
 public func isOk(r : Result<Any, Any>) : Bool {
   switch r {
     case (#ok _) true;
     case (#err _) false;
-  }
-};
-
-/// Extract and return the value `v` of an `#err v` result.
-/// Traps if its argument is an `#ok` result.
-/// Recommended for testing only, not for production code.
-public func unwrapErr<Ok,Error>(r:Result<Ok,Error>):Error {
-  switch(r) {
-    case (#err e) e;
-    case (#ok r) P.unreachable();
   }
 };
 

--- a/src/Result.mo
+++ b/src/Result.mo
@@ -134,15 +134,6 @@ public func fromOption<R, E>(x : ?R, err : E) : Result<R, E> {
   }
 };
 
-/// Maps the `Ok` type/value from the optional value, or else use the given error value.
-/// (Deprecate?)
-public func fromSomeMap<R1, R2, E>(x:?R1, f:R1->R2, err:E):Result<R2,E> {
-  switch x {
-    case (? x) {#ok (f x)};
-    case null {#err err};
-  }
-};
-
 /// Applies a function to a successful value, but discards the result. Use
 /// `iterate` if you're only interested in the side effect `f` produces.
 ///

--- a/src/Result.mo
+++ b/src/Result.mo
@@ -243,6 +243,14 @@ public func unwrapOk<Ok,Error>(r:Result<Ok,Error>):Ok {
   }
 };
 
+// Whether this Result is an `#ok`
+public func isOk(r : Result<Any, Any>) : Bool {
+  switch r {
+    case (#ok _) true;
+    case (#err _) false;
+  }
+};
+
 /// Extract and return the value `v` of an `#err v` result.
 /// Traps if its argument is an `#ok` result.
 /// Recommended for testing only, not for production code.
@@ -250,6 +258,14 @@ public func unwrapErr<Ok,Error>(r:Result<Ok,Error>):Error {
   switch(r) {
     case (#err e) e;
     case (#ok r) P.unreachable();
+  }
+};
+
+// Whether this Result is an `#err`
+public func isErr(r : Result<Any, Any>) : Bool {
+  switch r {
+    case (#ok _) false;
+    case (#err _) true;
   }
 };
 

--- a/src/Result.mo
+++ b/src/Result.mo
@@ -151,19 +151,6 @@ public func fromSome<Ok>(o:?Ok):Result<Ok,None> {
   }
 };
 
-/// a result that consists of an array of Ok results from an array of results, or the first error in the result array, if any.
-public func toArrayOk<R,E>(x:[Result<R,E>]) : Result<[R],E> {
-  // return early with the first Err result, if any
-  for (i in x.keys()) {
-    switch (x[i]) {
-      case (#err e) { return #err(e) };
-      case (#ok _) { };
-    }
-  };
-  // all of the results are Ok; tabulate them.
-  #ok(Array.tabulate<R>(x.size(), func (i:Nat):R {unwrapOk(x[i]) }))
-};
-
 /// Applies a function to a successful value, but discards the result. Use
 /// `iterate` if you're only interested in the side effect `f` produces.
 ///

--- a/src/Result.mo
+++ b/src/Result.mo
@@ -81,6 +81,22 @@ public func chain<R1, R2, Error>(
   }
 };
 
+/// Flattens a nested Result.
+///
+/// ```motoko
+/// assert(flatten<Nat, Text>(#ok(#ok(10))) == #ok(10))
+/// assert(flatten<Nat, Text>(#err("Wrong") == #err("Wrong"))
+/// assert(flatten<Nat, Text>(#ok(#err("Wrong")) == #err("Wrong"))
+/// ```
+public func flatten<Ok, Error>(
+  result : Result<Result<Ok, Error>, Error>
+) : Result<Ok, Error> {
+  switch result {
+    case (#ok ok) ok;
+    case (#err err) #err(err);
+  }
+};
+
 
 /// Maps the `Ok` type/value, leaving any `Error` type/value unchanged.
 public func mapOk<Ok1, Ok2, Error>(

--- a/test/arrayTest.mo
+++ b/test/arrayTest.mo
@@ -1,8 +1,10 @@
 import Array "mo:base/Array";
 import Debug "mo:base/Debug";
+import Int "mo:base/Int";
+import Result "mo:base/Result";
 import Text "mo:base/Text";
-import Suite "mo:matchers/Suite";
 import M "mo:matchers/Matchers";
+import Suite "mo:matchers/Suite";
 import T "mo:matchers/Testable";
 
 let findTest = {
@@ -67,7 +69,35 @@ let mapEntriesTest = {
   )
 };
 
+func makeNatural(x : Int) : Result.Result<Nat, Text> =
+  if (x >= 0) { #ok(Int.abs(x)) } else { #err(Int.toText(x) # " is not a natural number.") };
+
+func arrayRes(itm : Result.Result<[Nat], Text>) : T.TestableItem<Result.Result<[Nat], Text>> {
+  let resT = T.resultTestable(T.arrayTestable<Nat>(T.intTestable), T.textTestable);
+  { display = resT.display; equals = resT.equals; item = itm }
+};
+
+let mapResult = Suite.suite("mapResult", [
+  Suite.test("empty array",
+    Array.mapResult<Int, Nat, Text>([], makeNatural),
+    M.equals(arrayRes(#ok([])))
+  ),
+  Suite.test("success",
+    Array.mapResult<Int, Nat, Text>([ 1, 2, 3 ], makeNatural),
+    M.equals(arrayRes(#ok([1, 2, 3])))
+  ),
+  Suite.test("fail fast",
+    Array.mapResult<Int, Nat, Text>([ -1, 2, 3 ], makeNatural),
+    M.equals(arrayRes(#err("-1 is not a natural number.")))
+  ),
+  Suite.test("fail last",
+    Array.mapResult<Int, Nat, Text>([ 1, 2, -3 ], makeNatural),
+    M.equals(arrayRes(#err("-3 is not a natural number.")))
+  ),
+]);
+
 let suite = Suite.suite("Array", [
+  mapResult,
   Suite.test(
     "append",
     Array.append<Int>([ 1, 2, 3 ], [ 4, 5, 6 ]),

--- a/test/package-set.dhall
+++ b/test/package-set.dhall
@@ -2,7 +2,7 @@
   {
     name = "matchers",
     repo = "https://github.com/kritzcreek/motoko-matchers.git",
-    version = "v0.1.2",
+    version = "v1.0.0",
     dependencies = [] : List Text
   }
 ]

--- a/test/resultTest.mo
+++ b/test/resultTest.mo
@@ -1,0 +1,115 @@
+import Result "mo:base/Result";
+import Int "mo:base/Int";
+import Array "mo:base/Array";
+import List "mo:base/List";
+
+import Suite "mo:matchers/Suite";
+import M "mo:matchers/Matchers";
+import T "mo:matchers/Testable";
+
+func makeNatural(x : Int) : Result.Result<Nat, Text> =
+  if (x >= 0) { #ok(Int.abs(x)) } else { #err(Int.toText(x) # " is not a natural number.") };
+
+func largerThan10(x : Nat) : Result.Result<Nat, Text> =
+  if (x > 10) { #ok(x) } else { #err(Int.toText(x) # " is not larger than 10.") };
+
+let chain = Suite.suite("chain", [
+  Suite.test("ok -> ok",
+    Result.chain<Nat, Nat, Text>(makeNatural(11), largerThan10),
+    M.equals(T.result(T.natTestable, T.textTestable, #ok(11)))
+  ),
+  Suite.test("ok -> err",
+    Result.chain<Nat, Nat, Text>(makeNatural(5), largerThan10),
+    M.equals(T.result(T.natTestable, T.textTestable, #err("5 is not larger than 10.")))
+  ),
+  Suite.test("err",
+    Result.chain<Nat, Nat, Text>(makeNatural(-5), largerThan10),
+    M.equals(T.result(T.natTestable, T.textTestable, #err("-5 is not a natural number.")))
+  ),
+]);
+
+let flatten = Suite.suite("flatten", [
+  Suite.test("ok -> ok",
+    Result.flatten<Nat, Text>(#ok(#ok(10))),
+    M.equals(T.result(T.natTestable, T.textTestable, #ok(10)))
+  ),
+  Suite.test("err",
+    Result.flatten<Nat, Text>(#err("wrong")),
+    M.equals(T.result(T.natTestable, T.textTestable, #err("wrong")))
+  ),
+  Suite.test("ok -> err",
+    Result.flatten<Nat, Text>(#ok(#err("wrong"))),
+    M.equals(T.result(T.natTestable, T.textTestable, #err("wrong")))
+  ),
+]);
+
+let iterate = Suite.suite("iterate", {
+  var tests : [Suite.Suite] = [];
+  var counter : Nat = 0;
+  Result.iterate(makeNatural(5), func (x : Nat) { counter += x });
+  tests := Array.append(tests, [Suite.test("ok", counter, M.equals(T.nat(5)))]);
+  Result.iterate(makeNatural(-10), func (x : Nat) { counter += x });
+  tests := Array.append(tests, [Suite.test("err", counter, M.equals(T.nat(5)))]);
+  tests
+});
+
+func arrayRes(itm : Result.Result<[Nat], Text>) : T.TestableItem<Result.Result<[Nat], Text>> {
+  let resT = T.resultTestable(T.arrayTestable<Nat>(T.intTestable), T.textTestable);
+  { display = resT.display; equals = resT.equals; item = itm }
+};
+
+let traverseArray = Suite.suite("traverseArray", [
+  Suite.test("empty array",
+    Result.traverseArray<Int, Nat, Text>([], makeNatural), 
+    M.equals(arrayRes(#ok([])))
+  ),
+
+  Suite.test("success",
+    Result.traverseArray<Int, Nat, Text>([ 1, 2, 3 ], makeNatural), 
+    M.equals(arrayRes(#ok([1, 2, 3])))
+  ),
+
+  Suite.test("fail fast",
+    Result.traverseArray<Int, Nat, Text>([ -1, 2, 3 ], makeNatural), 
+    M.equals(arrayRes(#err("-1 is not a natural number.")))
+  ),
+
+  Suite.test("fail last",
+    Result.traverseArray<Int, Nat, Text>([ 1, 2, -3 ], makeNatural), 
+    M.equals(arrayRes(#err("-3 is not a natural number.")))
+  ),
+]);
+
+func listRes(itm : Result.Result<List.List<Nat>, Text>) : T.TestableItem<Result.Result<List.List<Nat>, Text>> {
+  let resT = T.resultTestable(T.listTestable<Nat>(T.intTestable), T.textTestable);
+  { display = resT.display; equals = resT.equals; item = itm }
+};
+
+let traverseList = Suite.suite("traverseList", [
+  Suite.test("empty list",
+    Result.traverseList<Int, Nat, Text>(List.nil(), makeNatural),
+    M.equals(listRes(#ok(List.nil())))
+  ),
+  Suite.test("success",
+    Result.traverseList<Int, Nat, Text>(?(1, ?(2, ?(3, null))), makeNatural),
+    M.equals(listRes(#ok(?(1, ?(2, ?(3, null))))))
+  ),
+  Suite.test("fail fast",
+    Result.traverseList<Int, Nat, Text>(?(-1, ?(2, ?(3, null))), makeNatural),
+    M.equals(listRes(#err("-1 is not a natural number.")))
+  ),
+  Suite.test("fail last",
+    Result.traverseList<Int, Nat, Text>(?(1, ?(2, ?(-3, null))), makeNatural),
+    M.equals(listRes(#err("-3 is not a natural number.")))
+  ),
+]);
+
+let suite = Suite.suite("Result", [
+  chain,
+  flatten,
+  iterate,
+  traverseArray,
+  traverseList
+]);
+
+Suite.run(suite);

--- a/test/resultTest.mo
+++ b/test/resultTest.mo
@@ -53,63 +53,10 @@ let iterate = Suite.suite("iterate", {
   tests
 });
 
-func arrayRes(itm : Result.Result<[Nat], Text>) : T.TestableItem<Result.Result<[Nat], Text>> {
-  let resT = T.resultTestable(T.arrayTestable<Nat>(T.intTestable), T.textTestable);
-  { display = resT.display; equals = resT.equals; item = itm }
-};
-
-let traverseArray = Suite.suite("traverseArray", [
-  Suite.test("empty array",
-    Result.traverseArray<Int, Nat, Text>([], makeNatural), 
-    M.equals(arrayRes(#ok([])))
-  ),
-
-  Suite.test("success",
-    Result.traverseArray<Int, Nat, Text>([ 1, 2, 3 ], makeNatural), 
-    M.equals(arrayRes(#ok([1, 2, 3])))
-  ),
-
-  Suite.test("fail fast",
-    Result.traverseArray<Int, Nat, Text>([ -1, 2, 3 ], makeNatural), 
-    M.equals(arrayRes(#err("-1 is not a natural number.")))
-  ),
-
-  Suite.test("fail last",
-    Result.traverseArray<Int, Nat, Text>([ 1, 2, -3 ], makeNatural), 
-    M.equals(arrayRes(#err("-3 is not a natural number.")))
-  ),
-]);
-
-func listRes(itm : Result.Result<List.List<Nat>, Text>) : T.TestableItem<Result.Result<List.List<Nat>, Text>> {
-  let resT = T.resultTestable(T.listTestable<Nat>(T.intTestable), T.textTestable);
-  { display = resT.display; equals = resT.equals; item = itm }
-};
-
-let traverseList = Suite.suite("traverseList", [
-  Suite.test("empty list",
-    Result.traverseList<Int, Nat, Text>(List.nil(), makeNatural),
-    M.equals(listRes(#ok(List.nil())))
-  ),
-  Suite.test("success",
-    Result.traverseList<Int, Nat, Text>(?(1, ?(2, ?(3, null))), makeNatural),
-    M.equals(listRes(#ok(?(1, ?(2, ?(3, null))))))
-  ),
-  Suite.test("fail fast",
-    Result.traverseList<Int, Nat, Text>(?(-1, ?(2, ?(3, null))), makeNatural),
-    M.equals(listRes(#err("-1 is not a natural number.")))
-  ),
-  Suite.test("fail last",
-    Result.traverseList<Int, Nat, Text>(?(1, ?(2, ?(-3, null))), makeNatural),
-    M.equals(listRes(#err("-3 is not a natural number.")))
-  ),
-]);
-
 let suite = Suite.suite("Result", [
   chain,
   flatten,
   iterate,
-  traverseArray,
-  traverseList
 ]);
 
 Suite.run(suite);


### PR DESCRIPTION
We didn't have any names for `traverse` equivalents in the design document, so I just went with `traverseArray` and `traverseList`, but if you've got better names I'm happy to change those.

I removed the trapping functions, that shouldn't be here.