### PR TITLE
Array.filterMap -> Array.mapFilter

### DIFF
--- a/doc/design.md
+++ b/doc/design.md
@@ -128,6 +128,8 @@
 
   - `map`: map function over container (may change type for polymorphic containers)
 
+  - `mapFilter`: map filtering function (returns option) over container (may change type for polymorphic containers)
+
   - `fold`, `foldLeft`, `foldRight`: fold unordered or ordered collection (have the same argument order, but their callback type differs in its order of arguments)
 
   - `filter`: narrow collections

--- a/src/Array.mo
+++ b/src/Array.mo
@@ -55,7 +55,7 @@ module {
     ys.toArray();
   };
   /// Output array contains each transformed optional value; ordering retained.
-  public func filterMap<A, B>(xs : [A], f : A -> ?B) : [B] {
+  public func mapFilter<A, B>(xs : [A], f : A -> ?B) : [B] {
     let ys : Buffer.Buffer<B> = Buffer.Buffer(xs.size());
     for (x in xs.vals()) {
       switch (f(x)) {

--- a/test/arrayTest.mo
+++ b/test/arrayTest.mo
@@ -89,10 +89,10 @@ let suite = Suite.suite("Array", [
     M.equals(T.array<Nat>(T.natTestable, [ 2, 4, 6 ]))
   ),
   Suite.test(
-    "filterMap",
+    "mapFilter",
     {
       let isEven = func (x : Nat) : ?Nat { if (x % 2 == 0) ?x else null };
-      Array.filterMap([ 1, 2, 3, 4, 5, 6 ], isEven);
+      Array.mapFilter([ 1, 2, 3, 4, 5, 6 ], isEven);
     },
     M.equals(T.array<Nat>(T.natTestable, [ 2, 4, 6 ]))
   ),


### PR DESCRIPTION
Also documents `mapFilter` as the chosen name for type changing filters.

Fixes #191 

This is a breaking change, do we write that down somewhere? Maybe in the `motoko` repo changelog?