### PR TITLE
upgrade matchers, motoko release and use do blocks in tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,9 +22,9 @@ jobs:
         nix-env --install graphviz --file '<nixpkgs>'
     - name: "install Motoko binaries"
       run: |
-       wget https://download.dfinity.systems/motoko/0.4.5/x86_64-linux/motoko-0.4.5.tar.gz
+       wget https://download.dfinity.systems/motoko/0.5.3/x86_64-linux/motoko-0.5.3.tar.gz
        mkdir -p /home/runner/bin
-       tar -xf motoko-0.4.5.tar.gz -C /home/runner/bin
+       tar -xf motoko-0.5.3.tar.gz -C /home/runner/bin
        echo "/home/runner/bin" >> $GITHUB_PATH
     - name: "install vessel"
       run: |

--- a/src/Trie.mo
+++ b/src/Trie.mo
@@ -127,7 +127,7 @@ public func isValid<K,V> (t:Trie<K,V>, enforceNormal:Bool) : Bool {
                  //and
                  ((k.hash & mask) == bits)
                  or
-                 ({ Prim.debugPrint("\nmalformed hash!:\n");
+                 (do { Prim.debugPrint("\nmalformed hash!:\n");
                      Prim.debugPrintInt(Prim.word32ToNat(k.hash));
                      Prim.debugPrint("\n (key hash) != (path bits): \n");
                      Prim.debugPrintInt(Prim.word32ToNat(bits));
@@ -138,7 +138,7 @@ public func isValid<K,V> (t:Trie<K,V>, enforceNormal:Bool) : Bool {
                    })
                }
              ) or
-           ({ Prim.debugPrint("one or more hashes are malformed"); false })
+           (do { Prim.debugPrint("one or more hashes are malformed"); false })
            )
          };
     case (#branch(b)) {
@@ -149,7 +149,7 @@ public func isValid<K,V> (t:Trie<K,V>, enforceNormal:Bool) : Bool {
            let mask1 = mask | (Prim.natToWord32(1) << bitpos1);
            let bits1 = bits | (Prim.natToWord32(1) << bitpos1);
            let sum = size<K,V>(b.left) + size<K,V>(b.right);
-           (b.size == sum or { Prim.debugPrint("malformed size"); false })
+           (b.size == sum or (do { Prim.debugPrint("malformed size"); false }))
            and
            rec(b.left,  ?bitpos1, bits,  mask1)
            and

--- a/test/RBTreeTest.mo
+++ b/test/RBTreeTest.mo
@@ -40,7 +40,7 @@ for ((num, lab) in unsort.vals()) {
   t.put(num, lab);
 };
 
-{ var i = 1;
+do { var i = 1;
 for ((num, lab) in t.entries()) {
   assert(num == i);
  i += 1;
@@ -48,7 +48,7 @@ for ((num, lab) in t.entries()) {
 
 assert RBT.size(t.share()) == 9;
 
-{ var i = 9;
+do { var i = 9;
 for ((num, lab) in t.entriesRev()) {
   assert(num == i);
   i -= 1;

--- a/test/arrayTest.mo
+++ b/test/arrayTest.mo
@@ -7,7 +7,7 @@ import M "mo:matchers/Matchers";
 import Suite "mo:matchers/Suite";
 import T "mo:matchers/Testable";
 
-let findTest = {
+let findTest = do {
   type Element = {
     key : Text;
     value : Int;
@@ -40,7 +40,7 @@ let findTest = {
   )
 };
 
-let mapEntriesTest = {
+let mapEntriesTest = do {
 
   let isEven = func (x : Int) : Bool {
     x % 2 == 0;
@@ -104,7 +104,7 @@ let suite = Suite.suite("Array", [
     M.equals(T.array<Int>(T.intTestable, [ 1, 2, 3, 4, 5, 6 ]))),
   Suite.test(
     "chain",
-    {
+    do {
       let purePlusOne = func (x : Int) : [Int] { [ x + 1 ] };
       Array.chain<Int, Int>([ 0, 1, 2 ], purePlusOne);
     },
@@ -112,7 +112,7 @@ let suite = Suite.suite("Array", [
   ),
   Suite.test(
     "filter",
-    {
+    do {
       let isEven = func (x : Nat) : Bool { x % 2 == 0 };
       Array.filter([ 1, 2, 3, 4, 5, 6 ], isEven);
     },
@@ -120,7 +120,7 @@ let suite = Suite.suite("Array", [
   ),
   Suite.test(
     "mapFilter",
-    {
+    do {
       let isEven = func (x : Nat) : ?Nat { if (x % 2 == 0) ?x else null };
       Array.mapFilter([ 1, 2, 3, 4, 5, 6 ], isEven);
     },
@@ -139,7 +139,7 @@ let suite = Suite.suite("Array", [
   ),
   Suite.test(
     "freeze",
-    {
+    do {
       var xs : [var Int] = [ var 1, 2, 3 ];
       Array.freeze<Int>(xs);
     },
@@ -152,7 +152,7 @@ let suite = Suite.suite("Array", [
   ),
   Suite.test(
     "map",
-    {
+    do {
       let isEven = func (x : Int) : Bool {
         x % 2 == 0;
       };
@@ -169,7 +169,7 @@ let suite = Suite.suite("Array", [
   ),
   Suite.test(
     "thaw",
-    {
+    do {
       let xs : [Int] = [ 1, 2, 3 ];
       Array.freeze(Array.thaw(xs))
     },
@@ -177,7 +177,7 @@ let suite = Suite.suite("Array", [
   ),
   Suite.test(
     "tabulateVar",
-    {
+    do {
       // regression test for (fixed) issues in base cases, where func was called too often:
       let test0 = Array.tabulateVar<Nat>(0, func (i:Nat) { assert(false); 0 });
       let test1 = Array.tabulateVar<Nat>(1, func (i:Nat) { assert(i < 1); 0 });

--- a/test/bufTest.mo
+++ b/test/bufTest.mo
@@ -64,7 +64,7 @@ func natIterEq(a:I.Iter<Nat>, b:I.Iter<Nat>) : Bool {
 };
 
 // regression test: buffers with extra space are converted to arrays of the correct length
-{
+do {
   let bigLen = 100;
   let len = 3;
   let c = B.Buffer<Nat>(bigLen);
@@ -81,7 +81,7 @@ func natIterEq(a:I.Iter<Nat>, b:I.Iter<Nat>) : Bool {
 };
 
 // regression test: initially-empty buffers grow, element-by-element
-{
+do {
   let c = B.Buffer<Nat>(0);
   assert (c.toArray().size() == 0);
   assert (c.toVarArray().size() == 0);

--- a/test/dequeTest.mo
+++ b/test/dequeTest.mo
@@ -4,7 +4,7 @@ import O "mo:base/Option";
 import D "mo:base/Debug";
 
 // test for Queue
-{
+do {
     var l = Deque.empty<Nat>();
     for (i in Iter.range(0, 100)) {
         l := Deque.pushBack(l, i);
@@ -22,8 +22,9 @@ import D "mo:base/Debug";
     };
     O.assertNull(Deque.peekFront<Nat>(l));
 };
+
 // test for Deque
-{
+do {
     var l = Deque.empty<Int>();
     for (i in Iter.range(1, 100)) {
         l := Deque.pushFront(l, -i);

--- a/test/floatTest.mo
+++ b/test/floatTest.mo
@@ -3,70 +3,70 @@ import Float "mo:base/Float";
 
 Debug.print("Float");
 
-{
+do {
   Debug.print("  abs");
 
   assert(Float.abs(1.1) == 1.1);
   assert(Float.abs(-1.1) == 1.1);
 };
 
-{
+do {
   Debug.print("  ceil");
 
   assert(Float.ceil(1.1) == 2.0);
 };
 
-{
+do {
   Debug.print("  floor");
 
   assert(Float.floor(1.1) == 1.0);
 };
 
-{
+do {
   Debug.print("  trunc");
 
   assert(Float.trunc(1.0012345789) == 1.0);
 };
 
-{
+do {
   Debug.print("  nearest");
 
   assert(Float.nearest(1.00001) == 1.0);
   assert(Float.nearest(1.99999) == 2.0);
 };
 
-{
+do {
   Debug.print("  min");
 
   assert(Float.min(1.1, 2.2) == 1.1);
 };
 
-{
+do {
   Debug.print("  max");
 
   assert(Float.max(1.1, 2.2) == 2.2);
 };
 
-{
+do {
   Debug.print("  sin");
 
   assert(Float.sin(0.0) == 0.0);
 };
 
-{
+do {
   Debug.print("  cos");
 
   assert(Float.cos(0.0) == 1.0);
 };
 
-{
+do {
   Debug.print("  toFloat64");
 
   assert(Float.toInt64(1e10) == (10000000000 : Int64));
   assert(Float.toInt64(-1e10) == (-10000000000 : Int64));
 };
 
-{
+do {
   Debug.print("  ofFloat64");
 
   assert(Float.fromInt64(10000000000) == 1e10);
@@ -74,7 +74,7 @@ Debug.print("Float");
 };
 
 
-{
+do {
   Debug.print("  format");
 
   assert(Float.format(#exact, 20.12345678901) == "20.12345678901");
@@ -85,14 +85,14 @@ Debug.print("Float");
 };
 
 
-{
+do {
   Debug.print("  Pi: " # Float.toText(Float.pi));
   Debug.print("  arccos(-1.0): " # Float.toText(Float.arccos(-1.)));
 
   assert(Float.pi == Float.arccos(-1.));
 };
 
-{
+do {
   Debug.print("  e: " # debug_show(Float.toText(Float.e)));
   Debug.print("  exp(1): " # debug_show(Float.toText(Float.exp(1))));
 

--- a/test/funcTest.mo
+++ b/test/funcTest.mo
@@ -4,7 +4,7 @@ import Text "mo:base/Text";
 
 Debug.print("Function");
 
-{
+do {
   Debug.print("  compose");
 
   func isEven(x : Int) : Bool { x % 2 == 0; };
@@ -15,7 +15,7 @@ Debug.print("Function");
   assert(isOdd(1));
 };
 
-{
+do {
   Debug.print("  const");
 
   assert(Function.const<Bool, Text>(true)("abc"));

--- a/test/heapTest.mo
+++ b/test/heapTest.mo
@@ -5,7 +5,7 @@ import Int "mo:base/Int";
 
 let order = Int.compare;
 
-{
+do {
     var pq = H.Heap<Int>(order);
     for (i in I.revRange(100, 0)) {
         pq.put(i);
@@ -27,8 +27,8 @@ let order = Int.compare;
 };
 
 // fromIter
-{
-    {
+do {
+    do {
         let iter = [5,10,9,7,3,8,1,0,2,4,6].vals();
         let pq = H.fromIter<Int>(iter, order);
         for (i in I.range(0, 10)) {
@@ -39,12 +39,12 @@ let order = Int.compare;
         O.assertNull(pq.peekMin());
     };
 
-    {
+    do {
         let pq = H.fromIter<Int>([].vals(), order);
         O.assertNull(pq.peekMin());
     };
 
-    {
+    do {
         let pq = H.fromIter<Int>([100].vals(), order);
         assert(O.unwrap(pq.peekMin()) == 100);
     };

--- a/test/intTest.mo
+++ b/test/intTest.mo
@@ -3,7 +3,7 @@ import Int "mo:base/Int";
 
 Debug.print("Int");
 
-{
+do {
   Debug.print("  add");
 
   assert(Int.add(1, Int.add(2, 3)) == Int.add(1, Int.add(2, 3)));
@@ -13,7 +13,7 @@ Debug.print("Int");
   assert(Int.add(1, 2) == Int.add(2, 1));
 };
 
-{
+do {
   Debug.print("  toText");
 
   assert(Int.toText(0) == "0");

--- a/test/iterTest.mo
+++ b/test/iterTest.mo
@@ -6,7 +6,7 @@ import Debug "mo:base/Debug";
 
 Debug.print("Iter");
 
-{
+do {
   Debug.print("  range");
 
   let tests = [((0,-1), "", "0-1"), ((0,0), "0", "0"), ((0, 5), "012345", ""), ((5, 0), "", "543210")];
@@ -24,7 +24,7 @@ Debug.print("Iter");
   };
 };
 
-{
+do {
   Debug.print("  iterate");
 
   let xs = [ "a", "b", "c", "d", "e", "f" ];
@@ -41,7 +41,7 @@ Debug.print("Iter");
   assert(z == 15);
 };
 
-{
+do {
   Debug.print("  map");
 
   let isEven = func (x : Int) : Bool {
@@ -59,7 +59,7 @@ Debug.print("Iter");
   };
 };
 
-{
+do {
   Debug.print("  make");
 
   let x = 1;
@@ -71,7 +71,7 @@ Debug.print("Iter");
   };
 };
 
-{
+do {
   Debug.print("  fromArray");
 
   let expected = [1, 2, 3];
@@ -85,7 +85,7 @@ Debug.print("Iter");
   };
 };
 
-{
+do {
   Debug.print("  fromArrayMut");
 
   let expected = [var 1, 2, 3];
@@ -99,7 +99,7 @@ Debug.print("Iter");
   };
 };
 
-{
+do {
   Debug.print("  fromList");
 
   let list : List.List<Nat> = ?(1, ?(2, ?(3, List.nil<Nat>())));
@@ -114,7 +114,7 @@ Debug.print("Iter");
   };
 };
 
-{
+do {
   Debug.print("  toArray");
 
   let expected = [1, 2, 3];
@@ -127,7 +127,7 @@ Debug.print("Iter");
   };
 };
 
-{
+do {
   Debug.print("  toArrayMut");
 
   let expected = [var 1, 2, 3];
@@ -140,7 +140,7 @@ Debug.print("Iter");
   };
 };
 
-{
+do {
   Debug.print("  toList");
 
   let expected : List.List<Nat> = ?(1, ?(2, ?(3, List.nil<Nat>())));

--- a/test/listTest.mo
+++ b/test/listTest.mo
@@ -65,7 +65,7 @@ type X = Nat;
   assert (List.size<X>(l2) == 1);
   assert (List.size<X>(l3) == 2);
 
-  {
+  do {
     Debug.print("  flatten");
 
     let expected : List.List<Nat> = ?(1, ?(2, ?(3, null)));
@@ -78,7 +78,7 @@ type X = Nat;
 
   };
 
-  {
+  do {
     Debug.print("  fromArray");
 
     let expected : List.List<Nat> = ?(1, ?(2, ?(3, List.nil<Nat>())));
@@ -88,7 +88,7 @@ type X = Nat;
     assert List.equal<Nat>(expected, actual, func (x1, x2) { x1 == x2 });
   };
 
-  {
+  do {
     Debug.print("  fromVarArray");
 
     let expected : List.List<Nat> = ?(1, ?(2, ?(3, List.nil<Nat>())));
@@ -98,7 +98,7 @@ type X = Nat;
     assert List.equal<Nat>(expected, actual, func (x1, x2) { x1 == x2 });
   };
 
-  {
+  do {
     Debug.print("  toArray");
 
     let expected = [1, 2, 3];
@@ -112,7 +112,7 @@ type X = Nat;
     };
   };
 
-  {
+  do {
     Debug.print("  toVarArray");
 
     let expected = [var 1, 2, 3];

--- a/test/natTest.mo
+++ b/test/natTest.mo
@@ -3,7 +3,7 @@ import Nat "mo:base/Nat";
 
 Debug.print("Nat");
 
-{
+do {
   Debug.print("  add");
 
   assert(Nat.add(1, Nat.add(2, 3)) == Nat.add(1, Nat.add(2, 3)));
@@ -13,7 +13,7 @@ Debug.print("Nat");
   assert(Nat.add(1, 2) == Nat.add(2, 1));
 };
 
-{
+do {
   Debug.print("  toText");
 
   assert(Nat.toText(0) == "0");

--- a/test/noneTest.mo
+++ b/test/noneTest.mo
@@ -4,7 +4,7 @@ import Debug "mo:base/Debug";
 
 Debug.print("None");
 
-{
+do {
   Debug.print("  impossible");
 
   func showNone(x : None) : Text {

--- a/test/optionTest.mo
+++ b/test/optionTest.mo
@@ -248,6 +248,7 @@ do {
     assert(witness == 1);
   };
 };
+
 do {
   Debug.print("  make");
 

--- a/test/optionTest.mo
+++ b/test/optionTest.mo
@@ -3,10 +3,10 @@ import Debug "mo:base/Debug";
 
 Debug.print("Option");
 
-{
+do {
   Debug.print("  apply");
 
-  {
+  do {
     Debug.print("    null function, null value");
 
     let actual = Option.apply<Int, Bool>(null, null);
@@ -22,7 +22,7 @@ Debug.print("Option");
     };
   };
 
-  {
+  do {
     Debug.print("    null function, non-null value");
 
      let actual = Option.apply<Int, Bool>(?0, null);
@@ -38,7 +38,7 @@ Debug.print("Option");
     };
   };
 
-  {
+  do {
     Debug.print("    non-null function, null value");
 
      let isEven = func (x : Int) : Bool {
@@ -58,8 +58,8 @@ Debug.print("Option");
     };
   };
 
-  {
-    Debug.print("    non-null function, non-null value");
+  do {
+   Debug.print("    non-null function, non-null value");
 
    let isEven = func (x : Int) : Bool {
       x % 2 == 0;
@@ -80,10 +80,10 @@ Debug.print("Option");
 
  };
 
-{
+do {
   Debug.print("  bind");
 
-  {
+  do {
     Debug.print("    null value to null value");
 
     let safeInt = func (x : Int) : ?Int {
@@ -107,7 +107,7 @@ Debug.print("Option");
     };
   };
 
-  {
+  do {
     Debug.print("    non-null value to null value");
 
     let safeInt = func (x : Int) : ?Int {
@@ -131,7 +131,7 @@ Debug.print("Option");
     };
   };
 
-  {
+  do {
     Debug.print("    non-null value to non-null value");
 
     let safeInt = func (x : Int) : ?Int {
@@ -157,10 +157,10 @@ Debug.print("Option");
 
 };
 
-{
+do {
   Debug.print("  flatten");
 
-  {
+  do {
     Debug.print("    null value");
 
     let actual = Option.flatten<Int>(?null);
@@ -176,7 +176,7 @@ Debug.print("Option");
     };
   };
 
-  {
+  do {
     Debug.print("    non-null value");
     let actual = Option.flatten<Int>(??0);
     let expected = ?0;
@@ -193,10 +193,10 @@ Debug.print("Option");
 
 };
 
-{
+do {
   Debug.print("  map");
 
-  {
+  do {
     Debug.print("    null value");
 
     let isEven = func (x : Int) : Bool {
@@ -216,7 +216,7 @@ Debug.print("Option");
     };
   };
 
-  {
+  do {
     Debug.print("    non-null value");
 
     let isEven = func (x : Int) : Bool {
@@ -237,10 +237,10 @@ Debug.print("Option");
   };
 
 };
-{
+do {
   Debug.print("  iterate");
 
-  {
+  do {
     var witness = 0;
     Option.iterate<Nat>(?(1), func (x : Nat) { witness += 1; });
     assert(witness == 1);
@@ -248,7 +248,7 @@ Debug.print("Option");
     assert(witness == 1);
   };
 };
-{
+do {
   Debug.print("  make");
 
   let actual = Option.make<Int>(0);

--- a/test/orderTest.mo
+++ b/test/orderTest.mo
@@ -3,7 +3,7 @@ import Debug "mo:base/Debug";
 
 Debug.print("Order");
 
-{
+do {
   Debug.print("  isLess");
 
   assert(Order.isLess(#less));
@@ -11,7 +11,7 @@ Debug.print("Order");
   assert(not Order.isLess(#greater));
 };
 
-{
+do {
   Debug.print("  isEqual");
 
   assert(not Order.isEqual(#less));
@@ -19,7 +19,7 @@ Debug.print("Order");
   assert(not Order.isEqual(#greater));
 };
 
-{
+do {
   Debug.print("  isGreater");
 
   assert(not Order.isGreater(#less));

--- a/test/package-set.dhall
+++ b/test/package-set.dhall
@@ -2,7 +2,7 @@
   {
     name = "matchers",
     repo = "https://github.com/kritzcreek/motoko-matchers.git",
-    version = "v1.0.0",
+    version = "v1.1.0",
     dependencies = [] : List Text
   }
 ]

--- a/test/resultTest.mo
+++ b/test/resultTest.mo
@@ -43,7 +43,7 @@ let flatten = Suite.suite("flatten", [
   ),
 ]);
 
-let iterate = Suite.suite("iterate", {
+let iterate = Suite.suite("iterate", do {
   var tests : [Suite.Suite] = [];
   var counter : Nat = 0;
   Result.iterate(makeNatural(5), func (x : Nat) { counter += x });

--- a/test/stackTest.mo
+++ b/test/stackTest.mo
@@ -2,7 +2,7 @@ import Stack "mo:base/Stack";
 import Iter "mo:base/Iter";
 import O "mo:base/Option";
 
-{
+do {
     var s = Stack.Stack<Nat>();
     for (i in Iter.range(0, 100)) {
         s.push(i);

--- a/test/textTest.mo
+++ b/test/textTest.mo
@@ -101,12 +101,12 @@ run(suite("toIter",
    "toIter-2",
    Text.toIter("abc"),
    M.equals(iterT (['a','b','c']))),
- {
+ do {
    let a = Array.tabulate<Char>(1000, func i = Char.fromWord32(65+Word32.fromInt(i % 26)));
    test(
-   "fromIter-2",
-   Text.toIter(Text.join("", Array.map(a, Char.toText).vals())),
-   M.equals(iterT a))
+     "fromIter-2",
+     Text.toIter(Text.join("", Array.map(a, Char.toText).vals())),
+     M.equals(iterT a))
  },
 ]));
 
@@ -124,7 +124,7 @@ run(suite("fromIter",
    "fromIter-2",
    Text.fromIter((['a', 'b', 'c'].vals())),
    M.equals(T.text "abc")),
- {
+ do {
    let a = Array.tabulate<Char>(1000, func i = Char.fromWord32(65+Word32.fromInt(i % 26)));
    test(
    "fromIter-3",
@@ -168,7 +168,7 @@ run(suite("join",
    "join-2",
    Text.join("", (["a","bb","ccc","dddd"].vals())),
    M.equals(T.text "abbcccdddd")),
- {
+ do {
    let a = Array.tabulate<Char>(1000, func i = Char.fromWord32(65+Word32.fromInt(i % 26)));
    test(
    "join-3",
@@ -199,7 +199,7 @@ run(suite("join",
    "join-2",
    Text.join(",", (["a","bb","ccc","dddd"].vals())),
    M.equals(T.text "a,bb,ccc,dddd")),
- {
+ do {
    let a = Array.tabulate<Char>(1000, func i = Char.fromWord32(65+Word32.fromInt(i % 26)));
    test(
    "join-3",
@@ -243,7 +243,7 @@ run(suite("split",
    "split-char-mixed",
    Text.split("a;;;ab;;abc;", #char ';'),
    M.equals(textIterT(["a","","","ab","","abc",""]))),
- {
+ do {
    let a = Array.tabulate<Text>(1000,func _ = "abc");
    let t = Text.join(";", a.vals());
    test(
@@ -251,7 +251,7 @@ run(suite("split",
      Text.split(t, #char ';'),
      M.equals(textIterT a))
  },
- {
+ do {
    let a = Array.tabulate<Text>(100000,func _ = "abc");
    let t = Text.join(";", a.vals());
    test(
@@ -262,7 +262,7 @@ run(suite("split",
 ]));
 
 
-{
+do {
 let pat : Text.Pattern = #predicate (func (c : Char) : Bool { c == ';' or c == '!' }) ;
 run(suite("split",
 [
@@ -290,7 +290,7 @@ run(suite("split",
    "split-pred-mixed",
    Text.split("a;!;ab;!abc;", pat),
    M.equals(textIterT(["a","","","ab","","abc",""]))),
- {
+ do {
    let a = Array.tabulate<Text>(1000,func _ = "abc");
    let t = Text.join(";", a.vals());
    test(
@@ -298,7 +298,7 @@ run(suite("split",
      Text.split(t, pat),
      M.equals(textIterT a))
  },
- {
+ do {
    let a = Array.tabulate<Text>(10000,func _ = "abc");
    let t = Text.join(";", a.vals());
    test(
@@ -310,7 +310,7 @@ run(suite("split",
 };
 
 
-{
+do {
 let pat : Text.Pattern = #text "PAT" ;
 run(suite("split",
 [
@@ -338,7 +338,7 @@ run(suite("split",
    "split-pat-mixed",
    Text.split("aPATPATPATabPATPATabcPAT", pat),
    M.equals(textIterT(["a","","","ab","","abc",""]))),
- {
+ do {
    let a = Array.tabulate<Text>(1000,func _ = "abc");
    let t = Text.join("PAT", a.vals());
    test(
@@ -346,7 +346,7 @@ run(suite("split",
      Text.split(t, pat),
      M.equals(textIterT a))
  },
- {
+ do {
    let a = Array.tabulate<Text>(10000,func _ = "abc");
    let t = Text.join("PAT", a.vals());
    test(
@@ -384,7 +384,7 @@ run(suite("tokens",
    "tokens-char-mixed",
    Text.tokens("a;;;ab;;abc;", #char ';'),
    M.equals(textIterT(["a","ab","abc"]))),
- {
+ do {
    let a = Array.tabulate<Text>(1000,func _ = "abc");
    let t = Text.join(";;", a.vals());
    test(
@@ -392,7 +392,7 @@ run(suite("tokens",
      Text.tokens(t, #char ';'),
      M.equals(textIterT a))
  },
- {
+ do {
    let a = Array.tabulate<Text>(100000,func _ = "abc");
    let t = Text.join(";;", a.vals());
    test(
@@ -684,7 +684,7 @@ run(suite("trim",
    M.equals(T.text "")),
 ]));
 
-{
+do {
 let cmp = Char.compare;
 run(suite("compareWith",
 [


### PR DESCRIPTION
Many of tests were warning about deprecated block syntax. This PR fixes that.