### PR TITLE
Update Array.adoc

### DIFF
--- a/modules/base-libraries/pages/Array.adoc
+++ b/modules/base-libraries/pages/Array.adoc
@@ -11,6 +11,15 @@ Functions on Arrays
 func equal<A>(a : [A], b : [A], eq : (A, A) -> Bool) : Bool
 ----
 
+[[value.size]]
+== zise
+
+[source.no-repl,motoko]
+----
+func size() : Nat32
+----
+
+
 Test if two arrays contain equal values
 
 [[value.append]]


### PR DESCRIPTION
Seems like Array size is missing from docs even though it works in code? 

so I've been testing with the following code if (Array.filter<VertexNode>(adjList, func (rv : VertexNode) { rv.name != v.name }).size() > 0)
and it seems to be working. Not sure I got that function definition right but it will be great if you can add the correct version. 

Thanks, 
Gabriel