### PR TITLE
Removes Html links from the doc strings

### DIFF
--- a/src/AssocList.mo
+++ b/src/AssocList.mo
@@ -105,7 +105,7 @@ public type AssocList<K,V> = List.List<(K,V)>;
     rec(al1, al2)
   };
 
-  /// Specialied version of [`disj`](AssocList.html#value.disj), optimized for disjoint sub-spaces of keyspace (no matching keys).
+  /// Specialied version of `disj`, optimized for disjoint sub-spaces of keyspace (no matching keys).
   public func disjDisjoint<K,V,W,X>(al1:AssocList<K,V>,
                              al2:AssocList<K,W>,
                              vbin:(?V,?W)->X)

--- a/src/Buffer.mo
+++ b/src/Buffer.mo
@@ -57,8 +57,8 @@ public class Buffer<X> (initCapacity : Nat) {
   /// Removes the item that was inserted last and returns it or `null` if no
   /// elements had been added to the Buffer.
   public func removeLast() : ?X {
-    if (count == 0) { 
-      null 
+    if (count == 0) {
+      null
     } else {
       count -= 1;
       ?elems[count]
@@ -96,7 +96,7 @@ public class Buffer<X> (initCapacity : Nat) {
     c
   };
 
-  /// Returns an [Iter](Iter.html#type.Iter) over the elements of this buffer.
+  /// Returns an `Iter` over the elements of this buffer.
   public func vals() : { next : () -> ?X } = object {
     var pos = 0;
     public func next() : ?X {

--- a/src/HashMap.mo
+++ b/src/HashMap.mo
@@ -119,7 +119,7 @@ public class HashMap<K,V> (
     ov
   };
 
-  /// Returns an [`Iter`](Iter.html#type.Iter) over the key value pairs in this
+  /// Returns an iterator over the key value pairs in this
   /// HashMap. Does _not_ modify the HashMap.
   public func entries() : Iter.Iter<(K,V)> {
     if (table.size() == 0) {

--- a/src/Iter.mo
+++ b/src/Iter.mo
@@ -11,7 +11,7 @@ module {
   /// Iterators are inherently stateful. Calling `next` "consumes" a value from
   /// the Iterator that cannot be put back, so keep that in mind when sharing
   /// iterators between consumers.
-  /// 
+  ///
   /// An iterater `i` can be iterated over using
   /// ```
   /// for (x in i) {
@@ -35,7 +35,7 @@ module {
     public func next() : ?Nat { if (i > y) { null } else {let j = i; i += 1; ?j} };
   };
 
-  /// Like [`range`](#value.range) but produces the values in the opposite
+  /// Like `range` but produces the values in the opposite
   /// order.
   public class revRange(x : Int, y : Int) {
       var i = x;
@@ -43,8 +43,8 @@ module {
   };
 
   /// Calls a function `f` on every value produced by an iterator and discards
-  /// the results. If you're looking to keep these results use
-  /// [`map`](#value.map).
+  /// the results. If you're looking to keep these results use `map` instead.
+  ///
   /// ```motoko
   /// import Iter "mo:base/Iter";
   /// var sum = 0;
@@ -148,14 +148,14 @@ module {
     }
   };
 
-  /// Like [`fromArray`](#value.fromArray) but for Arrays with mutable elements.
-  /// Captures the elements of the Array at the time the iterator is created, so
+  /// Like `fromArray` but for Arrays with mutable elements. Captures
+  /// the elements of the Array at the time the iterator is created, so
   /// further modifications won't be reflected in the iterator.
   public func fromArrayMut<A>(xs : [var A]) : Iter<A> {
     fromArray<A>(Array.freeze<A>(xs));
   };
 
-  /// Like [`fromArray`](#value.fromArray) but for Lists.
+  /// Like `fromArray` but for Lists.
   public func fromList<A>(xs : List.List<A>) : Iter<A> {
     List.toArray<A>(xs).vals();
   };
@@ -172,12 +172,12 @@ module {
     return buffer.toArray()
   };
 
-  /// Like [`toArray`](#value.toArray) but for Arrays with mutable elements.
+  /// Like `toArray` but for Arrays with mutable elements.
   public func toArrayMut<A>(xs : Iter<A>) : [var A] {
     Array.thaw<A>(toArray<A>(xs));
   };
 
-  /// Like [`toArray`](#value.toArray) but for Lists.
+  /// Like `toArray` but for Lists.
   public func toList<A>(xs : Iter<A>) : List.List<A> {
     var result = List.nil<A>();
     iterate<A>(xs, func (x, _i) {

--- a/src/Option.mo
+++ b/src/Option.mo
@@ -88,8 +88,6 @@ public func apply<A, B>(x : ?A, f : ?(A -> B)) : ?B {
 
 /// Applies a function to an optional value. Returns `null` if the argument is
 /// `null`, or the function returns `null`.
-///
-/// NOTE: Together with [`make`](#value.make), this forms a “monad”.
 public func chain<A, B>(x : ?A, f : A -> ?B) : ?B {
   switch(x) {
     case (?x_) {

--- a/src/Text.mo
+++ b/src/Text.mo
@@ -19,7 +19,7 @@ module {
   public let fromChar : (c : Char) -> Text = Prim.charToText;
 
   /// Conversion.
-  /// Creates an [iterator](Iter.html#type.Iter) that traverses the characters of the text `t`.
+  /// Creates an iterator that traverses the characters of the text `t`.
   public func toIter(t : Text) : Iter.Iter<Char> =
     t.chars();
 
@@ -192,11 +192,11 @@ module {
        case (#char(p)) {
          func (cs : Iter.Iter<Char>) : Match {
            switch (cs.next()) {
-             case (?c) { 
-               if (p == c) { 
-                 #success 
-               } else { 
-                 #fail (empty(), c) } 
+             case (?c) {
+               if (p == c) {
+                 #success
+               } else {
+                 #fail (empty(), c) }
                };
              case null { #empty(empty()) };
            }
@@ -205,11 +205,11 @@ module {
        case (#predicate(p)) {
          func (cs : Iter.Iter<Char>) : Match {
            switch (cs.next()) {
-             case (?c) { 
-               if (p(c)) { 
-                 #success 
-               } else { 
-                 #fail(empty(), c) } 
+             case (?c) {
+               if (p(c)) {
+                 #success
+               } else {
+                 #fail(empty(), c) }
                };
              case null { #empty (empty()) };
            }
@@ -271,7 +271,7 @@ module {
   };
 
   /// Returns the sequence of fields in `t`, derived from start to end,
-  /// separated by text matching [pattern](#type.Pattern) `p`.
+  /// separated by text matching pattern `p`.
   /// Two fields are separated by exactly one match.
   public func split(t : Text, p : Pattern) : Iter.Iter<Text> {
     let match = matchOfPattern(p);
@@ -331,7 +331,7 @@ module {
   };
 
   /// Returns the sequence of tokens in `t`, derived from start to end.
-  /// A _token_ is a non-empty maximal subsequence of `t` not containing a match for [pattern](#type.Pattern) `p`.
+  /// A _token_ is a non-empty maximal subsequence of `t` not containing a match for pattern `p`.
   /// Two tokens may be separated by one or more matches of `p`.
   public func tokens(t : Text, p : Pattern) : Iter.Iter<Text> {
     let fs = split(t, p);
@@ -345,7 +345,7 @@ module {
     }
   };
 
-  /// Returns true if `t` contains a match for [pattern](#type.Pattern) `p`.
+  /// Returns true if `t` contains a match for pattern `p`.
   public func contains(t : Text, p : Pattern) : Bool {
     let match = matchOfPattern(p);
     let cs = CharBuffer(t.chars());
@@ -370,7 +370,7 @@ module {
     }
   };
 
-  /// Returns `true` if `t` starts with a prefix matching [pattern](#type.Pattern) `p`, otherwise returns `false`.
+  /// Returns `true` if `t` starts with a prefix matching pattern `p`, otherwise returns `false`.
   public func startsWith(t : Text, p : Pattern) : Bool {
     var cs = t.chars();
     let match = matchOfPattern(p);
@@ -380,7 +380,7 @@ module {
     }
   };
 
-  /// Returns `true` if `t` ends with a suffix matching [pattern](#type.Pattern) `p`, otherwise returns `false`.
+  /// Returns `true` if `t` ends with a suffix matching pattern `p`, otherwise returns `false`.
   public func endsWith(t : Text, p : Pattern) : Bool {
     let s2 = sizeOfPattern(p);
     if (s2 == 0) return true;
@@ -399,7 +399,7 @@ module {
     }
   };
 
-  /// Returns `t` with all matches of [pattern](#type.Pattern) `p` replaced by text `r`.
+  /// Returns `t` with all matches of pattern `p` replaced by text `r`.
   public func replace(t : Text, p : Pattern, r : Text) : Text {
     let match = matchOfPattern(p);
     let size = sizeOfPattern(p);
@@ -438,7 +438,7 @@ module {
 
 
 
-  /// Returns the optioned suffix of `t` obtained by eliding exactly one leading match of [pattern](#type.Pattern) `p`, otherwise `null`.
+  /// Returns the optioned suffix of `t` obtained by eliding exactly one leading match of pattern `p`, otherwise `null`.
   public func stripStart(t : Text, p : Pattern) : ?Text {
     let s = sizeOfPattern(p);
     if (s == 0) return ?t;
@@ -450,7 +450,7 @@ module {
     }
   };
 
-  /// Returns the optioned prefix of `t` obtained by eliding exactly one trailing match of [pattern](#type.Pattern) `p`, otherwise `null`.
+  /// Returns the optioned prefix of `t` obtained by eliding exactly one trailing match of pattern `p`, otherwise `null`.
   public func stripEnd(t : Text, p : Pattern) : ?Text {
     let s2 = sizeOfPattern(p);
     if (s2 == 0) return ?t;
@@ -469,7 +469,7 @@ module {
     }
   };
 
-  /// Returns the suffix of `t` obtained by eliding all leading matches of [pattern](#type.Pattern) `p`.
+  /// Returns the suffix of `t` obtained by eliding all leading matches of pattern `p`.
   public func trimStart(t : Text, p : Pattern) : Text {
     let cs = t.chars();
     let size = sizeOfPattern(p);
@@ -482,11 +482,11 @@ module {
           matchSize += size;
         }; // continue
         case (#empty(cs1)) {
-          return if (matchSize == 0) { 
-            t 
+          return if (matchSize == 0) {
+            t
           } else {
             fromIter(cs1)
-          } 
+          }
         };
         case (#fail (cs1, c)) {
           return if (matchSize == 0) {
@@ -499,7 +499,7 @@ module {
     }
   };
 
-  /// Returns the prefix of `t` obtained by eliding all trailing matches of [pattern](#type.Pattern) `p`.
+  /// Returns the prefix of `t` obtained by eliding all trailing matches of pattern `p`.
   public func trimEnd(t : Text, p : Pattern) : Text {
     let cs = CharBuffer(t.chars());
     let size = sizeOfPattern(p);
@@ -528,7 +528,7 @@ module {
     extract(t, 0, t.size() - matchSize)
   };
 
-  /// Returns the subtext of `t` obtained by eliding all leading and trailing matches of [pattern](#type.Pattern) `p`.
+  /// Returns the subtext of `t` obtained by eliding all leading and trailing matches of pattern `p`.
   public func trim(t : Text, p : Pattern) : Text {
     let cs = t.chars();
     let size = sizeOfPattern(p);

--- a/src/Trie.mo
+++ b/src/Trie.mo
@@ -395,9 +395,9 @@ func splitList<K,V>(l:AssocList<Key<K>,V>, bitpos:Nat)
 ///
 ///   See also:
 ///
-///   - [`disj`](#value.disj)
-///   - [`join`](#value.join)
-///   - [`prod`](#value.prod)
+///   - `disj`
+///   - `join`
+///   - `prod`
 public func merge<K,V>(tl:Trie<K,V>, tr:Trie<K,V>, k_eq:(K,K)->Bool) : Trie<K,V> = label profile_trie_merge : Trie<K,V> {
     let key_eq = equalKey<K>(k_eq);
     func br(l:Trie<K,V>, r:Trie<K,V>) : Trie<K,V> = branch<K,V>(l,r);
@@ -538,9 +538,9 @@ public func diff<K,V,W>(tl:Trie<K,V>, tr:Trie<K,W>, k_eq:(K,K)->Bool): Trie<K,V>
 ///
 /// See also:
 ///
-/// - [`join`](#value.join)
-/// - [`merge`](#value.merge)
-/// - [`prod`](#value.prod)
+/// - `join`
+/// - `merge`
+/// - `prod`
 public func disj<K,V,W,X>(
     tl   : Trie<K,V>,
     tr   : Trie<K,W>,
@@ -617,9 +617,9 @@ public func disj<K,V,W,X>(
   ///
   /// See also:
   ///
-  /// - [`disj`](#value.disj)
-  /// - [`merge`](#value.merge)
-  /// - [`prod`](#value.prod)
+  /// - `disj`
+  /// - `merge`
+  /// - `prod`
   public func join<K,V,W,X>(
     tl:Trie<K,V>,
     tr:Trie<K,W>,
@@ -696,9 +696,9 @@ public func disj<K,V,W,X>(
   ///
   /// See also:
   ///
-  /// - [`disj`](#value.disj)
-  /// - [`join`](#value.join)
-  /// - [`merge`](#value.merge)
+  /// - `disj`
+  /// - `join`
+  /// - `merge`
   public func prod<K1,V1,K2,V2,K3,V3>(
     tl    :Trie<K1,V1>,
     tr    :Trie<K2,V2>,
@@ -931,7 +931,7 @@ public func disj<K,V,W,X>(
    /// Project the nth key-value pair from the trie.
    ///
    /// Note: This position is not meaningful; it's only here so that we
-   /// can inject tries into arrays using functions like [Array.tabulate](Array.html#value.tabulate).
+   /// can inject tries into arrays using functions like `Array.tabulate`.
   public func nth<K,V>(t:Trie<K,V>, i:Nat) : ?(Key<K>, V) = label profile_trie_nth : (?(Key<K>, V)) {
     func rec(t:Trie<K,V>, i:Nat) : ?(Key<K>, V) = label profile_trie_nth_rec : (?(Key<K>, V)) {
       switch t {

--- a/src/TrieMap.mo
+++ b/src/TrieMap.mo
@@ -15,7 +15,7 @@ import List "List";
 /// An imperative hash-based map with a minimal object-oriented interface.
 /// Maps keys of type `K` to values of type `V`.
 ///
-/// See also: [`HashMap`](HashMap.html), with a matching interface.
+/// See also the `HashMap` module, with a matching interface.
 /// Unlike HashMap, the iterators are persistent (pure), clones are cheap and the maps have an efficient persistent representation.
 module {
 public class TrieMap<K,V> (isEq:(K, K) -> Bool, hashOf: K -> Hash.Hash) {
@@ -30,7 +30,7 @@ public class TrieMap<K,V> (isEq:(K, K) -> Bool, hashOf: K -> Hash.Hash) {
   public func put(k:K, v:V) =
     ignore replace(k, v);
 
-  /// [`Put`](#value.put) the key and value, _and_ return the (optional) prior value for the key.
+  /// Put the key and value, _and_ return the (optional) prior value for the key.
   public func replace(k:K, v:V) : ?V {
     let keyObj = {key=k; hash=hashOf(k);};
     let (map2, ov) =
@@ -53,7 +53,7 @@ public class TrieMap<K,V> (isEq:(K, K) -> Bool, hashOf: K -> Hash.Hash) {
   public func delete(k:K) =
     ignore remove(k);
 
-  /// [`Delete`](#value.delete) and return the (optional) value associated with the given key.
+  /// Delete and return the (optional) value associated with the given key.
   public func remove(k:K) : ?V {
     let keyObj = {key=k; hash=hashOf(k);};
     let (t, ov) = T.remove<K, V>(map, keyObj, isEq);
@@ -65,7 +65,7 @@ public class TrieMap<K,V> (isEq:(K, K) -> Bool, hashOf: K -> Hash.Hash) {
     ov
   };
 
-  /// Returns an [`Iter`](Iter.html#type.Iter) over the entries.
+  /// Returns an `Iter` over the entries.
   ///
   /// Each iterator gets a _persistent view_ of the mapping, independent of concurrent updates to the iterated map.
   public func entries() : I.Iter<(K,V)> = object {


### PR DESCRIPTION
These don't work in the Asciidoc output, and most of these are covered by the new `mo-doc` cross-referencing anyways.

Fixes #215 