### PR TITLE
Expose new bit operations on NatN and IntN

### DIFF
--- a/src/Char.mo
+++ b/src/Char.mo
@@ -5,6 +5,11 @@ module {
   /// Convert character `c` to a word containing its Unicode scalar value.
   public let toWord32 : (c : Char) -> Word32 = Prim.charToWord32;
 
+  /// Convert `w` to a character.
+  /// Traps if `w` is not a valid Unicode scalar value.
+  /// Value `w` is valid if, and only if, `w < 0xD800 or (0xE000 <= w and w <= 0x10FFFF)`.
+  public let fromNat32 : (w : Nat32) -> Char = Prim.nat32ToChar;
+
   /// Convert word `w` to a character.
   /// Traps if `w` is not a valid Unicode scalar value.
   /// Value `w` is valid if, and only if, `w < 0xD800 or (0xE000 <= w and w <= 0x10FFFF)`.
@@ -21,7 +26,7 @@ module {
 
   /// Returns `true` when `c` is a decimal digit between `0` and `9`, otherwise `false`.
   public func isDigit(c : Char) : Bool {
-    Prim.charToWord32(c) - Prim.charToWord32('0') <= (9 : Word32)
+    Prim.charToNat32(c) -% Prim.charToNat32('0') <= (9 : Nat32)
   };
 
   /// Returns the Unicode _White_Space_ property of `c`.

--- a/src/Hash.mo
+++ b/src/Hash.mo
@@ -62,13 +62,13 @@ module {
   public func hashWord8(key : [Hash]) : Hash {
     var hash = Prim.natToWord32(0);
     for (wordOfKey in key.vals()) {
-      hash := hash + wordOfKey;
-      hash := hash + hash << 10;
+      hash := hash +% wordOfKey;
+      hash := hash +% hash << 10;
       hash := hash ^ (hash >> 6);
     };
-    hash := hash + hash << 3;
+    hash := hash +% hash << 3;
     hash := hash ^ (hash >> 11);
-    hash := hash + hash << 15;
+    hash := hash +% hash << 15;
     return hash;
   };
 

--- a/src/Int16.mo
+++ b/src/Int16.mo
@@ -12,6 +12,15 @@ module {
   /// Conversion. Traps on overflow/underflow.
   public let fromInt : Int -> Int16  = Prim.intToInt16;
 
+  /// Conversion. Wraps on overflow/underflow.
+  public let fromIntWrap : Int -> Int16  = Prim.intToInt16Wrap;
+
+  /// Conversion. Wraps on overflow/underflow.
+  public let fromNat16 : Nat16 -> Int16 = Prim.nat16ToInt16;
+
+  /// Conversion. Wraps on overflow/underflow.
+  public let toNat16 : Int16 -> Nat16  = Prim.int16ToNat16;
+
   /// Returns the Text representation of `x`.
   public func toText(x : Int16) : Text {
     Int.toText(toInt(x))
@@ -80,4 +89,68 @@ module {
   /// Returns `x` to the power of `y`, `x ** y`. Traps on overflow.
   public func pow(x : Int16, y : Int16) : Int16 { x ** y };
 
+  /// Returns the bitwise negation of `x`, `^x`.
+  public func bitnot(x : Int16, y : Int16) : Int16 { ^x };
+
+  /// Returns the bitwise and of `x` and `y`, `x & y`.
+  public func bitand(x : Int16, y : Int16) : Int16 { x & y };
+
+  /// Returns the bitwise or of `x` and `y`, `x \| y`.
+  public func bitor(x : Int16, y : Int16) : Int16 { x | y };
+
+  /// Returns the bitwise exclusive or of `x` and `y`, `x ^ y`.
+  public func bitxor(x : Int16, y : Int16) : Int16 { x ^ y };
+
+  /// Returns the bitwise shift left of `x` by `y`, `x << y`.
+  public func bitshiftLeft(x : Int16, y : Int16) : Int16 { x << y };
+
+  /// Returns the bitwise shift right of `x` by `y`, `x >> y`.
+  public func bitshiftRight(x : Int16, y : Int16) : Int16 { x >> y };
+
+  /// Returns the bitwise rotate left of `x` by `y`, `x <<> y`.
+  public func bitrotLeft(x : Int16, y : Int16) : Int16 { x <<> y };
+
+  /// Returns the bitwise rotate right of `x` by `y`, `x <>> y`.
+  public func bitrotRight(x : Int16, y : Int16) : Int16 { x <>> y };
+
+  /// Returns the value of bit `p mod 16` in `x`, `(x & 2^(p mod 16)) == 2^(p mod 16)`.
+  public func bittest(x : Int16, p : Nat) : Bool {
+    Prim.btstInt16(x, Prim.intToInt16(p));
+  };
+
+  /// Returns the value of setting bit `p mod 16` in `x` to `1`.
+  public func bitset(x : Int16, p : Nat) : Int16 {
+    x | (1 << Prim.intToInt16(p));
+  };
+
+  /// Returns the value of clearing bit `p mod 16` in `x` to `0`.
+  public func bitclear(x : Int16, p : Nat) : Int16 {
+    x & ^(1 << Prim.intToInt16(p));
+  };
+
+  /// Returns the value of flipping bit `p mod 16` in `x`.
+  public func bitflip(x : Int16, p : Nat) : Int16 {
+    x ^ (1 << Prim.intToInt16(p));
+  };
+
+  /// Returns the count of non-zero bits in `x`.
+  public let bitcountNonZero : (x : Int16) -> Int16 = Prim.popcntInt16;
+
+  /// Returns the count of leading zero bits in `x`.
+  public let bitcountLeadingZero : (x : Int16) -> Int16 = Prim.clzInt16;
+
+  /// Returns the count of trailing zero bits in `x`.
+  public let bitcountTrailingZero : (x : Int16) -> Int16 = Prim.ctzInt16;
+
+  /// Returns the sum of `x` and `y`, `x +% y`. Wraps on overflow.
+  public func addWrap(x : Int16, y : Int16) : Int16 { x +% y };
+
+  /// Returns the difference of `x` and `y`, `x -% y`. Wraps on underflow.
+  public func subWrap(x : Int16, y : Int16) : Int16 { x -% y };
+
+  /// Returns the product of `x` and `y`, `x *% y`. Wraps on overflow.
+  public func mulWrap(x : Int16, y : Int16) : Int16 { x *% y };
+
+  /// Returns `x` to the power of `y`, `x **% y`. Wraps on overflow. Traps if `y < 0`.
+  public func powWrap(x : Int16, y : Int16) : Int16 { x **% y };
 }

--- a/src/Int32.mo
+++ b/src/Int32.mo
@@ -12,6 +12,15 @@ module {
   /// Conversion. Traps on overflow/underflow.
   public let fromInt : Int -> Int32  = Prim.intToInt32;
 
+  /// Conversion. Wraps on overflow/underflow.
+  public let fromIntWrap : Int -> Int32  = Prim.intToInt32Wrap;
+
+  /// Conversion. Wraps on overflow/underflow.
+  public let fromNat32 : Nat32 -> Int32 = Prim.nat32ToInt32;
+
+  /// Conversion. Wraps on overflow/underflow.
+  public let toNat32 : Int32 -> Nat32  = Prim.int32ToNat32;
+
   /// Returns the Text representation of `x`.
   public func toText(x : Int32) : Text {
     Int.toText(toInt(x))
@@ -79,5 +88,70 @@ module {
 
   /// Returns `x` to the power of `y`, `x ** y`. Traps on overflow.
   public func pow(x : Int32, y : Int32) : Int32 { x ** y };
+
+  /// Returns the bitwise negation of `x`, `^x`.
+  public func bitnot(x : Int32, y : Int32) : Int32 { ^x };
+
+  /// Returns the bitwise and of `x` and `y`, `x & y`.
+  public func bitand(x : Int32, y : Int32) : Int32 { x & y };
+
+  /// Returns the bitwise or of `x` and `y`, `x \| y`.
+  public func bitor(x : Int32, y : Int32) : Int32 { x | y };
+
+  /// Returns the bitwise exclusive or of `x` and `y`, `x ^ y`.
+  public func bitxor(x : Int32, y : Int32) : Int32 { x ^ y };
+
+  /// Returns the bitwise shift left of `x` by `y`, `x << y`.
+  public func bitshiftLeft(x : Int32, y : Int32) : Int32 { x << y };
+
+  /// Returns the bitwise shift right of `x` by `y`, `x >> y`.
+  public func bitshiftRight(x : Int32, y : Int32) : Int32 { x >> y };
+
+  /// Returns the bitwise rotate left of `x` by `y`, `x <<> y`.
+  public func bitrotLeft(x : Int32, y : Int32) : Int32 { x <<> y };
+
+  /// Returns the bitwise rotate right of `x` by `y`, `x <>> y`.
+  public func bitrotRight(x : Int32, y : Int32) : Int32 { x <>> y };
+
+  /// Returns the value of bit `p mod 16` in `x`, `(x & 2^(p mod 16)) == 2^(p mod 16)`.
+  public func bittest(x : Int32, p : Nat) : Bool {
+    Prim.btstInt32(x, Prim.intToInt32(p));
+  };
+
+  /// Returns the value of setting bit `p mod 16` in `x` to `1`.
+  public func bitset(x : Int32, p : Nat) : Int32 {
+    x | (1 << Prim.intToInt32(p));
+  };
+
+  /// Returns the value of clearing bit `p mod 16` in `x` to `0`.
+  public func bitclear(x : Int32, p : Nat) : Int32 {
+    x & ^(1 << Prim.intToInt32(p));
+  };
+
+  /// Returns the value of flipping bit `p mod 16` in `x`.
+  public func bitflip(x : Int32, p : Nat) : Int32 {
+    x ^ (1 << Prim.intToInt32(p));
+  };
+
+  /// Returns the count of non-zero bits in `x`.
+  public let bitcountNonZero : (x : Int32) -> Int32 = Prim.popcntInt32;
+
+  /// Returns the count of leading zero bits in `x`.
+  public let bitcountLeadingZero : (x : Int32) -> Int32 = Prim.clzInt32;
+
+  /// Returns the count of trailing zero bits in `x`.
+  public let bitcountTrailingZero : (x : Int32) -> Int32 = Prim.ctzInt32;
+
+  /// Returns the sum of `x` and `y`, `x +% y`. Wraps on overflow.
+  public func addWrap(x : Int32, y : Int32) : Int32 { x +% y };
+
+  /// Returns the difference of `x` and `y`, `x -% y`. Wraps on underflow.
+  public func subWrap(x : Int32, y : Int32) : Int32 { x -% y };
+
+  /// Returns the product of `x` and `y`, `x *% y`. Wraps on overflow.
+  public func mulWrap(x : Int32, y : Int32) : Int32 { x *% y };
+
+  /// Returns `x` to the power of `y`, `x **% y`. Wraps on overflow. Traps if `y < 0`.
+  public func powWrap(x : Int32, y : Int32) : Int32 { x **% y };
 
 }

--- a/src/Int64.mo
+++ b/src/Int64.mo
@@ -12,6 +12,15 @@ module {
   /// Conversion. Traps on overflow/underflow.
   public let fromInt : Int -> Int64  = Prim.intToInt64;
 
+  /// Conversion. Wraps on overflow/underflow.
+  public let fromIntWrap : Int -> Int64  = Prim.intToInt64Wrap;
+
+  /// Conversion. Wraps on overflow/underflow.
+  public let fromNat64 : Nat64 -> Int64 = Prim.nat64ToInt64;
+
+  /// Conversion. Wraps on overflow/underflow.
+  public let toNat64 : Int64 -> Nat64  = Prim.int64ToNat64;
+
   /// Returns the Text representation of `x`.
   public func toText(x : Int64) : Text {
     Int.toText(toInt(x))
@@ -79,5 +88,71 @@ module {
 
   /// Returns `x` to the power of `y`, `x ** y`. Traps on overflow.
   public func pow(x : Int64, y : Int64) : Int64 { x ** y };
+
+  /// Returns the bitwise negation of `x`, `^x`.
+  public func bitnot(x : Int64, y : Int64) : Int64 { ^x };
+
+  /// Returns the bitwise and of `x` and `y`, `x & y`.
+  public func bitand(x : Int64, y : Int64) : Int64 { x & y };
+
+  /// Returns the bitwise or of `x` and `y`, `x \| y`.
+  public func bitor(x : Int64, y : Int64) : Int64 { x | y };
+
+  /// Returns the bitwise exclusive or of `x` and `y`, `x ^ y`.
+  public func bitxor(x : Int64, y : Int64) : Int64 { x ^ y };
+
+  /// Returns the bitwise shift left of `x` by `y`, `x << y`.
+  public func bitshiftLeft(x : Int64, y : Int64) : Int64 { x << y };
+
+  /// Returns the bitwise shift right of `x` by `y`, `x >> y`.
+  public func bitshiftRight(x : Int64, y : Int64) : Int64 { x >> y };
+
+  /// Returns the bitwise rotate left of `x` by `y`, `x <<> y`.
+  public func bitrotLeft(x : Int64, y : Int64) : Int64 { x <<> y };
+
+  /// Returns the bitwise rotate right of `x` by `y`, `x <>> y`.
+  public func bitrotRight(x : Int64, y : Int64) : Int64 { x <>> y };
+
+  /// Returns the value of bit `p mod 64` in `x`, `(x & 2^(p mod 64)) == 2^(p mod 64)`.
+  public func bittest(x : Int64, p : Nat) : Bool {
+    Prim.btstInt64(x, Prim.intToInt64(p));
+  };
+
+  /// Returns the value of setting bit `p mod 64` in `x` to `1`.
+  public func bitset(x : Int64, p : Nat) : Int64 {
+    x | (1 << Prim.intToInt64(p));
+  };
+
+  /// Returns the value of clearing bit `p mod 64` in `x` to `0`.
+  public func bitclear(x : Int64, p : Nat) : Int64 {
+    x & ^(1 << Prim.intToInt64(p));
+  };
+
+  /// Returns the value of flipping bit `p mod 64` in `x`.
+  public func bitflip(x : Int64, p : Nat) : Int64 {
+    x ^ (1 << Prim.intToInt64(p));
+  };
+
+  /// Returns the count of non-zero bits in `x`.
+  public let bitcountNonZero : (x : Int64) -> Int64 = Prim.popcntInt64;
+
+  /// Returns the count of leading zero bits in `x`.
+  public let bitcountLeadingZero : (x : Int64) -> Int64 = Prim.clzInt64;
+
+  /// Returns the count of trailing zero bits in `x`.
+  public let bitcountTrailingZero : (x : Int64) -> Int64 = Prim.ctzInt64;
+
+
+  /// Returns the sum of `x` and `y`, `x +% y`. Wraps on overflow.
+  public func addWrap(x : Int64, y : Int64) : Int64 { x +% y };
+
+  /// Returns the difference of `x` and `y`, `x -% y`. Wraps on underflow.
+  public func subWrap(x : Int64, y : Int64) : Int64 { x -% y };
+
+  /// Returns the product of `x` and `y`, `x *% y`. Wraps on overflow.
+  public func mulWrap(x : Int64, y : Int64) : Int64 { x *% y };
+
+  /// Returns `x` to the power of `y`, `x **% y`. Wraps on overflow. Traps if `y < 0`.
+  public func powWrap(x : Int64, y : Int64) : Int64 { x **% y };
 
 }

--- a/src/Int8.mo
+++ b/src/Int8.mo
@@ -12,6 +12,15 @@ module {
   /// Conversion. Traps on overflow/underflow.
   public let fromInt : Int -> Int8  = Prim.intToInt8;
 
+  /// Conversion. Wraps on overflow/underflow.
+  public let fromIntWrap : Int -> Int8  = Prim.intToInt8Wrap;
+
+  /// Conversion. Wraps on overflow/underflow.
+  public let fromNat8 : Nat8 -> Int8 = Prim.nat8ToInt8;
+
+  /// Conversion. Wraps on overflow/underflow.
+  public let toNat8 : Int8 -> Nat8  = Prim.int8ToNat8;
+
   /// Returns the Text representation of `x`.
   public func toText(x : Int8) : Text {
     Int.toText(toInt(x))
@@ -79,5 +88,70 @@ module {
 
   /// Returns `x` to the power of `y`, `x ** y`. Traps on overflow.
   public func pow(x : Int8, y : Int8) : Int8 { x ** y };
+
+  /// Returns the bitwise negation of `x`, `^x`.
+  public func bitnot(x : Int8, y : Int8) : Int8 { ^x };
+
+  /// Returns the bitwise and of `x` and `y`, `x & y`.
+  public func bitand(x : Int8, y : Int8) : Int8 { x & y };
+
+  /// Returns the bitwise or of `x` and `y`, `x \| y`.
+  public func bitor(x : Int8, y : Int8) : Int8 { x | y };
+
+  /// Returns the bitwise exclusive or of `x` and `y`, `x ^ y`.
+  public func bitxor(x : Int8, y : Int8) : Int8 { x ^ y };
+
+  /// Returns the bitwise shift left of `x` by `y`, `x << y`.
+  public func bitshiftLeft(x : Int8, y : Int8) : Int8 { x << y };
+
+  /// Returns the bitwise shift right of `x` by `y`, `x >> y`.
+  public func bitshiftRight(x : Int8, y : Int8) : Int8 { x >> y };
+
+  /// Returns the bitwise rotate left of `x` by `y`, `x <<> y`.
+  public func bitrotLeft(x : Int8, y : Int8) : Int8 { x <<> y };
+
+  /// Returns the bitwise rotate right of `x` by `y`, `x <>> y`.
+  public func bitrotRight(x : Int8, y : Int8) : Int8 { x <>> y };
+
+  /// Returns the value of bit `p mod 8` in `x`, `(x & 2^(p mod 8)) == 2^(p mod 8)`.
+  public func bittest(x : Int8, p : Nat) : Bool {
+    Prim.btstInt8(x, Prim.intToInt8(p));
+  };
+
+  /// Returns the value of setting bit `p mod 8` in `x` to `1`.
+  public func bitset(x : Int8, p : Nat) : Int8 {
+    x | (1 << Prim.intToInt8(p));
+  };
+
+  /// Returns the value of clearing bit `p mod 8` in `x` to `0`.
+  public func bitclear(x : Int8, p : Nat) : Int8 {
+    x & ^(1 << Prim.intToInt8(p));
+  };
+
+  /// Returns the value of flipping bit `p mod 8` in `x`.
+  public func bitflip(x : Int8, p : Nat) : Int8 {
+    x ^ (1 << Prim.intToInt8(p));
+  };
+
+  /// Returns the count of non-zero bits in `x`.
+  public let bitcountNonZero : (x : Int8) -> Int8 = Prim.popcntInt8;
+
+  /// Returns the count of leading zero bits in `x`.
+  public let bitcountLeadingZero : (x : Int8) -> Int8 = Prim.clzInt8;
+
+  /// Returns the count of trailing zero bits in `x`.
+  public let bitcountTrailingZero : (x : Int8) -> Int8 = Prim.ctzInt8;
+
+  /// Returns the sum of `x` and `y`, `x +% y`. Wraps on overflow.
+  public func addWrap(x : Int8, y : Int8) : Int8 { x +% y };
+
+  /// Returns the difference of `x` and `y`, `x -% y`. Wraps on underflow.
+  public func subWrap(x : Int8, y : Int8) : Int8 { x -% y };
+
+  /// Returns the product of `x` and `y`, `x *% y`. Wraps on overflow.
+  public func mulWrap(x : Int8, y : Int8) : Int8 { x *% y };
+
+  /// Returns `x` to the power of `y`, `x **% y`. Wraps on overflow. Traps if `y < 0`.
+  public func powWrap(x : Int8, y : Int8) : Int8 { x **% y };
 
 }

--- a/src/Nat16.mo
+++ b/src/Nat16.mo
@@ -12,6 +12,9 @@ module {
   /// Conversion. Traps on overflow/underflow.
   public let fromNat : Nat -> Nat16  = Prim.natToNat16;
 
+  /// Conversion. Wraps on overflow/underflow.
+  public let fromIntWrap : Int -> Nat16  = Prim.intToNat16Wrap;
+
   /// Returns the Text representation of `x`.
   public func toText(x : Nat16) : Text {
     Nat.toText(toNat(x))
@@ -71,5 +74,70 @@ module {
 
   /// Returns `x` to the power of `y`, `x ** y`. Traps on overflow.
   public func pow(x : Nat16, y : Nat16) : Nat16 { x ** y };
+
+  /// Returns the bitwise negation of `x`, `^x`.
+  public func bitnot(x : Nat16, y : Nat16) : Nat16 { ^x };
+
+  /// Returns the bitwise and of `x` and `y`, `x & y`.
+  public func bitand(x : Nat16, y : Nat16) : Nat16 { x & y };
+
+  /// Returns the bitwise or of `x` and `y`, `x \| y`.
+  public func bitor(x : Nat16, y : Nat16) : Nat16 { x | y };
+
+  /// Returns the bitwise exclusive or of `x` and `y`, `x ^ y`.
+  public func bitxor(x : Nat16, y : Nat16) : Nat16 { x ^ y };
+
+  /// Returns the bitwise shift left of `x` by `y`, `x << y`.
+  public func bitshiftLeft(x : Nat16, y : Nat16) : Nat16 { x << y };
+
+  /// Returns the bitwise shift right of `x` by `y`, `x >> y`.
+  public func bitshiftRight(x : Nat16, y : Nat16) : Nat16 { x >> y };
+
+  /// Returns the bitwise rotate left of `x` by `y`, `x <<> y`.
+  public func bitrotLeft(x : Nat16, y : Nat16) : Nat16 { x <<> y };
+
+  /// Returns the bitwise rotate right of `x` by `y`, `x <>> y`.
+  public func bitrotRight(x : Nat16, y : Nat16) : Nat16 { x <>> y };
+
+  /// Returns the value of bit `p mod 16` in `x`, `(x & 2^(p mod 16)) == 2^(p mod 16)`.
+  public func bittest(x : Nat16, p : Nat) : Bool {
+    Prim.btstNat16(x, Prim.natToNat16(p));
+  };
+
+  /// Returns the value of setting bit `p mod 16` in `x` to `1`.
+  public func bitset(x : Nat16, p : Nat) : Nat16 {
+    x | (1 << Prim.natToNat16(p));
+  };
+
+  /// Returns the value of clearing bit `p mod 16` in `x` to `0`.
+  public func bitclear(x : Nat16, p : Nat) : Nat16 {
+    x & ^(1 << Prim.natToNat16(p));
+  };
+
+  /// Returns the value of flipping bit `p mod 16` in `x`.
+  public func bitflip(x : Nat16, p : Nat) : Nat16 {
+    x ^ (1 << Prim.natToNat16(p));
+  };
+
+  /// Returns the count of non-zero bits in `x`.
+  public let bitcountNonZero : (x : Nat16) -> Nat16 = Prim.popcntNat16;
+
+  /// Returns the count of leading zero bits in `x`.
+  public let bitcountLeadingZero : (x : Nat16) -> Nat16 = Prim.clzNat16;
+
+  /// Returns the count of trailing zero bits in `x`.
+  public let bitcountTrailingZero : (x : Nat16) -> Nat16 = Prim.ctzNat16;
+
+  /// Returns the sum of `x` and `y`, `x +% y`. Wraps on overflow.
+  public func addWrap(x : Nat16, y : Nat16) : Nat16 { x +% y };
+
+  /// Returns the difference of `x` and `y`, `x -% y`. Wraps on underflow.
+  public func subWrap(x : Nat16, y : Nat16) : Nat16 { x -% y };
+
+  /// Returns the product of `x` and `y`, `x *% y`. Wraps on overflow.
+  public func mulWrap(x : Nat16, y : Nat16) : Nat16 { x *% y };
+
+  /// Returns `x` to the power of `y`, `x **% y`. Wraps on overflow.
+  public func powWrap(x : Nat16, y : Nat16) : Nat16 { x **% y };
 
 }

--- a/src/Nat32.mo
+++ b/src/Nat32.mo
@@ -12,6 +12,9 @@ module {
   /// Conversion. Traps on overflow/underflow.
   public let fromNat : Nat -> Nat32  = Prim.natToNat32;
 
+  /// Conversion. Wraps on overflow/underflow.
+  public let fromIntWrap : Int -> Nat32  = Prim.intToNat32Wrap;
+
   /// Returns the Text representation of `x`.
   public func toText(x : Nat32) : Text {
     Nat.toText(toNat(x))
@@ -71,5 +74,70 @@ module {
 
   /// Returns `x` to the power of `y`, `x ** y`. Traps on overflow.
   public func pow(x : Nat32, y : Nat32) : Nat32 { x ** y };
+
+  /// Returns the bitwise negation of `x`, `^x`.
+  public func bitnot(x : Nat32, y : Nat32) : Nat32 { ^x };
+
+  /// Returns the bitwise and of `x` and `y`, `x & y`.
+  public func bitand(x : Nat32, y : Nat32) : Nat32 { x & y };
+
+  /// Returns the bitwise or of `x` and `y`, `x \| y`.
+  public func bitor(x : Nat32, y : Nat32) : Nat32 { x | y };
+
+  /// Returns the bitwise exclusive or of `x` and `y`, `x ^ y`.
+  public func bitxor(x : Nat32, y : Nat32) : Nat32 { x ^ y };
+
+  /// Returns the bitwise shift left of `x` by `y`, `x << y`.
+  public func bitshiftLeft(x : Nat32, y : Nat32) : Nat32 { x << y };
+
+  /// Returns the bitwise shift right of `x` by `y`, `x >> y`.
+  public func bitshiftRight(x : Nat32, y : Nat32) : Nat32 { x >> y };
+
+  /// Returns the bitwise rotate left of `x` by `y`, `x <<> y`.
+  public func bitrotLeft(x : Nat32, y : Nat32) : Nat32 { x <<> y };
+
+  /// Returns the bitwise rotate right of `x` by `y`, `x <>> y`.
+  public func bitrotRight(x : Nat32, y : Nat32) : Nat32 { x <>> y };
+
+  /// Returns the value of bit `p mod 32` in `x`, `(x & 2^(p mod 32)) == 2^(p mod 32)`.
+  public func bittest(x : Nat32, p : Nat) : Bool {
+    Prim.btstNat32(x, Prim.natToNat32(p));
+  };
+
+  /// Returns the value of setting bit `p mod 32` in `x` to `1`.
+  public func bitset(x : Nat32, p : Nat) : Nat32 {
+    x | (1 << Prim.natToNat32(p));
+  };
+
+  /// Returns the value of clearing bit `p mod 32` in `x` to `0`.
+  public func bitclear(x : Nat32, p : Nat) : Nat32 {
+    x & ^(1 << Prim.natToNat32(p));
+  };
+
+  /// Returns the value of flipping bit `p mod 32` in `x`.
+  public func bitflip(x : Nat32, p : Nat) : Nat32 {
+    x ^ (1 << Prim.natToNat32(p));
+  };
+
+  /// Returns the count of non-zero bits in `x`.
+  public let bitcountNonZero : (x : Nat32) -> Nat32 = Prim.popcntNat32;
+
+  /// Returns the count of leading zero bits in `x`.
+  public let bitcountLeadingZero : (x : Nat32) -> Nat32 = Prim.clzNat32;
+
+  /// Returns the count of trailing zero bits in `x`.
+  public let bitcountTrailingZero : (x : Nat32) -> Nat32 = Prim.ctzNat32;
+
+  /// Returns the sum of `x` and `y`, `x +% y`. Wraps on overflow.
+  public func addWrap(x : Nat32, y : Nat32) : Nat32 { x +% y };
+
+  /// Returns the difference of `x` and `y`, `x -% y`. Wraps on underflow.
+  public func subWrap(x : Nat32, y : Nat32) : Nat32 { x -% y };
+
+  /// Returns the product of `x` and `y`, `x *% y`. Wraps on overflow.
+  public func mulWrap(x : Nat32, y : Nat32) : Nat32 { x *% y };
+
+  /// Returns `x` to the power of `y`, `x **% y`. Wraps on overflow.
+  public func powWrap(x : Nat32, y : Nat32) : Nat32 { x **% y };
 
 }

--- a/src/Nat64.mo
+++ b/src/Nat64.mo
@@ -12,6 +12,9 @@ module {
   /// Conversion. Traps on overflow/underflow.
   public let fromNat : Nat -> Nat64  = Prim.natToNat64;
 
+  /// Conversion. Wraps on overflow/underflow.
+  public let fromIntWrap : Int -> Nat64  = Prim.intToNat64Wrap;
+
   /// Returns the Text representation of `x`.
   public func toText(x : Nat64) : Text {
     Nat.toText(toNat(x))
@@ -71,5 +74,70 @@ module {
 
   /// Returns `x` to the power of `y`, `x ** y`. Traps on overflow.
   public func pow(x : Nat64, y : Nat64) : Nat64 { x ** y };
+
+  /// Returns the bitwise negation of `x`, `^x`.
+  public func bitnot(x : Nat64, y : Nat64) : Nat64 { ^x };
+
+  /// Returns the bitwise and of `x` and `y`, `x & y`.
+  public func bitand(x : Nat64, y : Nat64) : Nat64 { x & y };
+
+  /// Returns the bitwise or of `x` and `y`, `x \| y`.
+  public func bitor(x : Nat64, y : Nat64) : Nat64 { x | y };
+
+  /// Returns the bitwise exclusive or of `x` and `y`, `x ^ y`.
+  public func bitxor(x : Nat64, y : Nat64) : Nat64 { x ^ y };
+
+  /// Returns the bitwise shift left of `x` by `y`, `x << y`.
+  public func bitshiftLeft(x : Nat64, y : Nat64) : Nat64 { x << y };
+
+  /// Returns the bitwise shift right of `x` by `y`, `x >> y`.
+  public func bitshiftRight(x : Nat64, y : Nat64) : Nat64 { x >> y };
+
+  /// Returns the bitwise rotate left of `x` by `y`, `x <<> y`.
+  public func bitrotLeft(x : Nat64, y : Nat64) : Nat64 { x <<> y };
+
+  /// Returns the bitwise rotate right of `x` by `y`, `x <>> y`.
+  public func bitrotRight(x : Nat64, y : Nat64) : Nat64 { x <>> y };
+
+  /// Returns the value of bit `p mod 64` in `x`, `(x & 2^(p mod 64)) == 2^(p mod 64)`.
+  public func bittest(x : Nat64, p : Nat) : Bool {
+    Prim.btstNat64(x, Prim.natToNat64(p));
+  };
+
+  /// Returns the value of setting bit `p mod 64` in `x` to `1`.
+  public func bitset(x : Nat64, p : Nat) : Nat64 {
+    x | (1 << Prim.natToNat64(p));
+  };
+
+  /// Returns the value of clearing bit `p mod 64` in `x` to `0`.
+  public func bitclear(x : Nat64, p : Nat) : Nat64 {
+    x & ^(1 << Prim.natToNat64(p));
+  };
+
+  /// Returns the value of flipping bit `p mod 64` in `x`.
+  public func bitflip(x : Nat64, p : Nat) : Nat64 {
+    x ^ (1 << Prim.natToNat64(p));
+  };
+
+  /// Returns the count of non-zero bits in `x`.
+  public let bitcountNonZero : (x : Nat64) -> Nat64 = Prim.popcntNat64;
+
+  /// Returns the count of leading zero bits in `x`.
+  public let bitcountLeadingZero : (x : Nat64) -> Nat64 = Prim.clzNat64;
+
+  /// Returns the count of trailing zero bits in `x`.
+  public let bitcountTrailingZero : (x : Nat64) -> Nat64 = Prim.ctzNat64;
+
+  /// Returns the sum of `x` and `y`, `x +% y`. Wraps on overflow.
+  public func addWrap(x : Nat64, y : Nat64) : Nat64 { x +% y };
+
+  /// Returns the difference of `x` and `y`, `x -% y`. Wraps on underflow.
+  public func subWrap(x : Nat64, y : Nat64) : Nat64 { x -% y };
+
+  /// Returns the product of `x` and `y`, `x *% y`. Wraps on overflow.
+  public func mulWrap(x : Nat64, y : Nat64) : Nat64 { x *% y };
+
+  /// Returns `x` to the power of `y`, `x **% y`. Wraps on overflow.
+  public func powWrap(x : Nat64, y : Nat64) : Nat64 { x **% y };
 
 }

--- a/src/Nat8.mo
+++ b/src/Nat8.mo
@@ -12,6 +12,9 @@ module {
   /// Conversion. Traps on overflow/underflow.
   public let fromNat : Nat -> Nat8  = Prim.natToNat8;
 
+  /// Conversion. Wraps on overflow/underflow.
+  public let fromIntWrap : Int -> Nat8  = Prim.intToNat8Wrap;
+
   /// Returns the Text representation of `x`.
   public func toText(x : Nat8) : Text {
     Nat.toText(toNat(x))
@@ -71,5 +74,70 @@ module {
 
   /// Returns `x` to the power of `y`, `x ** y`. Traps on overflow.
   public func pow(x : Nat8, y : Nat8) : Nat8 { x ** y };
+
+  /// Returns the bitwise negation of `x`, `^x`.
+  public func bitnot(x : Nat8, y : Nat8) : Nat8 { ^x };
+
+  /// Returns the bitwise and of `x` and `y`, `x & y`.
+  public func bitand(x : Nat8, y : Nat8) : Nat8 { x & y };
+
+  /// Returns the bitwise or of `x` and `y`, `x \| y`.
+  public func bitor(x : Nat8, y : Nat8) : Nat8 { x | y };
+
+  /// Returns the bitwise exclusive or of `x` and `y`, `x ^ y`.
+  public func bitxor(x : Nat8, y : Nat8) : Nat8 { x ^ y };
+
+  /// Returns the bitwise shift left of `x` by `y`, `x << y`.
+  public func bitshiftLeft(x : Nat8, y : Nat8) : Nat8 { x << y };
+
+  /// Returns the bitwise shift right of `x` by `y`, `x >> y`.
+  public func bitshiftRight(x : Nat8, y : Nat8) : Nat8 { x >> y };
+
+  /// Returns the bitwise rotate left of `x` by `y`, `x <<> y`.
+  public func bitrotLeft(x : Nat8, y : Nat8) : Nat8 { x <<> y };
+
+  /// Returns the bitwise rotate right of `x` by `y`, `x <>> y`.
+  public func bitrotRight(x : Nat8, y : Nat8) : Nat8 { x <>> y };
+
+  /// Returns the value of bit `p mod 8` in `x`, `(x & 2^(p mod 8)) == 2^(p mod 8)`.
+  public func bittest(x : Nat8, p : Nat) : Bool {
+    Prim.btstNat8(x, Prim.natToNat8(p));
+  };
+
+  /// Returns the value of setting bit `p mod 8` in `x` to `1`.
+  public func bitset(x : Nat8, p : Nat) : Nat8 {
+    x | (1 << Prim.natToNat8(p));
+  };
+
+  /// Returns the value of clearing bit `p mod 8` in `x` to `0`.
+  public func bitclear(x : Nat8, p : Nat) : Nat8 {
+    x & ^(1 << Prim.natToNat8(p));
+  };
+
+  /// Returns the value of flipping bit `p mod 8` in `x`.
+  public func bitflip(x : Nat8, p : Nat) : Nat8 {
+    x ^ (1 << Prim.natToNat8(p));
+  };
+
+  /// Returns the count of non-zero bits in `x`.
+  public let bitcountNonZero : (x : Nat8) -> Nat8 = Prim.popcntNat8;
+
+  /// Returns the count of leading zero bits in `x`.
+  public let bitcountLeadingZero : (x : Nat8) -> Nat8 = Prim.clzNat8;
+
+  /// Returns the count of trailing zero bits in `x`.
+  public let bitcountTrailingZero : (x : Nat8) -> Nat8 = Prim.ctzNat8;
+
+  /// Returns the sum of `x` and `y`, `x +% y`. Wraps on overflow.
+  public func addWrap(x : Nat8, y : Nat8) : Nat8 { x +% y };
+
+  /// Returns the difference of `x` and `y`, `x -% y`. Wraps on underflow.
+  public func subWrap(x : Nat8, y : Nat8) : Nat8 { x -% y };
+
+  /// Returns the product of `x` and `y`, `x *% y`. Wraps on overflow.
+  public func mulWrap(x : Nat8, y : Nat8) : Nat8 { x *% y };
+
+  /// Returns `x` to the power of `y`, `x **% y`. Wraps on overflow.
+  public func powWrap(x : Nat8, y : Nat8) : Nat8 { x **% y };
 
 }

--- a/src/Random.mo
+++ b/src/Random.mo
@@ -97,13 +97,13 @@ module {
       var acc : Word8 = 0;
       for (i in it) {
         if (8 : Nat8 <= nn)
-        { acc += Prim.popcntWord8(i) }
+        { acc +%= Prim.popcntWord8(i) }
         else if (0 : Nat8 == nn)
         { return ?Prim.word8ToNat8(acc) }
         else {
           let mask : Word8 = -1 << Prim.nat8ToWord8(8 - nn);
           let residue = Prim.popcntWord8(i & mask);
-          return ?Prim.word8ToNat8(acc + residue)
+          return ?Prim.word8ToNat8(acc +% residue)
         };
         nn -= 8
       };
@@ -171,13 +171,13 @@ module {
     var acc : Word8 = 0;
     for (i in it) {
       if (8 : Nat8 <= nn)
-      { acc += Prim.popcntWord8(i) }
+      { acc +%= Prim.popcntWord8(i) }
       else if (0 : Nat8 == nn)
       { return Prim.word8ToNat8(acc) }
       else {
         let mask : Word8 = -1 << Prim.nat8ToWord8(8 - nn);
         let residue = Prim.popcntWord8(i & mask);
-        return Prim.word8ToNat8(acc + residue)
+        return Prim.word8ToNat8(acc +% residue)
       };
       nn -= 8
     };

--- a/src/Word16.mo
+++ b/src/Word16.mo
@@ -60,13 +60,13 @@ module {
   };
 
   /// Returns the sum of `x` and `y`, `(x + y) mod 2^16`.
-  public func add(x : Word16, y : Word16) : Word16 { x + y };
+  public func add(x : Word16, y : Word16) : Word16 { x +% y };
 
   /// Returns the difference of `x` and `y`, `(2^16 + x - y) mod 2^16`.
-  public func sub(x : Word16, y : Word16) : Word16 { x - y };
+  public func sub(x : Word16, y : Word16) : Word16 { x -% y };
 
   /// Returns the product of `x` and `y`, `(x * y) mod 2^16`.
-  public func mul(x : Word16, y : Word16) : Word16 { x * y };
+  public func mul(x : Word16, y : Word16) : Word16 { x *% y };
 
   /// Returns the division of `x` by `y`, `x / y`.
   /// Traps when `y` is zero.
@@ -77,7 +77,7 @@ module {
   public func rem(x : Word16, y : Word16) : Word16 { x % y };
 
   /// Returns `x` to the power of `y`, `(x ** y) mod 2^16`.
-  public func pow(x : Word16, y : Word16) : Word16 { x ** y };
+  public func pow(x : Word16, y : Word16) : Word16 { x **% y };
 
   /// Returns the bitwise negation of `x`, `^x`.
   public func bitnot(x : Word16, y : Word16) : Word16 { ^x };

--- a/src/Word32.mo
+++ b/src/Word32.mo
@@ -60,13 +60,13 @@ module {
   };
 
   /// Returns the sum of `x` and `y`, `(x + y) mod 2^32`.
-  public func add(x : Word32, y : Word32) : Word32 { x + y };
+  public func add(x : Word32, y : Word32) : Word32 { x +% y };
 
   /// Returns the difference of `x` and `y`, `(2^32 + x - y) mod 2^32`.
-  public func sub(x : Word32, y : Word32) : Word32 { x - y };
+  public func sub(x : Word32, y : Word32) : Word32 { x -% y };
 
   /// Returns the product of `x` and `y`, `(x * y) mod 2^32`.
-  public func mul(x : Word32, y : Word32) : Word32 { x * y };
+  public func mul(x : Word32, y : Word32) : Word32 { x *% y };
 
   /// Returns the division of `x` by `y`, `x / y`.
   /// Traps when `y` is zero.
@@ -77,7 +77,7 @@ module {
   public func rem(x : Word32, y : Word32) : Word32 { x % y };
 
   /// Returns `x` to the power of `y`, `(x ** y) mod 2^32`.
-  public func pow(x : Word32, y : Word32) : Word32 { x ** y };
+  public func pow(x : Word32, y : Word32) : Word32 { x **% y };
 
   /// Returns the bitwise negation of `x`, `^x`.
   public func bitnot(x : Word32, y : Word32) : Word32 { ^x };

--- a/src/Word64.mo
+++ b/src/Word64.mo
@@ -60,13 +60,13 @@ module {
   };
 
   /// Returns the sum of `x` and `y`, `(x + y) mod 2^64`.
-  public func add(x : Word64, y : Word64) : Word64 { x + y };
+  public func add(x : Word64, y : Word64) : Word64 { x +% y };
 
   /// Returns the difference of `x` and `y`, `(2^64 + x - y) mod 2^64`.
-  public func sub(x : Word64, y : Word64) : Word64 { x - y };
+  public func sub(x : Word64, y : Word64) : Word64 { x -% y };
 
   /// Returns the product of `x` and `y`, `(x * y) mod 2^64`.
-  public func mul(x : Word64, y : Word64) : Word64 { x * y };
+  public func mul(x : Word64, y : Word64) : Word64 { x *% y };
 
   /// Returns the division of `x` by `y`, `x / y`.
   /// Traps when `y` is zero.
@@ -77,7 +77,7 @@ module {
   public func rem(x : Word64, y : Word64) : Word64 { x % y };
 
   /// Returns `x` to the power of `y`, `(x ** y) mod 2^64`.
-  public func pow(x : Word64, y : Word64) : Word64 { x ** y };
+  public func pow(x : Word64, y : Word64) : Word64 { x **% y };
 
   /// Returns the bitwise negation of `x`, `^x`.
   public func bitnot(x : Word64, y : Word64) : Word64 { ^x };

--- a/src/Word8.mo
+++ b/src/Word8.mo
@@ -60,13 +60,13 @@ module {
   };
 
   /// Returns the sum of `x` and `y`, `(x + y) mod 2^8`.
-  public func add(x : Word8, y : Word8) : Word8 { x + y };
+  public func add(x : Word8, y : Word8) : Word8 { x +% y };
 
   /// Returns the difference of `x` and `y`, `(2^8 + x - y) mod 2^8`.
-  public func sub(x : Word8, y : Word8) : Word8 { x - y };
+  public func sub(x : Word8, y : Word8) : Word8 { x -% y };
 
   /// Returns the product of `x` and `y`, `(x * y) mod 2^8`.
-  public func mul(x : Word8, y : Word8) : Word8 { x * y };
+  public func mul(x : Word8, y : Word8) : Word8 { x *% y };
 
   /// Returns the division of `x` by `y`, `x / y`.
   /// Traps when `y` is zero.
@@ -77,7 +77,7 @@ module {
   public func rem(x : Word8, y : Word8) : Word8 { x % y };
 
   /// Returns `x` to the power of `y`, `(x ** y) mod 2^8`.
-  public func pow(x : Word8, y : Word8) : Word8 { x ** y };
+  public func pow(x : Word8, y : Word8) : Word8 { x **% y };
 
   /// Returns the bitwise negation of `x`, `^x`.
   public func bitnot(x : Word8, y : Word8) : Word8 { ^x };

--- a/test/Makefile
+++ b/test/Makefile
@@ -8,7 +8,7 @@ TESTS = $(wildcard *.mo)
 
 TEST_TARGETS = $(patsubst %.mo,_out/%.checked,$(TESTS))
 
-all: $(TEST_TARGETS) $(OUTDIR)/import_all.checked
+all: $(OUTDIR)/import_all.checked $(TEST_TARGETS) 
 
 STDLIB_FILES= $(wildcard $(STDLIB)/*.mo)
 

--- a/test/charTest.mo
+++ b/test/charTest.mo
@@ -29,15 +29,15 @@ assert(Char.isWhitespace(' '));
 assert(not Char.isWhitespace('x'));
 
 // 12288 (U+3000) = ideographic space
-assert(Char.isWhitespace(Prim.word32ToChar(12288)));
+assert(Char.isWhitespace(Prim.nat32ToChar(12288)));
 
 assert(Char.isWhitespace('\t'));
 
 // Vertical tab ('\v')
-assert(Char.isWhitespace(Prim.word32ToChar(0x0B)));
+assert(Char.isWhitespace(Prim.nat32ToChar(0x0B)));
 
 // Form feed ('\f')
-assert(Char.isWhitespace(Prim.word32ToChar(0x0C)));
+assert(Char.isWhitespace(Prim.nat32ToChar(0x0C)));
 
 assert(Char.isWhitespace('\r'));
 

--- a/test/int8Test.mo
+++ b/test/int8Test.mo
@@ -1,0 +1,7 @@
+import Debug "mo:base/Debug";
+import Int8 "mo:base/Int8";
+
+assert (Int8.fromIntWrap(256) == (0:Int8));
+assert (Int8.fromIntWrap(-256) == (0:Int8));
+assert (Int8.fromIntWrap(128) == (-128:Int8));
+assert (Int8.fromIntWrap(255) == (-1:Int8));

--- a/test/textTest.mo
+++ b/test/textTest.mo
@@ -102,7 +102,7 @@ run(suite("toIter",
    Text.toIter("abc"),
    M.equals(iterT (['a','b','c']))),
  do {
-   let a = Array.tabulate<Char>(1000, func i = Char.fromWord32(65+Word32.fromInt(i % 26)));
+   let a = Array.tabulate<Char>(1000, func i = Char.fromWord32(65+%Word32.fromInt(i % 26)));
    test(
      "fromIter-2",
      Text.toIter(Text.join("", Array.map(a, Char.toText).vals())),
@@ -125,7 +125,7 @@ run(suite("fromIter",
    Text.fromIter((['a', 'b', 'c'].vals())),
    M.equals(T.text "abc")),
  do {
-   let a = Array.tabulate<Char>(1000, func i = Char.fromWord32(65+Word32.fromInt(i % 26)));
+   let a = Array.tabulate<Char>(1000, func i = Char.fromWord32(65+%Word32.fromInt(i % 26)));
    test(
    "fromIter-3",
    Text.fromIter(a.vals()),
@@ -169,7 +169,7 @@ run(suite("join",
    Text.join("", (["a","bb","ccc","dddd"].vals())),
    M.equals(T.text "abbcccdddd")),
  do {
-   let a = Array.tabulate<Char>(1000, func i = Char.fromWord32(65+Word32.fromInt(i % 26)));
+   let a = Array.tabulate<Char>(1000, func i = Char.fromWord32(65+%Word32.fromInt(i % 26)));
    test(
    "join-3",
    Text.join("", Array.map(a, Char.toText).vals()),
@@ -200,7 +200,7 @@ run(suite("join",
    Text.join(",", (["a","bb","ccc","dddd"].vals())),
    M.equals(T.text "a,bb,ccc,dddd")),
  do {
-   let a = Array.tabulate<Char>(1000, func i = Char.fromWord32(65+Word32.fromInt(i % 26)));
+   let a = Array.tabulate<Char>(1000, func i = Char.fromWord32(65+%Word32.fromInt(i % 26)));
    test(
    "join-3",
    Text.join("", Array.map(a, Char.toText).vals()),


### PR DESCRIPTION
this goes along with https://github.com/dfinity/motoko/pull/2326
(and should not be merged before). It adds new bit operations, wrapping
arithmetic and conversions to IntN and NatN.

It does not port the rest of base to avoid Word. See #214 for that (and
we will likely pull that in selectively).