### PR TITLE
Deprecate Char.to/fromWord32

### DIFF
--- a/src/Char.mo
+++ b/src/Char.mo
@@ -3,6 +3,11 @@ import Prim "mo:prim";
 module {
 
   /// Convert character `c` to a word containing its Unicode scalar value.
+  public let toNat32 : (c : Char) -> Nat32 = Prim.charToNat32;
+
+  /// Convert character `c` to a word containing its Unicode scalar value.
+  ///
+  /// @deprecated Please use `Char.toNat32` or `Word32.fromChar`
   public let toWord32 : (c : Char) -> Word32 = Prim.charToWord32;
 
   /// Convert `w` to a character.
@@ -13,6 +18,8 @@ module {
   /// Convert word `w` to a character.
   /// Traps if `w` is not a valid Unicode scalar value.
   /// Value `w` is valid if, and only if, `w < 0xD800 or (0xE000 <= w and w <= 0x10FFFF)`.
+  ///
+  /// @deprecated Please use `Char.fromNat32` or `Word32.toChar`
   public let fromWord32 : (w : Word32) -> Char = Prim.word32ToChar;
 
   /// Convert character `c` to single character text.

--- a/src/Word32.mo
+++ b/src/Word32.mo
@@ -19,6 +19,14 @@ module {
   /// Conversion. Returns `x mod 2^32`.
   public let fromInt : (x : Int) -> Word32  = Prim.intToWord32;
 
+  /// Convert character `c` to a word containing its Unicode scalar value.
+  public let fromChar : (c : Char) -> Word32 = Prim.charToWord32;
+
+  /// Convert word `w` to a character.
+  /// Traps if `w` is not a valid Unicode scalar value.
+  /// Value `w` is valid if, and only if, `w < 0xD800 or (0xE000 <= w and w <= 0x10FFFF)`.
+  public let toChar : (w : Word32) -> Char = Prim.word32ToChar;
+
   /// Returns the Text representation of `x`.
   public func toText(x : Word32) : Text {
     Nat.toText(toNat(x))

--- a/test/charTest.mo
+++ b/test/charTest.mo
@@ -62,3 +62,7 @@ assert(not Char.isUppercase('x'));
 assert(Char.isAlphabetic('a'));
 assert(Char.isAlphabetic('京'));
 assert(not Char.isAlphabetic('㋡'));
+
+// To test the deprecations (by manually looking at the output)
+ignore(Char.toWord32)
+ignore(Char.fromWord32)

--- a/test/charTest.mo
+++ b/test/charTest.mo
@@ -65,4 +65,4 @@ assert(not Char.isAlphabetic('㋡'));
 
 // To test the deprecations (by manually looking at the output)
 ignore(Char.toWord32);
-ignore(Char.fromWord32)
+ignore(Char.fromWord32);

--- a/test/charTest.mo
+++ b/test/charTest.mo
@@ -64,5 +64,5 @@ assert(Char.isAlphabetic('京'));
 assert(not Char.isAlphabetic('㋡'));
 
 // To test the deprecations (by manually looking at the output)
-ignore(Char.toWord32)
+ignore(Char.toWord32);
 ignore(Char.fromWord32)


### PR DESCRIPTION
because of the upcoming deprecation of word types, we need to readicate
`Word` from all other modules’ interfaces.

This uses deprecation annotations to warn about the methods in `Char`
thta we will have to remove when we start warning about the `Word` type
itself.

This can be merged into `master` already, as support for the
`@deprecated` annotation is backward-compatible.