### PR TITLE
Changes to support polarity based inference

### DIFF
--- a/src/Blob.mo
+++ b/src/Blob.mo
@@ -3,7 +3,7 @@
 import Prim "mo:prim";
 module {
 
-  public let hash : Blob -> Word32 = Prim.hashBlob;
+  public let hash : Blob -> Nat32 = Prim.hashBlob;
 
   /// Returns `x == y`.
   public func equal(x : Blob, y : Blob) : Bool { x == y };

--- a/src/Hash.mo
+++ b/src/Hash.mo
@@ -4,8 +4,8 @@ import Prim "mo:prim";
 import Iter "Iter";
 
 module {
-  /// Hash values represent a string of _hash bits_, packed into a `Word32`.
-  public type Hash = Word32;
+  /// Hash values represent a string of _hash bits_, packed into a `Nat32`.
+  public type Hash = Nat32;
 
   /// The hash length, always 31.
   public let length : Nat = 31; // Why not 32?
@@ -13,7 +13,7 @@ module {
   /// Project a given bit from the bit vector.
   public func bit(h : Hash, pos : Nat) : Bool {
     assert (pos <= length);
-    (h & (Prim.natToWord32(1) << Prim.natToWord32(pos))) != Prim.natToWord32(0)
+    (h & (Prim.natToNat32(1) << Prim.natToNat32(pos))) != Prim.natToNat32(0)
   };
 
   /// Test if two hashes are equal
@@ -22,8 +22,8 @@ module {
   };
 
   public func hash(i : Nat) : Hash {
-    let j = Prim.natToWord32(i);
-    hashWord8(
+    let j = Prim.natToNat32(i);
+    hashNat8(
       [j & (255 << 0),
        j & (255 << 8),
        j & (255 << 16),
@@ -55,14 +55,14 @@ module {
   ///
   /// https://en.wikipedia.org/wiki/Jenkins_hash_function#one_at_a_time
   ///
-  /// The input type should actually be `[Word8]`.
-  /// Note: Be sure to explode each `Word8` of a `Word32` into its own `Word32`, and to shift into lower 8 bits.
+  /// The input type should actually be `[Nat8]`.
+  /// Note: Be sure to explode each `Nat8` of a `Nat32` into its own `Nat32`, and to shift into lower 8 bits.
 
   // should this really be public?
-  public func hashWord8(key : [Hash]) : Hash {
-    var hash = Prim.natToWord32(0);
-    for (wordOfKey in key.vals()) {
-      hash := hash +% wordOfKey;
+  public func hashNat8(key : [Hash]) : Hash {
+    var hash : Nat32 = 0;
+    for (natOfKey in key.vals()) {
+      hash := hash +% natOfKey;
       hash := hash +% hash << 10;
       hash := hash ^ (hash >> 6);
     };

--- a/src/HashMap.mo
+++ b/src/HashMap.mo
@@ -45,7 +45,7 @@ public class HashMap<K,V> (
   /// Removes the entry with the key `k` and returns the associated value if it
   /// existed or `null` otherwise.
   public func remove(k : K) : ?V {
-    let h = Prim.word32ToNat(keyHash(k));
+    let h = Prim.nat32ToNat(keyHash(k));
     let m = table.size();
     let pos = h % m;
     if (m > 0) {
@@ -64,7 +64,7 @@ public class HashMap<K,V> (
   /// Gets the entry with the key `k` and returns its associated value if it
   /// existed or `null` otherwise.
   public func get(k:K) : ?V {
-    let h = Prim.word32ToNat(keyHash(k));
+    let h = Prim.nat32ToNat(keyHash(k));
     let m = table.size();
     let v = if (m > 0) {
       AssocList.find<K,V>(table[h % m], k, keyEq)
@@ -98,7 +98,7 @@ public class HashMap<K,V> (
           switch kvs {
           case null { break moveKeyVals };
           case (?((k, v), kvsTail)) {
-                 let h = Prim.word32ToNat(keyHash(k));
+                 let h = Prim.nat32ToNat(keyHash(k));
                  let pos2 = h % table2.size();
                  table2[pos2] := ?((k,v), table2[pos2]);
                  kvs := kvsTail;
@@ -108,7 +108,7 @@ public class HashMap<K,V> (
       };
       table := table2;
     };
-    let h = Prim.word32ToNat(keyHash(k));
+    let h = Prim.nat32ToNat(keyHash(k));
     let pos = h % table.size();
     let (kvs2, ov) = AssocList.replace<K,V>(table[pos], k, keyEq, ?v);
     table[pos] := kvs2;

--- a/src/Int.mo
+++ b/src/Int.mo
@@ -55,8 +55,9 @@ module {
 
   // TODO: (re)move me?
   public func hash(i : Int) : Hash.Hash {
-    let j = Prim.intToWord32(i);
-    Hash.hashWord8(
+    // CAUTION: This removes the high bits!
+    let j = Prim.int32ToNat32(Prim.intToInt32Wrap(i));
+    Hash.hashNat8(
       [j & (255 << 0),
        j & (255 << 8),
        j & (255 << 16),
@@ -67,8 +68,9 @@ module {
   // TODO: (re)move me?
   /// WARNING: May go away (?)
   public func hashAcc(h1 : Hash.Hash, i : Int) : Hash.Hash {
-    let j = Prim.intToWord32(i);
-    Hash.hashWord8(
+    // CAUTION: This removes the high bits!
+    let j = Prim.int32ToNat32(Prim.intToInt32Wrap(i));
+    Hash.hashNat8(
       [h1,
        j & (255 << 0),
        j & (255 << 8),

--- a/src/Random.mo
+++ b/src/Random.mo
@@ -35,32 +35,32 @@ module {
   /// guaranteed only when the supplied entropy is originally obtained
   /// by the `blob()` call, and is never reused.
   public class Finite(entropy : Blob) {
-    let it : I.Iter<Word8> = entropy.bytes();
+    let it : I.Iter<Nat8> = entropy.vals();
 
     /// Uniformly distributes outcomes in the numeric range [0 .. 255].
     /// Consumes 1 byte of entropy.
     public func byte() : ?Nat8 {
-      Option.map(it.next(), Prim.word8ToNat8)
+      it.next()
     };
 
     /// Bool iterator splitting up a byte of entropy into 8 bits
     let bit : I.Iter<Bool> = object {
-      var mask = 0x80 : Word8;
-      var byte = 0x00 : Word8;
+      var mask = 0x80 : Nat8;
+      var byte = 0x00 : Nat8;
       public func next() : ?Bool {
-        if (0 : Word8 == mask) {
+        if (0 : Nat8 == mask) {
           switch (it.next()) {
             case null { null };
             case (?w) {
               byte := w;
               mask := 0x40;
-              ?(0 : Word8 != byte & (0x80 : Word8))
+              ?(0 : Nat8 != byte & (0x80 : Nat8))
             }
           }
         } else {
           let m = mask;
-          mask >>= (1 : Word8);
-          ?(0 : Word8 != byte & m)
+          mask >>= (1 : Nat8);
+          ?(0 : Nat8 != byte & m)
         }
       }
     };
@@ -78,13 +78,13 @@ module {
       var acc : Nat = 0;
       for (i in it) {
         if (8 : Nat8 <= pp)
-        { acc := acc * 256 + Prim.word8ToNat(i) }
+        { acc := acc * 256 + Prim.nat8ToNat(i) }
         else if (0 : Nat8 == pp)
         { return ?acc }
         else {
-          acc *= Prim.word8ToNat(1 << Prim.nat8ToWord8(pp));
-          let mask : Word8 = -1 >> Prim.nat8ToWord8(8 - pp);
-          return ?(acc + Prim.word8ToNat(i & mask))
+          acc *= Prim.nat8ToNat(1 << pp);
+          let mask : Nat8 = 0xff >> (8 - pp);
+          return ?(acc + Prim.nat8ToNat(i & mask))
         };
         pp -= 8
       };
@@ -95,16 +95,16 @@ module {
     /// Consumes ⌈p/8⌉ bytes of entropy.
     public func binomial(n : Nat8) : ?Nat8 {
       var nn = n;
-      var acc : Word8 = 0;
+      var acc : Nat8 = 0;
       for (i in it) {
         if (8 : Nat8 <= nn)
-        { acc +%= Prim.popcntWord8(i) }
+        { acc +%= Prim.popcntNat8(i) }
         else if (0 : Nat8 == nn)
-        { return ?Prim.word8ToNat8(acc) }
+        { return ?acc }
         else {
-          let mask : Word8 = -1 << Prim.nat8ToWord8(8 - nn);
-          let residue = Prim.popcntWord8(i & mask);
-          return ?Prim.word8ToNat8(acc +% residue)
+          let mask : Nat8 = 0xff << (8 - nn);
+          let residue = Prim.popcntNat8(i & mask);
+          return ?(acc +% residue)
         };
         nn -= 8
       };
@@ -117,8 +117,8 @@ module {
   /// Distributes outcomes in the numeric range [0 .. 255].
   /// Seed blob must contain at least a byte.
   public func byteFrom(seed : Blob) : Nat8 {
-    switch (seed.bytes().next()) {
-      case (?w) { Prim.word8ToNat8(w) };
+    switch (seed.vals().next()) {
+      case (?w) { w };
       case _ { P.unreachable() };
     }
   };
@@ -126,8 +126,8 @@ module {
   /// Simulates a coin toss.
   /// Seed blob must contain at least a byte.
   public func coinFrom(seed : Blob) : Bool {
-    switch (seed.bytes().next()) {
-      case (?w) { w > (127 : Word8) };
+    switch (seed.vals().next()) {
+      case (?w) { w > (127 : Nat8) };
       case _ { P.unreachable() };
     }
   };
@@ -138,22 +138,22 @@ module {
   /// Distributes outcomes in the numeric range [0 .. 2^p - 1].
   /// Seed blob must contain at least ((p+7) / 8) bytes.
   public func rangeFrom(p : Nat8, seed : Blob) : Nat {
-    rangeIter(p, seed.bytes())
+    rangeIter(p, seed.vals())
   };
 
   // internal worker method, expects iterator with sufficient supply
-  func rangeIter(p : Nat8, it : I.Iter<Word8>) : Nat {
+  func rangeIter(p : Nat8, it : I.Iter<Nat8>) : Nat {
     var pp = p;
     var acc : Nat = 0;
     for (i in it) {
       if (8 : Nat8 <= pp)
-      { acc := acc * 256 + Prim.word8ToNat(i) }
+      { acc := acc * 256 + Prim.nat8ToNat(i) }
       else if (0 : Nat8 == pp)
       { return acc }
       else {
-        acc *= Prim.word8ToNat(1 << Prim.nat8ToWord8(pp));
-        let mask : Word8 = -1 >> Prim.nat8ToWord8(8 - pp);
-        return acc + Prim.word8ToNat(i & mask)
+        acc *= Prim.nat8ToNat(1 << pp);
+        let mask : Nat8 = 0xff >> (8 - pp);
+        return acc + Prim.nat8ToNat(i & mask)
       };
       pp -= 8
     };
@@ -163,22 +163,22 @@ module {
   /// Counts the number of heads in `n` coin tosses.
   /// Seed blob must contain at least ((n+7) / 8) bytes.
   public func binomialFrom(n : Nat8, seed : Blob) : Nat8 {
-    binomialIter(n, seed.bytes())
+    binomialIter(n, seed.vals())
   };
 
   // internal worker method, expects iterator with sufficient supply
-  func binomialIter(n : Nat8, it : I.Iter<Word8>) : Nat8 {
+  func binomialIter(n : Nat8, it : I.Iter<Nat8>) : Nat8 {
     var nn = n;
-    var acc : Word8 = 0;
+    var acc : Nat8 = 0;
     for (i in it) {
       if (8 : Nat8 <= nn)
-      { acc +%= Prim.popcntWord8(i) }
+      { acc +%= Prim.popcntNat8(i) }
       else if (0 : Nat8 == nn)
-      { return Prim.word8ToNat8(acc) }
+      { return acc }
       else {
-        let mask : Word8 = -1 << Prim.nat8ToWord8(8 - nn);
-        let residue = Prim.popcntWord8(i & mask);
-        return Prim.word8ToNat8(acc +% residue)
+        let mask : Nat8 = 0xff << (8 - nn);
+        let residue = Prim.popcntNat8(i & mask);
+        return (acc +% residue)
       };
       nn -= 8
     };

--- a/src/Text.mo
+++ b/src/Text.mo
@@ -597,4 +597,10 @@ module {
     }
   };
 
+  /// Returns the UTF-8 encoding of the given text
+  public let encodeUtf8 : Text -> Blob = Prim.encodeUtf8;
+
+  /// Tries to decode the given `Blob` as UTF-8.
+  /// Returns `null` if the blob is _not_ valid UTF-8.
+  public let decodeUtf8 : Blob -> ?Text = Prim.decodeUtf8;
 }

--- a/src/Text.mo
+++ b/src/Text.mo
@@ -37,12 +37,12 @@ module {
   /// Returns `t.size()`, the number of characters in `t` (and `t.chars()`).
   public func size(t : Text) : Nat { t.size(); };
 
-  /// Returns a hash obtained by the `xor`-ing the (`Word32`) values of all characters in `t`.
+  /// Returns a hash obtained by the `xor`-ing the (`Nat32`) values of all characters in `t`.
   /// WARNING: this is a poor hash function and will be replaced.
   public func hash(t : Text) : Hash.Hash {
-    var x = 0 : Word32;
+    var x = 0 : Nat32;
     for (c in t.chars()) {
-      x := x ^ Prim.charToWord32(c);
+      x := x ^ Prim.charToNat32(c);
     };
     return x
   };

--- a/src/Trie.mo
+++ b/src/Trie.mo
@@ -128,11 +128,11 @@ public func isValid<K,V> (t:Trie<K,V>, enforceNormal:Bool) : Bool {
                  ((k.hash & mask) == bits)
                  or
                  (do { Prim.debugPrint("\nmalformed hash!:\n");
-                     Prim.debugPrintInt(Prim.word32ToNat(k.hash));
+                     Prim.debugPrintInt(Prim.nat32ToNat(k.hash));
                      Prim.debugPrint("\n (key hash) != (path bits): \n");
-                     Prim.debugPrintInt(Prim.word32ToNat(bits));
+                     Prim.debugPrintInt(Prim.nat32ToNat(bits));
                      Prim.debugPrint("\nmask  : ");
-                     Prim.debugPrintInt(Prim.word32ToNat(mask));
+                     Prim.debugPrintInt(Prim.nat32ToNat(mask));
                      Prim.debugPrint("\n");
                      false 
                    })
@@ -143,11 +143,11 @@ public func isValid<K,V> (t:Trie<K,V>, enforceNormal:Bool) : Bool {
          };
     case (#branch(b)) {
            let bitpos1 = switch bitpos {
-           case null  {Prim.natToWord32(0)};
-           case (?bp) {Prim.natToWord32(Prim.word32ToNat(bp) + 1)}
+           case null  {Prim.natToNat32(0)};
+           case (?bp) {Prim.natToNat32(Prim.nat32ToNat(bp) + 1)}
            };
-           let mask1 = mask | (Prim.natToWord32(1) << bitpos1);
-           let bits1 = bits | (Prim.natToWord32(1) << bitpos1);
+           let mask1 = mask | (Prim.natToNat32(1) << bitpos1);
+           let bits1 = bits | (Prim.natToNat32(1) << bitpos1);
            let sum = size<K,V>(b.left) + size<K,V>(b.right);
            (b.size == sum or (do { Prim.debugPrint("malformed size"); false }))
            and

--- a/test/arrayTest.mo
+++ b/test/arrayTest.mo
@@ -171,7 +171,7 @@ let suite = Suite.suite("Array", [
     "thaw",
     do {
       let xs : [Int] = [ 1, 2, 3 ];
-      Array.freeze(Array.thaw(xs))
+      Array.freeze(Array.thaw<Int>(xs))
     },
     M.equals(T.array<Int>(T.intTestable, [ 1, 2, 3]))
   ),

--- a/test/resultTest.mo
+++ b/test/resultTest.mo
@@ -16,30 +16,30 @@ func largerThan10(x : Nat) : Result.Result<Nat, Text> =
 let chain = Suite.suite("chain", [
   Suite.test("ok -> ok",
     Result.chain<Nat, Nat, Text>(makeNatural(11), largerThan10),
-    M.equals(T.result(T.natTestable, T.textTestable, #ok(11)))
+    M.equals(T.result<Nat,Text>(T.natTestable, T.textTestable, #ok(11)))
   ),
   Suite.test("ok -> err",
     Result.chain<Nat, Nat, Text>(makeNatural(5), largerThan10),
-    M.equals(T.result(T.natTestable, T.textTestable, #err("5 is not larger than 10.")))
+    M.equals(T.result<Nat,Text>(T.natTestable, T.textTestable, #err("5 is not larger than 10.")))
   ),
   Suite.test("err",
     Result.chain<Nat, Nat, Text>(makeNatural(-5), largerThan10),
-    M.equals(T.result(T.natTestable, T.textTestable, #err("-5 is not a natural number.")))
+    M.equals(T.result<Nat,Text>(T.natTestable, T.textTestable, #err("-5 is not a natural number.")))
   ),
 ]);
 
 let flatten = Suite.suite("flatten", [
   Suite.test("ok -> ok",
     Result.flatten<Nat, Text>(#ok(#ok(10))),
-    M.equals(T.result(T.natTestable, T.textTestable, #ok(10)))
+    M.equals(T.result<Nat,Text>(T.natTestable, T.textTestable, #ok(10)))
   ),
   Suite.test("err",
     Result.flatten<Nat, Text>(#err("wrong")),
-    M.equals(T.result(T.natTestable, T.textTestable, #err("wrong")))
+    M.equals(T.result<Nat,Text>(T.natTestable, T.textTestable, #err("wrong")))
   ),
   Suite.test("ok -> err",
     Result.flatten<Nat, Text>(#ok(#err("wrong"))),
-    M.equals(T.result(T.natTestable, T.textTestable, #err("wrong")))
+    M.equals(T.result<Nat,Text>(T.natTestable, T.textTestable, #err("wrong")))
   ),
 ]);
 

--- a/test/textTest.mo
+++ b/test/textTest.mo
@@ -5,7 +5,7 @@ import Iter "mo:base/Iter";
 import Char "mo:base/Char";
 import Order "mo:base/Order";
 import Array "mo:base/Array";
-import Word32 "mo:base/Word32";
+import Nat32 "mo:base/Nat32";
 
 import Suite "mo:matchers/Suite";
 import M "mo:matchers/Matchers";
@@ -108,7 +108,7 @@ run(suite("toIter",
    Text.toIter("abc"),
    M.equals(iterT (['a','b','c']))),
  do {
-   let a = Array.tabulate<Char>(1000, func i = Char.fromWord32(65+%Word32.fromInt(i % 26)));
+   let a = Array.tabulate<Char>(1000, func i = Char.fromNat32(65+%Nat32.fromNat(i % 26)));
    test(
      "fromIter-2",
      Text.toIter(Text.join("", Array.map(a, Char.toText).vals())),
@@ -131,7 +131,7 @@ run(suite("fromIter",
    Text.fromIter((['a', 'b', 'c'].vals())),
    M.equals(T.text "abc")),
  do {
-   let a = Array.tabulate<Char>(1000, func i = Char.fromWord32(65+%Word32.fromInt(i % 26)));
+   let a = Array.tabulate<Char>(1000, func i = Char.fromNat32(65+%Nat32.fromNat(i % 26)));
    test(
    "fromIter-3",
    Text.fromIter(a.vals()),
@@ -175,7 +175,7 @@ run(suite("join",
    Text.join("", (["a","bb","ccc","dddd"].vals())),
    M.equals(T.text "abbcccdddd")),
  do {
-   let a = Array.tabulate<Char>(1000, func i = Char.fromWord32(65+%Word32.fromInt(i % 26)));
+   let a = Array.tabulate<Char>(1000, func i = Char.fromNat32(65+%Nat32.fromNat(i % 26)));
    test(
    "join-3",
    Text.join("", Array.map(a, Char.toText).vals()),
@@ -206,7 +206,7 @@ run(suite("join",
    Text.join(",", (["a","bb","ccc","dddd"].vals())),
    M.equals(T.text "a,bb,ccc,dddd")),
  do {
-   let a = Array.tabulate<Char>(1000, func i = Char.fromWord32(65+%Word32.fromInt(i % 26)));
+   let a = Array.tabulate<Char>(1000, func i = Char.fromNat32(65+%Nat32.fromNat(i % 26)));
    test(
    "join-3",
    Text.join("", Array.map(a, Char.toText).vals()),

--- a/test/textTest.mo
+++ b/test/textTest.mo
@@ -1,5 +1,6 @@
 import Debug "mo:base/Debug";
 import Text "mo:base/Text";
+import Blob "mo:base/Blob";
 import Iter "mo:base/Iter";
 import Char "mo:base/Char";
 import Order "mo:base/Order";
@@ -18,6 +19,11 @@ func charT(c : Char): T.TestableItem<Char> = {
   equals = Char.equal;
 };
 
+func blobT(b : Blob): T.TestableItem<Blob> = {
+  item = b;
+  display = func(b : Blob) : Text { debug_show(b) };
+  equals = Blob.equal;
+};
 
 func ordT(o : Order.Order): T.TestableItem<Order.Order> = {
   item = o;
@@ -718,3 +724,27 @@ run(suite("compareWith",
    M.equals(ordT (#greater)))
 ]))
 };
+
+run(suite("utf8",
+[
+ test(
+   "encode-literal",
+   Text.encodeUtf8("FooBär☃"),
+   M.equals(blobT("FooBär☃"))),
+ test(
+   "encode-concat",
+   Text.encodeUtf8("Foo" # "Bär" # "☃"),
+   M.equals(blobT("FooBär☃"))),
+ test(
+   "decode-literal-good",
+   Text.decodeUtf8("FooBär☃"),
+   M.equals(optTextT(?"FooBär☃"))),
+ test(
+   "decode-literal-bad1",
+   Text.decodeUtf8("\FF"),
+   M.equals(optTextT(null))),
+ test(
+   "decode-literal-bad2",
+   Text.decodeUtf8("\D8\00t d"),
+   M.equals(optTextT(null))),
+]));

--- a/test/trieSetTest.mo
+++ b/test/trieSetTest.mo
@@ -1,11 +1,11 @@
 import Nat "mo:base/Nat";
 import TrieSet "mo:base/TrieSet";
-import Word32 "mo:base/Word32";
+import Nat32 "mo:base/Nat32";
 import Suite "mo:matchers/Suite";
 import M "mo:matchers/Matchers";
 import T "mo:matchers/Testable";
 
-let set1 = TrieSet.fromArray<Nat>([ 1, 2, 3, 1, 2, 3, 1 ], Word32.fromNat, Nat.equal);
+let set1 = TrieSet.fromArray<Nat>([ 1, 2, 3, 1, 2, 3, 1 ], Nat32.fromNat, Nat.equal);
 
 let suite = Suite.suite("TrieSet fromArray", [
   Suite.test(


### PR DESCRIPTION
 explicates  missing type instantiations that are now considered underconstrained by upcoming release of motoko