### PR TITLE
Uses a better hash function for Text

### DIFF
--- a/src/Text.mo
+++ b/src/Text.mo
@@ -37,12 +37,14 @@ module {
   /// Returns `t.size()`, the number of characters in `t` (and `t.chars()`).
   public func size(t : Text) : Nat { t.size(); };
 
-  /// Returns a hash obtained by the `xor`-ing the (`Word32`) values of all characters in `t`.
-  /// WARNING: this is a poor hash function and will be replaced.
+  /// Returns a hash obtained by using the `djb2` algorithm from http://www.cse.yorku.ca/~oz/hash.html
+  ///
+  /// This function is _good enough_ for use in a hash-table but it's not a cryptographic hash function!
   public func hash(t : Text) : Hash.Hash {
-    var x = 0 : Word32;
-    for (c in t.chars()) {
-      x := x ^ Prim.charToWord32(c);
+    var x : Word32 = 5381;
+    for (char in t.chars()) {
+      let c : Word32 = Prim.charToWord32(char);
+      x := ((x << 5) +% x) +% c;
     };
     return x
   };


### PR DESCRIPTION
According to https://softwareengineering.stackexchange.com/a/145633 `djb2` does reasonably well, certainly a _lot_ better than what we have now.

Is this a breaking change? People might have stored these hashes in stable memory. Do we need to add a disclaimer that people shouldn't do that, or are we doomed to never improve our hash functions in base?