### PR TITLE
Reformat to guidelines and add (commented out) type bindings 

### DIFF
--- a/src/Array.mo
+++ b/src/Array.mo
@@ -15,7 +15,7 @@ module {
     };
     var i = 0;
     while (i < a.size()) {
-      if (not eq(a[i],b[i])) {
+      if (not eq(a[i], b[i])) {
         return false;
       };
       i += 1;

--- a/src/AssocList.mo
+++ b/src/AssocList.mo
@@ -1,6 +1,6 @@
 /// Lists of key-value entries ("associations").
 ///
-/// Implements the same operations as [`Trie`](Trie.html), but uses a
+/// Implements the same operations as library `Trie`, but uses a
 /// linked-list of entries and no hashing.
 
 import List "List";

--- a/src/AssocList.mo
+++ b/src/AssocList.mo
@@ -29,7 +29,7 @@ module {
               rec(tl)
             }
           };
-	}
+        }
     };
     label profile_assocList_find_begin : (?V) {
       rec(al)

--- a/src/AssocList.mo
+++ b/src/AssocList.mo
@@ -7,8 +7,8 @@ import List "List";
 
 module {
 
-/// polymorphic association linked lists between keys and values
-public type AssocList<K,V> = List.List<(K,V)>;
+  /// polymorphic association linked lists between keys and values
+  public type AssocList<K,V> = List.List<(K,V)>;
 
   /// Find the value associated with a given key, or null if absent.
   public func find<K,V>(al : AssocList<K,V>,
@@ -105,7 +105,7 @@ public type AssocList<K,V> = List.List<(K,V)>;
     rec(al1, al2)
   };
 
-  /// Specialied version of `disj`, optimized for disjoint sub-spaces of keyspace (no matching keys).
+  /// Specialized version of `disj`, optimized for disjoint sub-spaces of keyspace (no matching keys).
   public func disjDisjoint<K,V,W,X>(al1:AssocList<K,V>,
                              al2:AssocList<K,W>,
                              vbin:(?V,?W)->X)

--- a/src/AssocList.mo
+++ b/src/AssocList.mo
@@ -45,7 +45,7 @@ module {
     ov : ?V
   )
   : (AssocList<K, V>, ?V) {
-    func rec(al:AssocList<K, V>) : (AssocList<K, V>, ?V) {
+    func rec(al : AssocList<K, V>) : (AssocList<K, V>, ?V) {
       switch (al) {
         case (null) {
           switch ov {

--- a/src/AssocList.mo
+++ b/src/AssocList.mo
@@ -76,7 +76,7 @@ module {
   /// values of the right list are irrelevant.
   public func diff<K, V, W>(
     al1 : AssocList<K, V>,
-    al2 : AssocList<K,W>,
+    al2 : AssocList<K, W>,
     keq : (K, K) -> Bool
   ) : AssocList<K, V>  {
     func rec(al1 : AssocList<K, V>) : AssocList<K, V> {
@@ -103,9 +103,9 @@ module {
       func rec(al1 : AssocList<K, V>, al2 : AssocList<K, W>) : AssocList<K, X> =
         label profile_assocList_mapAppend_rec : AssocList<K,X> {
           switch (al1, al2) {
-            case (null, null)          { null };
-            case (?((k,v),al1_), _   ) { ?((k, vbin(?v, null)), rec(al1_, al2 )) };
-            case (null, ?((k,v),al2_)) { ?((k, vbin(null, ?v)), rec(null, al2_)) };
+            case (null, null) { null };
+            case (?((k, v), al1_), _   ) { ?((k, vbin(?v, null)), rec(al1_, al2 )) };
+            case (null, ?((k, v), al2_)) { ?((k, vbin(null, ?v)), rec(null, al2_)) };
           }
         };
       rec(al1, al2)
@@ -137,7 +137,7 @@ module {
     func rec1(al1 : AssocList<K, V>) : AssocList<K, X> {
       switch al1 {
         case (null) {
-          func rec2(al2:AssocList<K,W>) : AssocList<K,X> {
+          func rec2(al2 : AssocList<K, W>) : AssocList<K, X> {
             switch al2 {
               case (null) { null };
               case (?((k, v2), tl)) {
@@ -151,7 +151,7 @@ module {
           rec2(al2)
         };
         case (?((k, v1), tl)) {
-          switch (find<K,W>(al2, k, keq)) {
+          switch (find<K, W>(al2, k, keq)) {
             case (null) { ?((k, vbin(?v1, null)), rec1(tl)) };
             case (?v2) { /* handled above */ rec1(tl) };
           }
@@ -171,11 +171,11 @@ module {
     keq : (K, K) -> Bool,
     vbin : (V, W) -> X
   ) : AssocList<K, X>  {
-    func rec(al1:AssocList<K, V>) : AssocList<K, X> {
+    func rec(al1 : AssocList<K, V>) : AssocList<K, X> {
       switch al1 {
         case (null) { null };
         case (?((k, v1), tl)) {
-          switch (find<K,W>(al2, k, keq)) {
+          switch (find<K, W>(al2, k, keq)) {
             case (null) { rec(tl) };
             case (?v2) { ?((k, vbin(v1, v2)), rec(tl)) };
           }

--- a/src/AssocList.mo
+++ b/src/AssocList.mo
@@ -1,6 +1,6 @@
 /// Lists of key-value entries ("associations").
 ///
-/// Implements the same operations as [`Trie`](Trie.html), but uses as a
+/// Implements the same operations as [`Trie`](Trie.html), but uses a
 /// linked-list of entries and no hashing.
 
 import List "List";
@@ -8,110 +8,116 @@ import List "List";
 module {
 
   /// polymorphic association linked lists between keys and values
-  public type AssocList<K,V> = List.List<(K,V)>;
+  public type AssocList<K, V> = List.List<(K, V)>;
 
   /// Find the value associated with a given key, or null if absent.
-  public func find<K,V>(al : AssocList<K,V>,
-                 k:K,
-                 k_eq:(K,K)->Bool)
-    : ?V
-  {
-    func rec(al:AssocList<K,V>) : ?V {
-    label profile_assocList_find_rec : (?V)
-      switch (al) {
-      case (null) { label profile_assocList_find_end_fail : (?V)  { null } };
-      case (?((hd_k, hd_v), tl)) {
-             if (k_eq(k, hd_k)) {
-               label profile_assocList_find_end_success : (?V) {
+  public func find<K, V>(
+    al : AssocList<K, V>,
+    k : K,
+    k_eq : (K, K) -> Bool
+  ) : ?V {
+    func rec(al : AssocList<K, V>) : ?V {
+      label profile_assocList_find_rec : (?V)
+        switch (al) {
+          case (null) { label profile_assocList_find_end_fail : (?V)  { null } };
+          case (?((hd_k, hd_v), tl)) {
+            if (k_eq(k, hd_k)) {
+              label profile_assocList_find_end_success : (?V) {
                  ?hd_v
-               }
-             } else {
-               rec(tl)
-             }
-           };
-    }};
-    label profile_assocList_find_begin : (?V) { rec(al) }
+              }
+            } else {
+              rec(tl)
+            }
+          };
+	}
+    };
+    label profile_assocList_find_begin : (?V) {
+      rec(al)
+    }
   };
 
   /// replace the value associated with a given key, or add it, if missing.
   /// returns old value, or null, if no prior value existed.
-  public func replace<K,V>(al : AssocList<K,V>,
-                    k:K,
-                    k_eq:(K,K)->Bool,
-                    ov: ?V)
-    : (AssocList<K,V>, ?V)
-  {
-    func rec(al:AssocList<K,V>) : (AssocList<K,V>, ?V) {
+  public func replace<K, V>(
+    al : AssocList<K, V>,
+    k : K,
+    k_eq : (K, K) -> Bool,
+    ov : ?V
+  )
+  : (AssocList<K, V>, ?V) {
+    func rec(al:AssocList<K, V>) : (AssocList<K, V>, ?V) {
       switch (al) {
-      case (null) {
-             switch ov {
-               case (null) { (null, null) };
-               case (?v) { (?((k, v), null), null) };
-             }
-           };
-      case (?((hd_k, hd_v), tl)) {
-             if (k_eq(k, hd_k)) {
-               // if value is null, remove the key; otherwise, replace key's old value
-               // return old value
-               switch ov {
-                 case (null) { (tl, ?hd_v) };
-                 case (?v)   { (?((hd_k, v), tl), ?hd_v) };
-               }
-             } else {
-               let (tl2, old_v) = rec(tl);
-               (?((hd_k, hd_v), tl2), old_v)
-             }
-           };
-    }};
+        case (null) {
+          switch ov {
+            case (null) { (null, null) };
+            case (?v) { (?((k, v), null), null) };
+          }
+        };
+        case (?((hd_k, hd_v), tl)) {
+          if (k_eq(k, hd_k)) {
+            // if value is null, remove the key; otherwise, replace key's old value
+            // return old value
+            switch ov {
+              case (null) { (tl, ?hd_v) };
+              case (?v) { (?((hd_k, v), tl), ?hd_v) };
+            }
+          } else {
+            let (tl2, old_v) = rec(tl);
+            (?((hd_k, hd_v), tl2), old_v)
+            }
+        };
+      }
+    };
     rec(al)
   };
 
   /// The entries of the final list consist of those pairs of
   /// the left list whose keys are not present in the right list; the
   /// values of the right list are irrelevant.
-  public func diff<K,V,W>(al1: AssocList<K,V>,
-                   al2: AssocList<K,W>,
-                   keq: (K,K)->Bool)
-    : AssocList<K,V>
-  {
-    func rec(al1:AssocList<K,V>) : AssocList<K,V> {
+  public func diff<K, V, W>(
+    al1 : AssocList<K, V>,
+    al2 : AssocList<K,W>,
+    keq : (K, K) -> Bool
+  ) : AssocList<K, V>  {
+    func rec(al1 : AssocList<K, V>) : AssocList<K, V> {
       switch al1 {
         case (null) { null };
         case (?((k, v1), tl)) {
-               switch (find<K,W>(al2, k, keq)) {
-                 case (null) { rec(tl)};
-                 case (?v2) { ?((k, v1), rec(tl)) };
-               }
-             };
+          switch (find<K, W>(al2, k, keq)) {
+            case (null) { rec(tl)};
+            case (?v2) { ?((k, v1), rec(tl)) };
+          }
+        };
       }
     };
     rec(al1)
   };
 
   /// Transform and combine the entries of two association lists.
-  public func mapAppend<K,V,W,X>(al1:AssocList<K,V>,
-                          al2:AssocList<K,W>,
-                          vbin:(?V,?W)->X)
-    : AssocList<K,X> = label profile_assocList_mapAppend : AssocList<K,X>
-  {
-    func rec(al1:AssocList<K,V>,
-             al2:AssocList<K,W>) : AssocList<K,X> = label profile_assocList_mapAppend_rec : AssocList<K,X> {
-      switch (al1, al2) {
-        case (null, null)          { null };
-        case (?((k,v),al1_), _   ) { ?((k, vbin(?v, null)), rec(al1_, al2 )) };
-        case (null, ?((k,v),al2_)) { ?((k, vbin(null, ?v)), rec(null, al2_)) };
-      }
+  public func mapAppend<K, V, W, X>(
+    al1 : AssocList<K, V>,
+    al2 : AssocList<K, W>,
+    vbin : (?V, ?W) -> X
+  ) : AssocList<K, X> =
+    label profile_assocList_mapAppend : AssocList<K, X> {
+      func rec(al1 : AssocList<K, V>, al2 : AssocList<K, W>) : AssocList<K, X> =
+        label profile_assocList_mapAppend_rec : AssocList<K,X> {
+          switch (al1, al2) {
+            case (null, null)          { null };
+            case (?((k,v),al1_), _   ) { ?((k, vbin(?v, null)), rec(al1_, al2 )) };
+            case (null, ?((k,v),al2_)) { ?((k, vbin(null, ?v)), rec(null, al2_)) };
+          }
+        };
+      rec(al1, al2)
     };
-    rec(al1, al2)
-  };
 
   /// Specialized version of `disj`, optimized for disjoint sub-spaces of keyspace (no matching keys).
-  public func disjDisjoint<K,V,W,X>(al1:AssocList<K,V>,
-                             al2:AssocList<K,W>,
-                             vbin:(?V,?W)->X)
-    : AssocList<K,X> = label profile_assocList_disjDisjoint : AssocList<K,X>
-  {
-    mapAppend<K,V,W,X>(al1, al2, vbin)
+  public func disjDisjoint<K, V, W, X>(
+    al1 : AssocList<K, V>,
+    al2 : AssocList<K, W>,
+    vbin : (?V, ?W) -> X)
+  : AssocList<K, X> = label profile_assocList_disjDisjoint : AssocList<K,X>  {
+    mapAppend<K, V, W, X>(al1, al2, vbin)
   };
 
   /// This operation generalizes the notion of "set union" to finite maps.
@@ -122,34 +128,34 @@ module {
   /// create the value in the image.  To accomodate these various
   /// situations, the operator accepts optional values, but is never
   /// applied to (null, null).
-  public func disj<K,V,W,X>(al1:AssocList<K,V>,
-                     al2:AssocList<K,W>,
-                     keq:(K,K)->Bool,
-                     vbin:(?V,?W)->X)
-    : AssocList<K,X>
-  {
-    func rec1(al1:AssocList<K,V>) : AssocList<K,X> {
+  public func disj<K, V, W, X>(
+    al1 : AssocList<K, V>,
+    al2 : AssocList<K, W>,
+    keq : (K, K) -> Bool,
+    vbin :(?V, ?W) -> X
+  ) : AssocList<K, X> {
+    func rec1(al1 : AssocList<K, V>) : AssocList<K, X> {
       switch al1 {
         case (null) {
-               func rec2(al2:AssocList<K,W>) : AssocList<K,X> {
-                 switch al2 {
-                 case (null) { null };
-                 case (?((k, v2), tl)) {
-                        switch (find<K,V>(al1, k, keq)) {
-                        case (null) { ?((k, vbin(null, ?v2)), rec2(tl)) };
-                        case (?v1) { ?((k, vbin(?v1, ?v2)), rec2(tl)) };
-                        }
-                      };
-                 }
-               };
-               rec2(al2)
-             };
+          func rec2(al2:AssocList<K,W>) : AssocList<K,X> {
+            switch al2 {
+              case (null) { null };
+              case (?((k, v2), tl)) {
+                switch (find<K, V>(al1, k, keq)) {
+                  case (null) { ?((k, vbin(null, ?v2)), rec2(tl)) };
+                  case (?v1) { ?((k, vbin(?v1, ?v2)), rec2(tl)) };
+                  }
+                };
+              }
+            };
+          rec2(al2)
+        };
         case (?((k, v1), tl)) {
-               switch (find<K,W>(al2, k, keq)) {
-                 case (null) { ?((k, vbin(?v1, null)), rec1(tl)) };
-                 case (?v2) { /* handled above */ rec1(tl) };
-               }
-             };
+          switch (find<K,W>(al2, k, keq)) {
+            case (null) { ?((k, vbin(?v1, null)), rec1(tl)) };
+            case (?v2) { /* handled above */ rec1(tl) };
+          }
+        };
       }
     };
     rec1(al1)
@@ -159,36 +165,36 @@ module {
   /// finite maps.  Produces a "conjuctive image" of the two lists, where
   /// the values of matching keys are combined with the given binary
   /// operator, and unmatched entries are not present in the output.
-  public func join<K,V,W,X>(al1 : AssocList<K,V>,
-                     al2:AssocList<K,W>,
-                     keq:(K,K)->Bool,
-                     vbin:(V,W)->X)
-    : AssocList<K,X>
-  {
-    func rec(al1:AssocList<K,V>) : AssocList<K,X> {
+  public func join<K, V, W, X>(
+    al1 : AssocList<K, V>,
+    al2 : AssocList<K, W>,
+    keq : (K, K) -> Bool,
+    vbin : (V, W) -> X
+  ) : AssocList<K, X>  {
+    func rec(al1:AssocList<K, V>) : AssocList<K, X> {
       switch al1 {
         case (null) { null };
         case (?((k, v1), tl)) {
-               switch (find<K,W>(al2, k, keq)) {
-                 case (null) { rec(tl) };
-                 case (?v2) { ?((k, vbin(v1, v2)), rec(tl)) };
-               }
-             };
+          switch (find<K,W>(al2, k, keq)) {
+            case (null) { rec(tl) };
+            case (?v2) { ?((k, vbin(v1, v2)), rec(tl)) };
+          }
+        };
       }
     };
     rec(al1)
   };
 
   /// Fold the entries based on the recursive list structure.
-  public func fold<K,V,X>(al:AssocList<K,V>,
-                   nil:X,
-                   cons:(K,V,X)->X)
-    : X
-  {
-    func rec(al:AssocList<K,V>) : X {
+  public func fold<K, V, X>(
+    al : AssocList<K, V>,
+    nil : X,
+    cons : (K, V, X) -> X
+  ) : X {
+    func rec(al : AssocList<K, V>) : X {
       switch al {
-      case null { nil };
-      case (?((k,v),t)) { cons(k, v, rec(t)) };
+        case null { nil };
+        case (?((k, v), t)) { cons(k, v, rec(t)) };
       }
     };
     rec(al)

--- a/src/Blob.mo
+++ b/src/Blob.mo
@@ -3,7 +3,16 @@
 import Prim "mo:⛔";
 module {
 
-  public let hash : Blob -> Nat32 = Prim.hashBlob;
+  /// An immutable, possibly empty sequence of bytes.
+  /// Given `b : Blob`:
+  ///
+  /// * `b.size() : Nat` returns the number of bytes in the blob;
+  /// * `b.bytes() : Iter.Iter<Nat8>` returns an iterator to enumerate the bytes of the blob.
+  /// (Direct indexing of Blobs is not unsupported yet.)
+  public type Blob = Prim.Types.Blob;
+
+  /// Returns a (non-cryptographic) hash of 'b'
+  public let hash : (b : Blob) -> Nat32 = Prim.hashBlob;
 
   /// Returns `x == y`.
   public func equal(x : Blob, y : Blob) : Bool { x == y };

--- a/src/Blob.mo
+++ b/src/Blob.mo
@@ -3,6 +3,7 @@
 import Prim "mo:⛔";
 module {
 
+/*
   /// An immutable, possibly empty sequence of bytes.
   /// Given `b : Blob`:
   ///
@@ -10,6 +11,7 @@ module {
   /// * `b.bytes() : Iter.Iter<Nat8>` returns an iterator to enumerate the bytes of the blob.
   /// (Direct indexing of Blobs is not unsupported yet.)
   public type Blob = Prim.Types.Blob;
+*/
 
   /// Returns a (non-cryptographic) hash of 'b'
   public let hash : (b : Blob) -> Nat32 = Prim.hashBlob;

--- a/src/Bool.mo
+++ b/src/Bool.mo
@@ -8,8 +8,10 @@
 import Prim "mo:⛔";
 module {
 
+/*
   /// Booleans with constants `true` and `false`.
   public type Bool = Prim.Types.Bool;
+*/
 
   /// Conversion.
   public func toText(x : Bool) : Text {

--- a/src/Bool.mo
+++ b/src/Bool.mo
@@ -8,7 +8,7 @@
 import Prim "mo:⛔";
 module {
 
-  // Booleans with constants `true` and `false`
+  /// Booleans with constants `true` and `false`.
   public type Bool = Prim.Types.Bool;
 
   /// Conversion.

--- a/src/Bool.mo
+++ b/src/Bool.mo
@@ -8,6 +8,9 @@
 import Prim "mo:⛔";
 module {
 
+  // Booleans with constants `true` and `false`
+  public type Bool = Prim.Types.Bool;
+
   /// Conversion.
   public func toText(x : Bool) : Text {
     if x { "true" } else { "false" }

--- a/src/Buffer.mo
+++ b/src/Buffer.mo
@@ -9,148 +9,147 @@
 /// of application-specific elements.
 ///
 /// The `Array` module focuses on Motoko's builtin arrays, whose size is
-/// each fixed.  They do not permit general growth/appending, which is the
+/// fixed.  Arrays do not permit general growth/appending, which is the
 /// focus here.
 ///
 /// To create these arrays, and to consume them with ergonomic (imperative) code, and
-/// low API friction, developers need _buffers that grow_.
+/// low API friction, developers can employ `Buffer` objects.
 ///
 /// ## Define `Buf<X>` object type
 ///
-/// A "buffer" is a mutable sequence that grows, either one element at a
-/// time, or one (second) buffer at time.
+/// A "Buffer" is a mutable sequence that can be extended by a single element or the contents of another buffer.
 import Prim "mo:⛔";
 
 module {
 
-/// Create a buffer represented internally by an mutable array.
-///
-/// The argument `initCapacity` gives the initial capacity.  Under the
-/// interface, the mutable array grows by doubling when this initial
-/// capacity is exhausted.
-public class Buffer<X> (initCapacity : Nat) {
-  var count : Nat = 0;
-  var elems : [var X] = [var]; // initially empty; allocated upon first `add`
+  /// Create a stateful buffer class encapsulating a mutable array.
+  ///
+  /// The argument `initCapacity` determines its initial capacity.
+  /// The underlying mutable array grows by doubling when its current
+  /// capacity is exceeded.
+  public class Buffer<X> (initCapacity : Nat) {
+    var count : Nat = 0;
+    var elems : [var X] = [var]; // initially empty; allocated upon first `add`
 
-  /// Adds a single element to the buffer.
-  public func add(elem : X) {
-    if (count == elems.size()) {
-      let size =
-        if (count == 0) {
-          if (initCapacity > 0) { initCapacity } else { 1 }
-        } else {
-          2 * elems.size()
-        };
-      let elems2 = Prim.Array_init<X>(size, elem);
+    /// Adds a single element to the buffer.
+    public func add(elem : X) {
+      if (count == elems.size()) {
+	let size =
+	  if (count == 0) {
+	    if (initCapacity > 0) { initCapacity } else { 1 }
+	  } else {
+	    2 * elems.size()
+	  };
+	let elems2 = Prim.Array_init<X>(size, elem);
+	var i = 0;
+	label l loop {
+	  if (i >= count) break l;
+	  elems2[i] := elems[i];
+	  i += 1;
+	};
+	elems := elems2;
+      };
+      elems[count] := elem;
+      count += 1;
+    };
+
+    /// Removes the item that was inserted last and returns it or `null` if no
+    /// elements had been added to the Buffer.
+    public func removeLast() : ?X {
+      if (count == 0) {
+	null
+      } else {
+	count -= 1;
+	?elems[count]
+      };
+    };
+
+    /// Adds all elements in buffer `b` to this buffer.
+    public func append(b : Buffer<X>) {
+      let i = b.vals();
+      loop {
+	switch (i.next()) {
+	case null return;
+	case (?x) { add(x) };
+	};
+      };
+    };
+
+    /// Returns the current number of elements.
+    public func size() : Nat =
+      count;
+
+    /// Resets the buffer.
+    public func clear() =
+      count := 0;
+
+    /// Returns a copy of this buffer.
+    public func clone() : Buffer<X> {
+      let c = Buffer<X>(elems.size());
       var i = 0;
       label l loop {
-        if (i >= count) break l;
-        elems2[i] := elems[i];
-        i += 1;
+	if (i >= count) break l;
+	c.add(elems[i]);
+	i += 1;
       };
-      elems := elems2;
+      c
     };
-    elems[count] := elem;
-    count += 1;
-  };
 
-  /// Removes the item that was inserted last and returns it or `null` if no
-  /// elements had been added to the Buffer.
-  public func removeLast() : ?X {
-    if (count == 0) {
-      null
-    } else {
-      count -= 1;
-      ?elems[count]
-    };
-  };
-
-  /// Adds all elements in buffer `b` to this buffer.
-  public func append(b : Buffer<X>) {
-    let i = b.vals();
-    loop {
-      switch (i.next()) {
-      case null return;
-      case (?x) { add(x) };
-      };
-    };
-  };
-
-  /// Returns the current number of elements.
-  public func size() : Nat =
-    count;
-
-  /// Resets the buffer.
-  public func clear() =
-    count := 0;
-
-  /// Returns a copy of this buffer.
-  public func clone() : Buffer<X> {
-    let c = Buffer<X>(elems.size());
-    var i = 0;
-    label l loop {
-      if (i >= count) break l;
-      c.add(elems[i]);
-      i += 1;
-    };
-    c
-  };
-
-  /// Returns an `Iter` over the elements of this buffer.
-  public func vals() : { next : () -> ?X } = object {
-    var pos = 0;
-    public func next() : ?X {
-      if (pos == count) { null } else {
-        let elem = ?elems[pos];
-        pos += 1;
-        elem
+    /// Returns an `Iter` over the elements of this buffer.
+    public func vals() : { next : () -> ?X } = object {
+      var pos = 0;
+      public func next() : ?X {
+	if (pos == count) { null } else {
+	  let elem = ?elems[pos];
+	  pos += 1;
+	  elem
+	}
       }
-    }
-  };
+    };
 
-  /// Creates a new array containing this buffer's elements.
-  public func toArray() : [X] =
-    // immutable clone of array
-    Prim.Array_tabulate<X>(
-      count,
-      func(x: Nat): X { elems[x] }
-    );
+    /// Creates a new array containing this buffer's elements.
+    public func toArray() : [X] =
+      // immutable clone of array
+      Prim.Array_tabulate<X>(
+	count,
+	func(x: Nat): X { elems[x] }
+      );
 
-  /// Creates a mutable array containing this buffer's elements.
-  public func toVarArray() : [var X] {
-    if (count == 0) { [var] } else {
-      let a = Prim.Array_init<X>(count, elems[0]);
-      var i = 0;
-      label l loop {
-        if (i >= count) break l;
-        a[i] := elems[i];
-        i += 1;
-      };
-      a
-    }
-  };
+    /// Creates a mutable array containing this buffer's elements.
+    public func toVarArray() : [var X] {
+      if (count == 0) { [var] } else {
+	let a = Prim.Array_init<X>(count, elems[0]);
+	var i = 0;
+	label l loop {
+	  if (i >= count) break l;
+	  a[i] := elems[i];
+	  i += 1;
+	};
+	a
+      }
+    };
 
-  /// Gets the `i`-th element of this buffer. Traps if  `i >= count`. Indexing is zero-based.
-  public func get(i : Nat) : X {
-    assert(i < count);
-    elems[i]
-  };
+    /// Gets the `i`-th element of this buffer. Traps if  `i >= count`. Indexing is zero-based.
+    public func get(i : Nat) : X {
+      assert(i < count);
+      elems[i]
+    };
 
-  /// Gets the 'i'-th element of the buffer as an option. Returns `null` when `i >= count`. Indexing is zero-based.
-  public func getOpt(i : Nat) : ?X {
-    if (i < count) {
-      ?elems[i]
-    }
-    else {
-      null
-    }
-  };
+    /// Gets the `i`-th element of the buffer as an option. Returns `null` when `i >= count`. Indexing is zero-based.
+    public func getOpt(i : Nat) : ?X {
+      if (i < count) {
+	?elems[i]
+      }
+      else {
+	null
+      }
+    };
 
-  /// Overwrites the current value of the `i`-entry of  this buffer with `elem`. Traps if the
-  /// index is out of bounds. Indexing is zero-based.
-  public func put(i : Nat, elem : X) {
-    elems[i] := elem;
+    /// Overwrites the current value of the `i`-entry of  this buffer with `elem`. Traps if the
+    /// index is out of bounds. Indexing is zero-based.
+    public func put(i : Nat, elem : X) {
+      elems[i] := elem;
+    };
   };
-};
 
 }

--- a/src/Buffer.mo
+++ b/src/Buffer.mo
@@ -9,7 +9,7 @@
 /// of application-specific elements.
 ///
 /// The `Array` module focuses on Motoko's builtin arrays, whose size is
-/// fixed.  Arrays do not permit general growth/appending, which is the
+/// fixed. Arrays do not permit general growth/appending, which is the
 /// focus here.
 ///
 /// To create these arrays, and to consume them with ergonomic (imperative) code, and
@@ -27,7 +27,7 @@ module {
   /// The argument `initCapacity` determines its initial capacity.
   /// The underlying mutable array grows by doubling when its current
   /// capacity is exceeded.
-  public class Buffer<X> (initCapacity : Nat) {
+  public class Buffer<X>(initCapacity : Nat) {
     var count : Nat = 0;
     var elems : [var X] = [var]; // initially empty; allocated upon first `add`
 
@@ -69,8 +69,8 @@ module {
       let i = b.vals();
       loop {
         switch (i.next()) {
-        case null return;
-        case (?x) { add(x) };
+          case null return;
+          case (?x) { add(x) };
         };
       };
     };
@@ -112,7 +112,7 @@ module {
       // immutable clone of array
       Prim.Array_tabulate<X>(
         count,
-        func(x: Nat): X { elems[x] }
+        func(x : Nat) : X { elems[x] }
       );
 
     /// Creates a mutable array containing this buffer's elements.

--- a/src/Buffer.mo
+++ b/src/Buffer.mo
@@ -34,20 +34,20 @@ module {
     /// Adds a single element to the buffer.
     public func add(elem : X) {
       if (count == elems.size()) {
-	let size =
-	  if (count == 0) {
-	    if (initCapacity > 0) { initCapacity } else { 1 }
-	  } else {
-	    2 * elems.size()
-	  };
-	let elems2 = Prim.Array_init<X>(size, elem);
-	var i = 0;
-	label l loop {
-	  if (i >= count) break l;
-	  elems2[i] := elems[i];
-	  i += 1;
-	};
-	elems := elems2;
+        let size =
+          if (count == 0) {
+            if (initCapacity > 0) { initCapacity } else { 1 }
+          } else {
+            2 * elems.size()
+          };
+        let elems2 = Prim.Array_init<X>(size, elem);
+        var i = 0;
+        label l loop {
+          if (i >= count) break l;
+          elems2[i] := elems[i];
+          i += 1;
+        };
+        elems := elems2;
       };
       elems[count] := elem;
       count += 1;
@@ -57,10 +57,10 @@ module {
     /// elements had been added to the Buffer.
     public func removeLast() : ?X {
       if (count == 0) {
-	null
+        null
       } else {
-	count -= 1;
-	?elems[count]
+        count -= 1;
+        ?elems[count]
       };
     };
 
@@ -68,10 +68,10 @@ module {
     public func append(b : Buffer<X>) {
       let i = b.vals();
       loop {
-	switch (i.next()) {
-	case null return;
-	case (?x) { add(x) };
-	};
+        switch (i.next()) {
+        case null return;
+        case (?x) { add(x) };
+        };
       };
     };
 
@@ -88,9 +88,9 @@ module {
       let c = Buffer<X>(elems.size());
       var i = 0;
       label l loop {
-	if (i >= count) break l;
-	c.add(elems[i]);
-	i += 1;
+        if (i >= count) break l;
+        c.add(elems[i]);
+        i += 1;
       };
       c
     };
@@ -99,11 +99,11 @@ module {
     public func vals() : { next : () -> ?X } = object {
       var pos = 0;
       public func next() : ?X {
-	if (pos == count) { null } else {
-	  let elem = ?elems[pos];
-	  pos += 1;
-	  elem
-	}
+        if (pos == count) { null } else {
+          let elem = ?elems[pos];
+          pos += 1;
+          elem
+        }
       }
     };
 
@@ -111,21 +111,21 @@ module {
     public func toArray() : [X] =
       // immutable clone of array
       Prim.Array_tabulate<X>(
-	count,
-	func(x: Nat): X { elems[x] }
+        count,
+        func(x: Nat): X { elems[x] }
       );
 
     /// Creates a mutable array containing this buffer's elements.
     public func toVarArray() : [var X] {
       if (count == 0) { [var] } else {
-	let a = Prim.Array_init<X>(count, elems[0]);
-	var i = 0;
-	label l loop {
-	  if (i >= count) break l;
-	  a[i] := elems[i];
-	  i += 1;
-	};
-	a
+        let a = Prim.Array_init<X>(count, elems[0]);
+        var i = 0;
+        label l loop {
+          if (i >= count) break l;
+          a[i] := elems[i];
+          i += 1;
+        };
+        a
       }
     };
 
@@ -138,10 +138,10 @@ module {
     /// Gets the `i`-th element of the buffer as an option. Returns `null` when `i >= count`. Indexing is zero-based.
     public func getOpt(i : Nat) : ?X {
       if (i < count) {
-	?elems[i]
+        ?elems[i]
       }
       else {
-	null
+        null
       }
     };
 

--- a/src/CertifiedData.mo
+++ b/src/CertifiedData.mo
@@ -1,17 +1,13 @@
-/**
+/// Certified data.
+///
+/// The Internet Computer allows canisters to store a small amount of data during
+/// update method processing so that during query call processing, the canister can obtain
+/// a certificate about that data.
 
-Certified data
-
-The Internet Computer allows canisters to store a small amount of data during
-update method processing so that during query call processing, the canister can obtain
-a certificate about that data.
-
-This module provides a _low-level_ interface to this API, aimed at advanced
-users and library implementors. See the Internet Computer Functional
-Specification and corresponding documentation for how to use this to make query
-calls to your canister tamperproof.
-
-*/
+/// This module provides a _low-level_ interface to this API, aimed at advanced
+/// users and library implementors. See the Internet Computer Functional
+/// Specification and corresponding documentation for how to use this to make query
+/// calls to your canister tamperproof.
 
 import Prim "mo:⛔";
 

--- a/src/CertifiedData.mo
+++ b/src/CertifiedData.mo
@@ -3,7 +3,7 @@
 /// The Internet Computer allows canisters to store a small amount of data during
 /// update method processing so that during query call processing, the canister can obtain
 /// a certificate about that data.
-
+///
 /// This module provides a _low-level_ interface to this API, aimed at advanced
 /// users and library implementors. See the Internet Computer Functional
 /// Specification and corresponding documentation for how to use this to make query

--- a/src/Char.mo
+++ b/src/Char.mo
@@ -2,6 +2,9 @@
 import Prim "mo:⛔";
 module {
 
+  /// Characters represented as Unicode code points.
+  public type Char = Prim.Types.Char;
+
   /// Convert character `c` to a word containing its Unicode scalar value.
   public let toNat32 : (c : Char) -> Nat32 = Prim.charToNat32;
 

--- a/src/Char.mo
+++ b/src/Char.mo
@@ -2,8 +2,10 @@
 import Prim "mo:⛔";
 module {
 
+/*
   /// Characters represented as Unicode code points.
   public type Char = Prim.Types.Char;
+*/
 
   /// Convert character `c` to a word containing its Unicode scalar value.
   public let toNat32 : (c : Char) -> Nat32 = Prim.charToNat32;

--- a/src/Debug.mo
+++ b/src/Debug.mo
@@ -2,8 +2,10 @@
 
 import Prim "mo:⛔";
 module {
-  /// This prints a text (which typically does not include a final newline) to the
-  /// debug output. Where this debug output is stored and shown depends on the
-  /// environment the program runs in.
+
+  /// `print(t)` emits text `t` to the debug output stream.
+  /// How this stream is stored or displayed depends on the
+  /// execution environment.
   public let print : Text -> () = Prim.debugPrint;
+
 }

--- a/src/Deque.mo
+++ b/src/Deque.mo
@@ -4,63 +4,72 @@ import List "List";
 import P "Prelude";
 
 module {
-    type List<T> = List.List<T>;
+  type List<T> = List.List<T>;
 
-    /// Double-ended queue
-    public type Deque<T> = (List<T>, List<T>);
+  /// Double-ended queue
+  public type Deque<T> = (List<T>, List<T>);
 
-    /// Empty queue
-    public func empty<T> () : Deque<T> = (List.nil(), List.nil());
+  /// Empty queue
+  public func empty<T> () : Deque<T> { (List.nil(), List.nil()); };
 
-    /// True when the queue is empty
-    public func isEmpty<T>(q : Deque<T>) : Bool {
-      switch q {
+  /// True when the queue is empty
+  public func isEmpty<T>(q : Deque<T>) : Bool {
+    switch q {
       case (f, r) { List.isNil(f) and List.isNil(r) };
-      }
-    };
-    func check<T>(q : Deque<T>) : Deque<T> {
-      switch q {
+    }
+  };
+
+  func check<T>(q : Deque<T>) : Deque<T> {
+    switch q {
       case (null, r) { let (a,b) = List.split(List.size(r) / 2, r); (List.reverse(b), a) };
       case (f, null) { let (a,b) = List.split(List.size(f) / 2, f); (a, List.reverse(b)) };
       case q { q };
-      }
-    };
-    /// Insert a new element on the front end of the queue
-    public func pushFront<T>(q : Deque<T>, x : T) : Deque<T> =
-      check (List.push(x, q.0), q.1);
-    /// Inspect the (optional) first element on the front end of the queue
-    public func peekFront<T>(q: Deque<T>) : ?T {
-      switch q {
+    }
+  };
+
+  /// Insert a new element on the front end of the queue
+  public func pushFront<T>(q : Deque<T>, x : T) : Deque<T> {
+    check (List.push(x, q.0), q.1);
+  };
+
+  /// Inspect the (optional) first element on the front end of the queue
+  public func peekFront<T>(q : Deque<T>) : ?T {
+    switch q {
       case (?(x, f), r) { ?x };
       case (null, ?(x, r)) { ?x };
       case _ { null };
-      };
     };
-    /// Remove the first element on the front end of the queue; Returns null when empty.
-    public func popFront<T>(q: Deque<T>) : ?(T, Deque<T>) {
-      switch q {
+  };
+
+  /// Remove the first element on the front end of the queue; Returns null when empty.
+  public func popFront<T>(q : Deque<T>) : ?(T, Deque<T>) {
+    switch q {
       case (?(x, f), r) { ?(x, check(f, r)) };
       case (null, ?(x, r)) { ?(x, check(null, r)) };
       case _ { null };
-      };
     };
-    /// Insert a new element on the back end of the queue
-    public func pushBack<T>(q : Deque<T>, x : T) : Deque<T> =
-      check (q.0, List.push(x, q.1));
-    /// Inspect the (optional) first element on the back end of the queue
-    public func peekBack<T>(q: Deque<T>) : ?T {
-      switch q {
+  };
+
+  /// Insert a new element on the back end of the queue
+  public func pushBack<T>(q : Deque<T>, x : T) : Deque<T> {
+    check (q.0, List.push(x, q.1));
+  };
+
+  /// Inspect the (optional) first element on the back end of the queue
+  public func peekBack<T>(q : Deque<T>) : ?T {
+    switch q {
       case (f, ?(x, r)) { ?x };
       case (?(x, r), null) { ?x };
       case _ { null };
-      };
     };
-    /// Remove the first element on the back end of the queue; Returns null when empty.
-    public func popBack<T>(q: Deque<T>) : ?(Deque<T>, T) {
-      switch q {
+  };
+
+  /// Remove the first element on the back end of the queue; Returns null when empty.
+  public func popBack<T>(q : Deque<T>) : ?(Deque<T>, T) {
+    switch q {
       case (f, ?(x, r)) { ?(check(f, r), x) };
       case (?(x, f), null) { ?(check(f, null), x) };
       case _ { null };
-      };
     };
+  };
 };

--- a/src/Error.mo
+++ b/src/Error.mo
@@ -7,8 +7,10 @@ import Prim "mo:⛔";
 
 module {
 
+/*
   /// Error values resulting from  `async` computations
   public type Error = Prim.Types.Error;
+*/
 
   /// Error codes (user and system), where module `Prim` defines:
   /// ```motoko

--- a/src/Error.mo
+++ b/src/Error.mo
@@ -7,6 +7,9 @@ import Prim "mo:⛔";
 
 module {
 
+  /// Error values resulting from  `async` computations
+  public type Error = Prim.Types.Error;
+
   /// Error codes (user and system), where module `Prim` defines:
   /// ```motoko
   /// type ErrorCode = {

--- a/src/Float.mo
+++ b/src/Float.mo
@@ -5,6 +5,9 @@ import Int "Int";
 
 module {
 
+  /// 64-bit floating point values
+  public type Float = Prim.Types.Float;
+
   /// Ratio of the circumference of a circle to its diameter.
   public let pi : Float = 3.14159265358979323846; // taken from musl math.h
 

--- a/src/Float.mo
+++ b/src/Float.mo
@@ -5,8 +5,10 @@ import Int "Int";
 
 module {
 
-  /// 64-bit floating point values
+/*
+  /// 64-bit floating point numbers.
   public type Float = Prim.Types.Float;
+*/
 
   /// Ratio of the circumference of a circle to its diameter.
   public let pi : Float = 3.14159265358979323846; // taken from musl math.h

--- a/src/Func.mo
+++ b/src/Func.mo
@@ -1,10 +1,10 @@
 /// Functions on functions
 ///
-/// The functions in this module are rather useless on their own but they're
-/// commonly used when programming in a functional style with higher-order
-/// functions.
+/// (Most commonly used when programming in functional style using higher-order
+/// functions.)
 
 module {
+
   /// The composition of two functions `f` and `g` is a function that applies `g` and then `f`.
   ///
   /// ```

--- a/src/Hash.mo
+++ b/src/Hash.mo
@@ -4,6 +4,7 @@ import Prim "mo:⛔";
 import Iter "Iter";
 
 module {
+
   /// Hash values represent a string of _hash bits_, packed into a `Nat32`.
   public type Hash = Nat32;
 

--- a/src/HashMap.mo
+++ b/src/HashMap.mo
@@ -22,7 +22,7 @@ module {
 
 
   // key-val list type
-  type KVs<K,V> = AssocList.AssocList<K, V>;
+  type KVs<K, V> = AssocList.AssocList<K, V>;
 
   /// An imperative HashMap with a minimal object-oriented interface.
   /// Maps keys of type `K` to values of type `V`.
@@ -66,7 +66,7 @@ module {
       let h = Prim.nat32ToNat(keyHash(k));
       let m = table.size();
       let v = if (m > 0) {
-        AssocList.find<K,V>(table[h % m], k, keyEq)
+        AssocList.find<K, V>(table[h % m], k, keyEq)
       } else {
         null
       };
@@ -109,7 +109,7 @@ module {
       };
       let h = Prim.nat32ToNat(keyHash(k));
       let pos = h % table.size();
-      let (kvs2, ov) = AssocList.replace<K,V>(table[pos], k, keyEq, ?v);
+      let (kvs2, ov) = AssocList.replace<K, V>(table[pos], k, keyEq, ?v);
       table[pos] := kvs2;
       switch(ov){
         case null { _count += 1 };
@@ -120,15 +120,15 @@ module {
 
     /// Returns an iterator over the key value pairs in this
     /// `HashMap`. Does _not_ modify the `HashMap`.
-    public func entries() : Iter.Iter<(K,V)> {
+    public func entries() : Iter.Iter<(K, V)> {
       if (table.size() == 0) {
-        object { public func next() : ?(K,V) { null } }
+        object { public func next() : ?(K, V) { null } }
       }
       else {
         object {
           var kvs = table[0];
           var nextTablePos = 1;
-          public func next () : ?(K,V) {
+          public func next () : ?(K, V) {
             switch kvs {
               case (?(kv, kvs2)) {
                 kvs := kvs2;
@@ -153,11 +153,12 @@ module {
 
   /// clone cannot be an efficient object method,
   /// ...but is still useful in tests, and beyond.
-  public func clone<K,V>
-    (h : HashMap<K,V>,
-     keyEq : (K,K) -> Bool,
-     keyHash : K -> Hash.Hash) : HashMap<K,V> {
-    let h2 = HashMap<K,V>(h.size(), keyEq, keyHash);
+  public func clone<K, V> (
+    h : HashMap<K, V>,
+    keyEq : (K, K) -> Bool,
+    keyHash : K -> Hash.Hash
+  ) : HashMap<K, V> {
+    let h2 = HashMap<K, V>(h.size(), keyEq, keyHash);
     for ((k,v) in h.entries()) {
       h2.put(k,v);
     };
@@ -165,24 +166,26 @@ module {
   };
 
   /// Clone from any iterator of key-value pairs
-  public func fromIter<K, V>(iter : Iter.Iter<(K, V)>,
-                             initCapacity : Nat,
-                             keyEq : (K,K) -> Bool,
-                             keyHash : K -> Hash.Hash) : HashMap<K,V> {
-    let h = HashMap<K,V>(initCapacity, keyEq, keyHash);
+  public func fromIter<K, V>(
+    iter : Iter.Iter<(K, V)>,
+    initCapacity : Nat,
+    keyEq : (K, K) -> Bool,
+    keyHash : K -> Hash.Hash
+  ) : HashMap<K, V> {
+    let h = HashMap<K, V>(initCapacity, keyEq, keyHash);
     for ((k,v) in iter) {
       h.put(k,v);
     };
     h
   };
 
-  public func map<K, V1, V2>
-    (h : HashMap<K,V1>,
-     keyEq : (K,K) -> Bool,
-     keyHash : K -> Hash.Hash,
-     mapFn : (K, V1) -> V2,
-    ) : HashMap<K,V2> {
-    let h2 = HashMap<K,V2>(h.size(), keyEq, keyHash);
+  public func map<K, V1, V2>(
+    h : HashMap<K, V1>,
+    keyEq : (K, K) -> Bool,
+    keyHash : K -> Hash.Hash,
+    mapFn : (K, V1) -> V2,
+  ) : HashMap<K, V2> {
+    let h2 = HashMap<K, V2>(h.size(), keyEq, keyHash);
     for ((k, v1) in h.entries()) {
       let v2 = mapFn(k, v1);
       h2.put(k,v2);
@@ -190,13 +193,13 @@ module {
     h2
   };
 
-  public func mapFilter<K, V1, V2>
-    (h : HashMap<K,V1>,
-     keyEq : (K,K) -> Bool,
-     keyHash : K -> Hash.Hash,
-     mapFn : (K, V1) -> ?V2,
-    ) : HashMap<K,V2> {
-    let h2 = HashMap<K,V2>(h.size(), keyEq, keyHash);
+  public func mapFilter<K, V1, V2>(
+    h : HashMap<K, V1>,
+    keyEq : (K, K) -> Bool,
+    keyHash : K -> Hash.Hash,
+    mapFn : (K, V1) -> ?V2,
+  ) : HashMap<K, V2> {
+    let h2 = HashMap<K, V2>(h.size(), keyEq, keyHash);
     for ((k, v1) in h.entries()) {
       switch (mapFn(k, v1)) {
         case null { };

--- a/src/HashMap.mo
+++ b/src/HashMap.mo
@@ -26,7 +26,7 @@ module {
 
   /// An imperative HashMap with a minimal object-oriented interface.
   /// Maps keys of type `K` to values of type `V`.
-  public class HashMap<K, V> (
+  public class HashMap<K, V>(
     initCapacity : Nat,
     keyEq : (K, K) -> Bool,
     keyHash : K -> Hash.Hash) {
@@ -51,8 +51,8 @@ module {
         let (kvs2, ov) = AssocList.replace<K, V>(table[pos], k, keyEq, null);
         table[pos] := kvs2;
         switch(ov){
-        case null { };
-        case _ { _count -= 1; }
+          case null { };
+          case _ { _count -= 1; }
         };
         ov
       } else {
@@ -173,8 +173,8 @@ module {
     keyHash : K -> Hash.Hash
   ) : HashMap<K, V> {
     let h = HashMap<K, V>(initCapacity, keyEq, keyHash);
-    for ((k,v) in iter) {
-      h.put(k,v);
+    for ((k, v) in iter) {
+      h.put(k, v);
     };
     h
   };
@@ -188,7 +188,7 @@ module {
     let h2 = HashMap<K, V2>(h.size(), keyEq, keyHash);
     for ((k, v1) in h.entries()) {
       let v2 = mapFn(k, v1);
-      h2.put(k,v2);
+      h2.put(k, v2);
     };
     h2
   };
@@ -204,7 +204,7 @@ module {
       switch (mapFn(k, v1)) {
         case null { };
         case (?v2) {
-          h2.put(k,v2);
+          h2.put(k, v2);
         };
       }
     };

--- a/src/HashMap.mo
+++ b/src/HashMap.mo
@@ -2,15 +2,14 @@
 ///
 /// This module defines an imperative hash map (hash table), with a general key and value type.
 ///
-/// It has a minimal object-oriented interface: get, set, swap, delete, count and entries.
+/// It has a minimal object-oriented interface: `get`, `set`, `delete`, `count` and `entries`.
 ///
 /// The class is parameterized by the key's equality and hash functions,
-/// and an initial capacity.  However, as with `Buf`, no array allocation
-/// happens until the first `set` (or `swap`).
+/// and an initial capacity.  However, as with the `Buffer` class, no array allocation
+/// happens until the first `set`.
 ///
 /// Internally, table growth policy is very simple, for now:
-///   Double an initial capacity when the expected
-///   bucket list beyond a certain constant.
+///  Double the current capacity when the expected bucket list size grows beyond a certain constant.
 
 import Prim "mo:⛔";
 import P "Prelude";
@@ -22,190 +21,191 @@ import AssocList "AssocList";
 module {
 
 
-// key-val list type
-type KVs<K,V> = AssocList.AssocList<K,V>;
+  // key-val list type
+  type KVs<K,V> = AssocList.AssocList<K, V>;
 
-/// An imperative HashMap with a minimal object-oriented interface.
-/// Maps keys of type `K` to values of type `V`.
-public class HashMap<K,V> (
-  initCapacity: Nat,
-  keyEq: (K,K) -> Bool,
-  keyHash: K -> Hash.Hash) {
+  /// An imperative HashMap with a minimal object-oriented interface.
+  /// Maps keys of type `K` to values of type `V`.
+  public class HashMap<K, V> (
+    initCapacity : Nat,
+    keyEq : (K, K) -> Bool,
+    keyHash : K -> Hash.Hash) {
 
-  var table : [var KVs<K,V>] = [var];
-  var _count : Nat = 0;
+    var table : [var KVs<K, V>] = [var];
+    var _count : Nat = 0;
 
-  /// Returns the number of entries in this HashMap.
-  public func size() : Nat = _count;
+    /// Returns the number of entries in this HashMap.
+    public func size() : Nat = _count;
 
-  /// Deletes the entry with the key `k`. Doesn't do anything if the key doesn't
-  /// exist.
-  public func delete(k : K) = ignore remove(k);
+    /// Deletes the entry with the key `k`. Doesn't do anything if the key doesn't
+    /// exist.
+    public func delete(k : K) = ignore remove(k);
 
-  /// Removes the entry with the key `k` and returns the associated value if it
-  /// existed or `null` otherwise.
-  public func remove(k : K) : ?V {
-    let m = table.size();
-    if (m > 0) {
+    /// Removes the entry with the key `k` and returns the associated value if it
+    /// existed or `null` otherwise.
+    public func remove(k : K) : ?V {
+      let m = table.size();
+      if (m > 0) {
+        let h = Prim.nat32ToNat(keyHash(k));
+        let pos = h % m;
+        let (kvs2, ov) = AssocList.replace<K, V>(table[pos], k, keyEq, null);
+        table[pos] := kvs2;
+        switch(ov){
+        case null { };
+        case _ { _count -= 1; }
+        };
+        ov
+      } else {
+        null
+      };
+    };
+
+    /// Gets the entry with the key `k` and returns its associated value if it
+    /// existed or `null` otherwise.
+    public func get(k : K) : ?V {
       let h = Prim.nat32ToNat(keyHash(k));
-      let pos = h % m;
-      let (kvs2, ov) = AssocList.replace<K, V>(table[pos], k, keyEq, null);
+      let m = table.size();
+      let v = if (m > 0) {
+        AssocList.find<K,V>(table[h % m], k, keyEq)
+      } else {
+        null
+      };
+    };
+
+    /// Insert the value `v` at key `k`. Overwrites an existing entry with key `k`
+    public func put(k : K, v : V) = ignore replace(k, v);
+
+    /// Insert the value `v` at key `k` and returns the previous value stored at
+    /// `k` or `null` if it didn't exist.
+    public func replace(k : K, v : V) : ?V {
+      if (_count >= table.size()) {
+        let size =
+          if (_count == 0) {
+            if (initCapacity > 0) {
+              initCapacity
+            } else {
+              1
+            }
+          } else {
+            table.size() * 2;
+          };
+        let table2 = A.init<KVs<K, V>>(size, null);
+        for (i in table.keys()) {
+          var kvs = table[i];
+          label moveKeyVals : ()
+          loop {
+            switch kvs {
+              case null { break moveKeyVals };
+              case (?((k, v), kvsTail)) {
+                let h = Prim.nat32ToNat(keyHash(k));
+                let pos2 = h % table2.size();
+                table2[pos2] := ?((k,v), table2[pos2]);
+                kvs := kvsTail;
+              };
+            }
+          };
+        };
+        table := table2;
+      };
+      let h = Prim.nat32ToNat(keyHash(k));
+      let pos = h % table.size();
+      let (kvs2, ov) = AssocList.replace<K,V>(table[pos], k, keyEq, ?v);
       table[pos] := kvs2;
       switch(ov){
-      case null { };
-      case _ { _count -= 1; }
+        case null { _count += 1 };
+        case _ {}
       };
       ov
-    } else {
-      null
     };
+
+    /// Returns an iterator over the key value pairs in this
+    /// `HashMap`. Does _not_ modify the `HashMap`.
+    public func entries() : Iter.Iter<(K,V)> {
+      if (table.size() == 0) {
+        object { public func next() : ?(K,V) { null } }
+      }
+      else {
+        object {
+          var kvs = table[0];
+          var nextTablePos = 1;
+          public func next () : ?(K,V) {
+            switch kvs {
+              case (?(kv, kvs2)) {
+                kvs := kvs2;
+                ?kv
+              };
+              case null {
+                if (nextTablePos < table.size()) {
+                  kvs := table[nextTablePos];
+                  nextTablePos += 1;
+                  next()
+                } else {
+                  null
+                }
+              }
+            }
+          }
+        }
+      }
+    };
+
   };
 
-  /// Gets the entry with the key `k` and returns its associated value if it
-  /// existed or `null` otherwise.
-  public func get(k:K) : ?V {
-    let h = Prim.nat32ToNat(keyHash(k));
-    let m = table.size();
-    let v = if (m > 0) {
-      AssocList.find<K,V>(table[h % m], k, keyEq)
-    } else {
-      null
+  /// clone cannot be an efficient object method,
+  /// ...but is still useful in tests, and beyond.
+  public func clone<K,V>
+    (h : HashMap<K,V>,
+     keyEq : (K,K) -> Bool,
+     keyHash : K -> Hash.Hash) : HashMap<K,V> {
+    let h2 = HashMap<K,V>(h.size(), keyEq, keyHash);
+    for ((k,v) in h.entries()) {
+      h2.put(k,v);
     };
+    h2
   };
 
-  /// Insert the value `v` at key `k`. Overwrites an existing entry with key `k`
-  public func put(k : K, v : V) = ignore replace(k, v);
-
-  /// Insert the value `v` at key `k` and returns the previous value stored at
-  /// `k` or null if it didn't exist.
-  public func replace(k:K, v:V) : ?V {
-    if (_count >= table.size()) {
-      let size =
-        if (_count == 0) {
-          if (initCapacity > 0) {
-            initCapacity
-          } else {
-            1
-          }
-        } else {
-          table.size() * 2;
-        };
-      let table2 = A.init<KVs<K,V>>(size, null);
-      for (i in table.keys()) {
-        var kvs = table[i];
-        label moveKeyVals : ()
-        loop {
-          switch kvs {
-          case null { break moveKeyVals };
-          case (?((k, v), kvsTail)) {
-                 let h = Prim.nat32ToNat(keyHash(k));
-                 let pos2 = h % table2.size();
-                 table2[pos2] := ?((k,v), table2[pos2]);
-                 kvs := kvsTail;
-               };
-          }
-        };
-      };
-      table := table2;
+  /// Clone from any iterator of key-value pairs
+  public func fromIter<K, V>(iter : Iter.Iter<(K, V)>,
+                             initCapacity : Nat,
+                             keyEq : (K,K) -> Bool,
+                             keyHash : K -> Hash.Hash) : HashMap<K,V> {
+    let h = HashMap<K,V>(initCapacity, keyEq, keyHash);
+    for ((k,v) in iter) {
+      h.put(k,v);
     };
-    let h = Prim.nat32ToNat(keyHash(k));
-    let pos = h % table.size();
-    let (kvs2, ov) = AssocList.replace<K,V>(table[pos], k, keyEq, ?v);
-    table[pos] := kvs2;
-    switch(ov){
-    case null { _count += 1 };
-    case _ {}
-    };
-    ov
+    h
   };
 
-  /// Returns an iterator over the key value pairs in this
-  /// HashMap. Does _not_ modify the HashMap.
-  public func entries() : Iter.Iter<(K,V)> {
-    if (table.size() == 0) {
-      object { public func next() : ?(K,V) { null } }
-    }
-    else {
-      object {
-        var kvs = table[0];
-        var nextTablePos = 1;
-        public func next () : ?(K,V) {
-          switch kvs {
-          case (?(kv, kvs2)) {
-                 kvs := kvs2;
-                 ?kv
-               };
-          case null {
-                 if (nextTablePos < table.size()) {
-                   kvs := table[nextTablePos];
-                   nextTablePos += 1;
-                   next()
-                 } else {
-                   null
-                 }
-               }
-          }
+  public func map<K, V1, V2>
+    (h : HashMap<K,V1>,
+     keyEq : (K,K) -> Bool,
+     keyHash : K -> Hash.Hash,
+     mapFn : (K, V1) -> V2,
+    ) : HashMap<K,V2> {
+    let h2 = HashMap<K,V2>(h.size(), keyEq, keyHash);
+    for ((k, v1) in h.entries()) {
+      let v2 = mapFn(k, v1);
+      h2.put(k,v2);
+    };
+    h2
+  };
+
+  public func mapFilter<K, V1, V2>
+    (h : HashMap<K,V1>,
+     keyEq : (K,K) -> Bool,
+     keyHash : K -> Hash.Hash,
+     mapFn : (K, V1) -> ?V2,
+    ) : HashMap<K,V2> {
+    let h2 = HashMap<K,V2>(h.size(), keyEq, keyHash);
+    for ((k, v1) in h.entries()) {
+      switch (mapFn(k, v1)) {
+        case null { };
+        case (?v2) {
+          h2.put(k,v2);
         };
       }
-    }
+    };
+    h2
   };
-};
-
-/// clone cannot be an efficient object method,
-/// ...but is still useful in tests, and beyond.
-public func clone<K,V>
-  (h:HashMap<K,V>,
-   keyEq: (K,K) -> Bool,
-   keyHash: K -> Hash.Hash) : HashMap<K,V> {
-  let h2 = HashMap<K,V>(h.size(), keyEq, keyHash);
-  for ((k,v) in h.entries()) {
-    h2.put(k,v);
-  };
-  h2
-};
-
-/// Clone from any iterator of key-value pairs
-public func fromIter<K, V>(iter:Iter.Iter<(K, V)>,
-                           initCapacity: Nat,
-                           keyEq: (K,K) -> Bool,
-                           keyHash: K -> Hash.Hash) : HashMap<K,V> {
-  let h = HashMap<K,V>(initCapacity, keyEq, keyHash);
-  for ((k,v) in iter) {
-    h.put(k,v);
-  };
-  h
-};
-
-public func map<K, V1, V2>
-  (h:HashMap<K,V1>,
-   keyEq: (K,K) -> Bool,
-   keyHash: K -> Hash.Hash,
-   mapFn: (K, V1) -> V2,
-  ) : HashMap<K,V2> {
-  let h2 = HashMap<K,V2>(h.size(), keyEq, keyHash);
-  for ((k, v1) in h.entries()) {
-    let v2 = mapFn(k, v1);
-    h2.put(k,v2);
-  };
-  h2
-};
-
-public func mapFilter<K, V1, V2>
-  (h:HashMap<K,V1>,
-   keyEq: (K,K) -> Bool,
-   keyHash: K -> Hash.Hash,
-   mapFn: (K, V1) -> ?V2,
-  ) : HashMap<K,V2> {
-  let h2 = HashMap<K,V2>(h.size(), keyEq, keyHash);
-  for ((k, v1) in h.entries()) {
-    switch (mapFn(k, v1)) {
-      case null { };
-      case (?v2) {
-             h2.put(k,v2);
-           };
-    }
-  };
-  h2
-};
 
 }

--- a/src/Heap.mo
+++ b/src/Heap.mo
@@ -9,106 +9,105 @@ import I "Iter";
 
 module {
 
-public type Tree<T> = ?(Int, T, Tree<T>, Tree<T>);
+  public type Tree<T> = ?(Int, T, Tree<T>, Tree<T>);
 
-public class Heap<T>(ord : (T, T) -> O.Order) {
+  public class Heap<T>(ord : (T, T) -> O.Order) {
     var heap : Tree<T> = null;
 
     /// Get purely-functional representation
     public func share() : Tree<T> {
-        heap
+      heap
     };
 
     /// Put purely-functional representation into class. Need to make sure the tree is constructed with the same compare function
-    public func unsafeUnshare(t: Tree<T>) {
-        heap := t;
+    public func unsafeUnshare(t : Tree<T>) {
+      heap := t;
     };
 
     /// Insert an element to the heap
     public func put(x : T) {
-        heap := merge(heap, ?(1, x, null, null), ord);
+      heap := merge(heap, ?(1, x, null, null), ord);
     };
 
     /// Return the minimal element
     public func peekMin() : ?T {
-        switch heap {
+      switch heap {
         case (null) { null };
         case (?(_, x, _, _)) { ?x };
-        }
+      }
     };
 
     /// Delete the minimal element
     public func deleteMin() {
-        switch heap {
+      switch heap {
         case null {};
         case (?(_, _, a, b)) { heap := merge(a, b, ord) };
-        }
+      }
     };
 
     /// Remove the minimal element and return its value
     public func removeMin() : ?T {
-        switch heap {
+      switch heap {
         case null { null };
         case (?(_, x, a, b)) {
-                 heap := merge(a, b, ord);
-                 ?x
-             };
-        }
+          heap := merge(a, b, ord);
+          ?x
+        };
+      }
     };
-};
+  };
 
-func rank<T>(heap : Tree<T>) : Int {
+  func rank<T>(heap : Tree<T>) : Int {
     switch heap {
-    case null { 0 };
-    case (?(r, _, _, _)) { r };
+      case null { 0 };
+      case (?(r, _, _, _)) { r };
     }
-};
+  };
 
-func makeT<T>(x : T, a : Tree<T>, b : Tree<T>) : Tree<T> {
+  func makeT<T>(x : T, a : Tree<T>, b : Tree<T>) : Tree<T> {
     if (rank(a) >= rank(b)) {
         ?(rank(b) + 1, x, a, b)
     } else {
         ?(rank(a) + 1, x, b, a)
     };
-};
+  };
 
-func merge<T>(h1 : Tree<T>, h2 : Tree<T>, ord: (T, T) -> O.Order) : Tree<T> {
+  func merge<T>(h1 : Tree<T>, h2 : Tree<T>, ord : (T, T) -> O.Order) : Tree<T> {
     switch (h1, h2) {
-    case (null, h) { h };
-    case (h, null) { h };
-    case (?(_, x, a, b), ?(_, y, c, d)) {
-             switch (ord(x,y)) {
-             case (#less) { makeT(x, a, merge(b, h2, ord)) };
-             case _ { makeT(y, c, merge(d, h1, ord)) };
-             };
-         };
-    
+      case (null, h) { h };
+      case (h, null) { h };
+      case (?(_, x, a, b), ?(_, y, c, d)) {
+        switch (ord(x,y)) {
+          case (#less) { makeT(x, a, merge(b, h2, ord)) };
+          case _ { makeT(y, c, merge(d, h1, ord)) };
+        };
+      };
     };
-};
+  };
 
-/// Convert iterator into a heap, takes O(N) time.
-public func fromIter<T>(iter: I.Iter<T>, ord: (T, T) -> O.Order) : Heap<T> {
+  /// Convert iterator into a heap in O(N) time.
+  public func fromIter<T>(iter : I.Iter<T>, ord : (T, T) -> O.Order) : Heap<T> {
     let heap = Heap<T>(ord);
     func build(xs : L.List<Tree<T>>) : Tree<T> {
-        func join(xs : L.List<Tree<T>>) : L.List<Tree<T>> {
-            switch(xs) {
-            case (null) { null };
-            case (?(hd, null)) { ?(hd, null) };
-            case (?(h1, ?(h2, tl))) { ?(merge(h1, h2, ord), join(tl)) };
-            }
-        };
+      func join(xs : L.List<Tree<T>>) : L.List<Tree<T>> {
         switch(xs) {
+          case (null) { null };
+          case (?(hd, null)) { ?(hd, null) };
+          case (?(h1, ?(h2, tl))) { ?(merge(h1, h2, ord), join(tl)) };
+        }
+      };
+      switch(xs) {
         case null { P.unreachable() };
         case (?(hd, null)) { hd };
         case _ { build(join(xs)) };
-        };
+      };
     };
-    let list = I.toList(I.map(iter, func (x : T) : Tree<T> = ?(1, x, null, null)));
+    let list = I.toList(I.map(iter, func (x : T) : Tree<T> { ?(1, x, null, null) } ));
     if (not L.isNil(list)) {
-        let t = build(list);
-        heap.unsafeUnshare(t);
+      let t = build(list);
+      heap.unsafeUnshare(t);
     };
     heap
-};
+  };
 
 };

--- a/src/Int.mo
+++ b/src/Int.mo
@@ -8,9 +8,14 @@ import Prelude "Prelude";
 import Hash "Hash";
 
 module {
+
+  /// Infinite precision signed integers.
+  public type Int = Prim.Types.Int;
+
   /// Returns the absolute value of the number
   public let abs : Int -> Nat = Prim.abs;
 
+  /// Conversion.
   public let toText : Int -> Text = func(x) {
     if (x == 0) {
       return "0";

--- a/src/Int.mo
+++ b/src/Int.mo
@@ -9,8 +9,10 @@ import Hash "Hash";
 
 module {
 
+/*
   /// Infinite precision signed integers.
   public type Int = Prim.Types.Int;
+*/
 
   /// Returns the absolute value of the number
   public let abs : Int -> Nat = Prim.abs;

--- a/src/Int16.mo
+++ b/src/Int16.mo
@@ -6,8 +6,10 @@ import Prim "mo:⛔";
 
 module {
 
+/*
   /// 16-bit signed integers
   public type Int16 = Prim.Types.Int16;
+*/
 
   /// Conversion.
   public let toInt : Int16 -> Int = Prim.int16ToInt;

--- a/src/Int16.mo
+++ b/src/Int16.mo
@@ -6,6 +6,9 @@ import Prim "mo:⛔";
 
 module {
 
+  /// 16-bit signed integers
+  public type Int16 = Prim.Types.Int16;
+
   /// Conversion.
   public let toInt : Int16 -> Int = Prim.int16ToInt;
 

--- a/src/Int32.mo
+++ b/src/Int32.mo
@@ -6,6 +6,9 @@ import Prim "mo:⛔";
 
 module {
 
+  /// 32-bit signed integers
+  public type Int32 = Prim.Types.Int32;
+
   /// Conversion.
   public let toInt : Int32 -> Int = Prim.int32ToInt;
 

--- a/src/Int32.mo
+++ b/src/Int32.mo
@@ -6,8 +6,10 @@ import Prim "mo:⛔";
 
 module {
 
-  /// 32-bit signed integers
+/*
+  /// 32-bit signed integers.
   public type Int32 = Prim.Types.Int32;
+*/
 
   /// Conversion.
   public let toInt : Int32 -> Int = Prim.int32ToInt;

--- a/src/Int64.mo
+++ b/src/Int64.mo
@@ -6,6 +6,9 @@ import Prim "mo:⛔";
 
 module {
 
+  /// 64-bit signed integers
+  public type Int64 = Prim.Types.Int64;
+
   /// Conversion.
   public let toInt : Int64 -> Int = Prim.int64ToInt;
 

--- a/src/Int64.mo
+++ b/src/Int64.mo
@@ -6,8 +6,10 @@ import Prim "mo:⛔";
 
 module {
 
-  /// 64-bit signed integers
+/*
+  /// 64-bit signed integers.
   public type Int64 = Prim.Types.Int64;
+*/
 
   /// Conversion.
   public let toInt : Int64 -> Int = Prim.int64ToInt;

--- a/src/Int8.mo
+++ b/src/Int8.mo
@@ -6,6 +6,9 @@ import Prim "mo:⛔";
 
 module {
 
+  /// 8-bit signed integers
+  public type Int8 = Prim.Types.Int8;
+
   /// Conversion.
   public let toInt : Int8 -> Int = Prim.int8ToInt;
 

--- a/src/Int8.mo
+++ b/src/Int8.mo
@@ -6,8 +6,10 @@ import Prim "mo:⛔";
 
 module {
 
-  /// 8-bit signed integers
+/*
+  /// 8-bit signed integers.
   public type Int8 = Prim.Types.Int8;
+*/
 
   /// Conversion.
   public let toInt : Int8 -> Int = Prim.int8ToInt;

--- a/src/Iter.mo
+++ b/src/Iter.mo
@@ -5,6 +5,7 @@ import Buffer "Buffer";
 import List "List";
 
 module {
+
   /// An iterator that produces values of type `T`. Calling `next` returns
   /// `null` when iteration is finished.
   ///

--- a/src/IterType.mo
+++ b/src/IterType.mo
@@ -3,5 +3,5 @@
 // Just here to break cyclic module definitions
 
 module {
-  public type Iter<T> = {next : () -> ?T};
+  public type Iter<T> = { next : () -> ?T };
 }

--- a/src/List.mo
+++ b/src/List.mo
@@ -31,8 +31,8 @@ module {
   public func last<T>(l : List<T>) : ?T {
     switch l {
       case null { null };
-      case (?(x,null)) { ?x };
-      case (?(_,t)) { last<T>(t) };
+      case (?(x, null)) { ?x };
+      case (?(_, t)) { last<T>(t) };
     }
   };
 
@@ -50,7 +50,7 @@ module {
     func rec(l : List<T>, n : Nat) : Nat {
       switch l {
         case null { n };
-        case (?(_,t)) { rec(t,n+1) };
+        case (?(_, t)) { rec(t, n + 1) };
       }
     };
     rec(l,0)
@@ -63,8 +63,8 @@ module {
   public func get<T>(l : List<T>, n : Nat) : ?T {
     switch (n, l) {
       case (_, null) { null };
-      case (0, (?(h,t))) { ?h };
-      case (_, (?(_,t))) { get<T>(t, n - 1) };
+      case (0, (?(h, t))) { ?h };
+      case (_, (?(_, t))) { get<T>(t, n - 1) };
     }
   };
 
@@ -73,7 +73,7 @@ module {
     func rec(l : List<T>, r : List<T>) : List<T> {
       switch l {
         case null { r };
-        case (?(h,t)) { rec(t,?(h,r)) };
+        case (?(h, t)) { rec(t,?(h, r)) };
       }
     };
     rec(l, null)
@@ -86,16 +86,16 @@ module {
   public func iterate<T>(l : List<T>, f : T -> ()) {
     switch l {
       case null { () };
-      case (?(h,t)) { f(h) ; iterate<T>(t, f) };
+      case (?(h, t)) { f(h); iterate<T>(t, f) };
     }
   };
 
   /// Call the given function on each list element and collect the results
   /// in a new list.
-  public func map<T,S>(l : List<T>, f : T -> S) : List<S> {
+  public func map<T, S>(l : List<T>, f : T -> S) : List<S> {
     switch l {
       case null { null };
-      case (?(h,t)) { ?(f(h),map<T,S>(t,f)) };
+      case (?(h, t)) { ?(f(h), map<T, S>(t, f)) };
     }
   };
 
@@ -188,7 +188,7 @@ module {
   public func take<T>(l : List<T>, n:Nat) : List<T> {
     switch (l, n) {
       case (_, 0) { null };
-      case (null,_) { null };
+      case (null, _) { null };
       case (?(h, t), m) {?(h, take<T>(t, m - 1))};
     }
   };
@@ -196,8 +196,8 @@ module {
   /// Drop the first `n` elements from the given list.
   public func drop<T>(l : List<T>, n:Nat) : List<T> {
     switch (l, n) {
-      case (l_,     0) { l_ };
-      case (null,   _) { null };
+      case (l_, 0) { l_ };
+      case (null, _) { null };
       case ((?(h, t)), m) { drop<T>(t, m - 1) };
     }
   };
@@ -211,7 +211,7 @@ module {
   };
 
   /// Fold the list right-to-left using the given function (`f`).
-  public func foldRight<T,S>(l : List<T>, a : S, f : (T, S) -> S) : S {
+  public func foldRight<T, S>(l : List<T>, a : S, f : (T, S) -> S) : S {
     switch l {
       case null { a };
       case (?(h, t)) { f(h, foldRight<T,S>(t, a, f)) };
@@ -287,7 +287,7 @@ module {
     switch (l1, l2) {
       case (null, null) { true };
       case (null, _) { false };
-      case (_,    null) { false };
+      case (_, null) { false };
       case (?(h1, t1), ?(h2, t2)) { eq(h1, h2) and equal<T>(t1, t2, eq) };
     }
   };

--- a/src/List.mo
+++ b/src/List.mo
@@ -17,11 +17,11 @@ module {
 
   /// Check whether a list is empty and return true if the list is empty.
   public func isNil<T>(l : List<T>) : Bool {
-      switch l {
+    switch l {
       case null { true  };
-      case _    { false };
-      }
-    };
+      case _ { false };
+    }
+  };
 
   /// Construct a list by pre-pending a value.
   /// This function is similar to a `list.cons(item)` function.
@@ -30,9 +30,9 @@ module {
   /// Return the last element of the list, if present.
   public func last<T>(l : List<T>) : ?T {
     switch l {
-    case null        { null };
-    case (?(x,null)) { ?x };
-    case (?(_,t))    { last<T>(t) };
+      case null { null };
+      case (?(x,null)) { ?x };
+      case (?(_,t)) { last<T>(t) };
     }
   };
 
@@ -40,8 +40,8 @@ module {
   /// This function combines the `head` and (non-failing) `tail` operations into one operation.
   public func pop<T>(l : List<T>) : (?T, List<T>) {
     switch l {
-    case null      { (null, null) };
-    case (?(h, t)) { (?h, t) };
+      case null { (null, null) };
+      case (?(h, t)) { (?h, t) };
     }
   };
 
@@ -49,7 +49,7 @@ module {
   public func size<T>(l : List<T>) : Nat {
     func rec(l : List<T>, n : Nat) : Nat {
       switch l {
-        case null     { n };
+        case null { n };
         case (?(_,t)) { rec(t,n+1) };
       }
     };
@@ -62,9 +62,9 @@ module {
   /// to use.
   public func get<T>(l : List<T>, n : Nat) : ?T {
     switch (n, l) {
-    case (_, null)     { null };
-    case (0, (?(h,t))) { ?h };
-    case (_, (?(_,t))) { get<T>(t, n - 1) };
+      case (_, null) { null };
+      case (0, (?(h,t))) { ?h };
+      case (_, (?(_,t))) { get<T>(t, n - 1) };
     }
   };
 
@@ -72,8 +72,8 @@ module {
   public func reverse<T>(l : List<T>) : List<T> {
     func rec(l : List<T>, r : List<T>) : List<T> {
       switch l {
-            case null     { r };
-            case (?(h,t)) { rec(t,?(h,r)) };
+        case null { r };
+        case (?(h,t)) { rec(t,?(h,r)) };
       }
     };
     rec(l, null)
@@ -85,7 +85,7 @@ module {
   /// and the `iter` function in OCaml.
   public func iterate<T>(l : List<T>, f : T -> ()) {
     switch l {
-      case null     { () };
+      case null { () };
       case (?(h,t)) { f(h) ; iterate<T>(t, f) };
     }
   };
@@ -94,7 +94,7 @@ module {
   /// in a new list.
   public func map<T,S>(l : List<T>, f : T -> S) : List<S> {
     switch l {
-      case null     { null };
+      case null { null };
       case (?(h,t)) { ?(f(h),map<T,S>(t,f)) };
     }
   };
@@ -121,13 +121,13 @@ module {
   public func partition<T>(l : List<T>, f : T -> Bool) : (List<T>, List<T>) {
     switch l {
       case null { (null, null) };
-      case (?(h,t)) {
+      case (?(h, t)) {
         if (f(h)) { // call f in-order
-          let (l,r) = partition<T>(t, f);
-          (?(h,l), r)
+          let (l, r) = partition<T>(t, f);
+          (?(h, l), r)
         } else {
-          let (l,r) = partition<T>(t, f);
-          (l, ?(h,r))
+          let (l, r) = partition<T>(t, f);
+          (l, ?(h, r))
         }
       };
     };
@@ -168,8 +168,8 @@ module {
   public func append<T>(l : List<T>, m : List<T>) : List<T> {
     func rec(l : List<T>) : List<T> {
       switch l {
-      case null     { m };
-      case (?(h,t)) {?(h,rec(t))};
+        case null { m };
+        case (?(h, t)) {?(h,rec(t))};
       }
     };
     rec(l)
@@ -187,9 +187,9 @@ module {
   /// a copy of the full input list.
   public func take<T>(l : List<T>, n:Nat) : List<T> {
     switch (l, n) {
-    case (_, 0) { null };
-    case (null,_) { null };
-    case (?(h, t), m) {?(h, take<T>(t, m - 1))};
+      case (_, 0) { null };
+      case (null,_) { null };
+      case (?(h, t), m) {?(h, take<T>(t, m - 1))};
     }
   };
 
@@ -198,7 +198,7 @@ module {
     switch (l, n) {
       case (l_,     0) { l_ };
       case (null,   _) { null };
-      case ((?(h,t)), m) { drop<T>(t, m - 1) };
+      case ((?(h, t)), m) { drop<T>(t, m - 1) };
     }
   };
 
@@ -213,8 +213,8 @@ module {
   /// Fold the list right-to-left using the given function (`f`).
   public func foldRight<T,S>(l : List<T>, a : S, f : (T, S) -> S) : S {
     switch l {
-      case null     { a };
-      case (?(h,t)) { f(h, foldRight<T,S>(t, a, f)) };
+      case null { a };
+      case (?(h, t)) { f(h, foldRight<T,S>(t, a, f)) };
     };
   };
 
@@ -222,8 +222,8 @@ module {
   /// if such an element exists.
   public func find<T>(l: List<T>, f:T -> Bool) : ?T {
     switch l {
-      case null     { null };
-      case (?(h,t)) { if (f(h)) { ?h } else { find<T>(t, f) } };
+      case null { null };
+      case (?(h, t)) { if (f(h)) { ?h } else { find<T>(t, f) } };
     };
   };
 
@@ -231,17 +231,17 @@ module {
   /// the given predicate `f` is true.
   public func some<T>(l : List<T>, f : T -> Bool) : Bool {
     switch l {
-      case null     { false };
-      case (?(h,t)) { f(h) or some<T>(t, f)};
+      case null { false };
+      case (?(h, t)) { f(h) or some<T>(t, f)};
     };
   };
 
   /// Return true if the given predicate `f` is true for all list
   /// elements.
-  public func all<T>(l: List<T>, f:T -> Bool) : Bool {
+  public func all<T>(l : List<T>, f : T -> Bool) : Bool {
     switch l {
-      case null     { true };
-      case (?(h,t)) { f(h) and all<T>(t, f) };
+      case null { true };
+      case (?(h, t)) { f(h) and all<T>(t, f) };
     }
   };
 
@@ -252,8 +252,8 @@ module {
     switch (l1, l2) {
       case (null, _) { l2 };
       case (_, null) { l1 };
-      case (?(h1,t1), ?(h2,t2)) {
-        if (lte(h1,h2)) {
+      case (?(h1, t1), ?(h2, t2)) {
+        if (lte(h1, h2)) {
           ?(h1, merge<T>(t1, l2, lte))
         } else {
           ?(h2, merge<T>(l1, t2, lte))
@@ -263,40 +263,40 @@ module {
   };
 
   /// Compare two lists using lexicographic ordering specified by the given relation `lte`.
-  public func compare<T>(l1: List<T>, l2: List<T>, compElm:(T,T) -> Order.Order) : Order.Order {
+  public func compare<T>(l1 : List<T>, l2 : List<T>, compElm: (T, T) -> Order.Order) : Order.Order {
     switch (l1, l2) {
       case (null, null) { #equal };
       case (null, _) { #less };
       case (_, null) { #greater };
-      case (?(h1,t1), ?(h2,t2)) {
-             let hOrder = compElm(h1, h2);
-             if (Order.isEqual(hOrder)) {
-               compare<T>(t1, t2, compElm) 
-             } else { 
-               hOrder 
-             }
-           };
+      case (?(h1, t1), ?(h2, t2)) {
+        let hOrder = compElm(h1, h2);
+        if (Order.isEqual(hOrder)) {
+          compare<T>(t1, t2, compElm)
+        } else {
+          hOrder
+        }
+      };
     };
   };
 
   /// Compare two lists for equality as specified by the given relation `eq` on the elements.
   ///
-  /// The function `isEq(l1, l2)` is equivalent to `lessThanEq(l1,l2) && lessThanEq(l2,l1)`,
+  /// The function `isEq(l1, l2)` is equivalent to `lessThanEq(l1, l2) && lessThanEq(l2, l1)`,
   /// but the former is more efficient.
-  public func equal<T>(l1: List<T>, l2: List<T>, eq:(T,T) -> Bool) : Bool {
+  public func equal<T>(l1 : List<T>, l2 : List<T>, eq :(T, T) -> Bool) : Bool {
     switch (l1, l2) {
       case (null, null) { true };
-      case (null, _)    { false };
+      case (null, _) { false };
       case (_,    null) { false };
-      case (?(h1,t1), ?(h2,t2)) { eq(h1,h2) and equal<T>(t1, t2, eq) };
+      case (?(h1, t1), ?(h2, t2)) { eq(h1, h2) and equal<T>(t1, t2, eq) };
     }
   };
 
   /// Generate a list based on a length and a function that maps from
   /// a list index to a list element.
-  public func tabulate<T>(n:Nat, f:Nat -> T) : List<T> {
-    func rec(i:Nat, n: Nat, f : Nat -> T) : List<T> {
-      if (i == n) { null } else { ?(f(i), rec(i+1, n, f)) }
+  public func tabulate<T>(n : Nat, f : Nat -> T) : List<T> {
+    func rec(i : Nat, n : Nat, f : Nat -> T) : List<T> {
+      if (i == n) { null } else { ?(f(i), rec(i + 1, n, f)) }
     };
     rec(0, n, f)
   };

--- a/src/Nat.mo
+++ b/src/Nat.mo
@@ -9,8 +9,10 @@ import Prim "mo:⛔";
 
 module {
 
+/*
   /// Infinite precision natural numbers.
   public type Nat = Prim.Types.Nat;
+*/
 
   /// Conversion.
   public let toText : Nat -> Text = Int.toText;

--- a/src/Nat.mo
+++ b/src/Nat.mo
@@ -9,6 +9,9 @@ import Prim "mo:⛔";
 
 module {
 
+  /// Infinite precision natural numbers.
+  public type Nat = Prim.Types.Nat;
+
   /// Conversion.
   public let toText : Nat -> Text = Int.toText;
 

--- a/src/Nat16.mo
+++ b/src/Nat16.mo
@@ -6,6 +6,9 @@ import Prim "mo:⛔";
 
 module {
 
+  /// 16-bit natural numbers.
+  public type Nat16 = Prim.Types.Nat16;
+
   /// Conversion.
   public let toNat : Nat16 -> Nat = Prim.nat16ToNat;
 

--- a/src/Nat16.mo
+++ b/src/Nat16.mo
@@ -6,8 +6,10 @@ import Prim "mo:⛔";
 
 module {
 
+/*
   /// 16-bit natural numbers.
   public type Nat16 = Prim.Types.Nat16;
+*/
 
   /// Conversion.
   public let toNat : Nat16 -> Nat = Prim.nat16ToNat;

--- a/src/Nat32.mo
+++ b/src/Nat32.mo
@@ -6,6 +6,9 @@ import Prim "mo:⛔";
 
 module {
 
+  /// 32-bit natural numbers.
+  public type Nat32 = Prim.Types.Nat32;
+
   /// Conversion.
   public let toNat : Nat32 -> Nat = Prim.nat32ToNat;
 

--- a/src/Nat32.mo
+++ b/src/Nat32.mo
@@ -6,8 +6,10 @@ import Prim "mo:⛔";
 
 module {
 
+/*
   /// 32-bit natural numbers.
   public type Nat32 = Prim.Types.Nat32;
+*/
 
   /// Conversion.
   public let toNat : Nat32 -> Nat = Prim.nat32ToNat;

--- a/src/Nat64.mo
+++ b/src/Nat64.mo
@@ -6,6 +6,9 @@ import Prim "mo:⛔";
 
 module {
 
+  /// 64-bit natural numbers.
+  public type Nat64 = Prim.Types.Nat64;
+
   /// Conversion.
   public let toNat : Nat64 -> Nat = Prim.nat64ToNat;
 

--- a/src/Nat64.mo
+++ b/src/Nat64.mo
@@ -6,8 +6,10 @@ import Prim "mo:⛔";
 
 module {
 
+/*
   /// 64-bit natural numbers.
   public type Nat64 = Prim.Types.Nat64;
+*/
 
   /// Conversion.
   public let toNat : Nat64 -> Nat = Prim.nat64ToNat;

--- a/src/Nat8.mo
+++ b/src/Nat8.mo
@@ -6,6 +6,9 @@ import Prim "mo:⛔";
 
 module {
 
+  /// 8-bit natural numbers.
+  public type Nat8 = Prim.Types.Nat8;
+
   /// Conversion.
   public let toNat : Nat8 -> Nat = Prim.nat8ToNat;
 

--- a/src/Nat8.mo
+++ b/src/Nat8.mo
@@ -6,8 +6,10 @@ import Prim "mo:⛔";
 
 module {
 
+/*
   /// 8-bit natural numbers.
   public type Nat8 = Prim.Types.Nat8;
+*/
 
   /// Conversion.
   public let toNat : Nat8 -> Nat = Prim.nat8ToNat;

--- a/src/None.mo
+++ b/src/None.mo
@@ -1,13 +1,19 @@
 /// The absent value
 ///
-/// The `None` type represents a type with _no_ value, often used to mark dead
-/// code.
+/// The `None` type represents a type with _no_ value.
 ///
-/// For example, the type `[None]` has only empty lists.
+/// It is often used to type code that fails to return control (e.g. an infinite loop)
+/// or to designate impossible values (e.g. the type `?None` only contains `null`).
+
+import Prim "mo:⛔";
 
 module {
+
+  /// The empty type. A subtype of all types.
+  public type None = Prim.Types.None;
+
   /// Turns an absurd value into an arbitrary type.
-  public let impossible : <A> None -> A = func<A>(x: None) : A {
+  public let impossible : <A> None -> A = func<A>(x : None) : A {
     switch (x) {};
   };
 }

--- a/src/None.mo
+++ b/src/None.mo
@@ -9,8 +9,10 @@ import Prim "mo:⛔";
 
 module {
 
+/*
   /// The empty type. A subtype of all types.
   public type None = Prim.Types.None;
+*/
 
   /// Turns an absurd value into an arbitrary type.
   public let impossible : <A> None -> A = func<A>(x : None) : A {

--- a/src/Option.mo
+++ b/src/Option.mo
@@ -78,10 +78,10 @@ module {
   public func apply<A, B>(x : ?A, f : ?(A -> B)) : ?B {
     switch (f, x) {
       case (?f_, ?x_) {
-	?f_(x_);
+        ?f_(x_);
       };
       case (_, _) {
-	null;
+        null;
       };
     };
   };
@@ -91,10 +91,10 @@ module {
   public func chain<A, B>(x : ?A, f : A -> ?B) : ?B {
     switch(x) {
       case (?x_) {
-	f(x_);
+        f(x_);
       };
       case (null) {
-	null;
+        null;
       };
     };
   };

--- a/src/Option.mo
+++ b/src/Option.mo
@@ -28,133 +28,133 @@ import P "Prelude";
 
 module {
 
-/// Unwraps an optional value, with a default value, i.e. `get(?x, d) = x` and
-/// `get(null, d) = d`.
-public func get<T>(x : ?T, default : T) : T =
-  switch x {
-    case null { default };
-    case (?x_) { x_ };
-  };
-
-/// Unwraps an optional value using a function, or returns the default, i.e.
-/// `option(?x, f, d) = f x` and `option(null, f, d) = d`.
-public func getMapped<A, B>(x : ?A, f : A -> B, default : B) : B =
-  switch x {
-    case null { default };
-    case (?x_) { f(x_) };
-  };
-
-/// Applies a function to the wrapped value. `null`'s are left untouched.
-/// ```motoko
-/// import Option "mo:base/Option";
-/// assert(Option.map<Nat, Nat>(?(42), func x = x+1) == ?(43));
-/// assert(Option.map<Nat, Nat>(null, func x = x+1) == null);
-/// ```
-public func map<A, B>(x : ?A, f : A -> B) : ?B =
-  switch x {
-    case null { null };
-    case (?x_) { ?f(x_) };
-  };
-
-/// Applies a function to the wrapped value, but discards the result. Use
-/// `iterate` if you're only interested in the side effect `f` produces.
-///
-/// ```motoko
-/// import Option "mo:base/Option";
-/// var counter : Nat = 0;
-/// Option.iterate(?(5), func (x : Nat) { counter += x });
-/// assert(counter == 5);
-/// Option.iterate(null, func (x : Nat) { counter += x });
-/// assert(counter == 5);
-/// ```
-public func iterate<A>(x : ?A, f : A -> ()) =
-  switch x {
-    case null {};
-    case (?x_) { f(x_) };
-  };
-
-/// Applies an optional function to an optional value. Returns `null` if at
-/// least one of the arguments is `null`.
-public func apply<A, B>(x : ?A, f : ?(A -> B)) : ?B {
-  switch (f, x) {
-    case (?f_, ?x_) {
-      ?f_(x_);
+  /// Unwraps an optional value, with a default value, i.e. `get(?x, d) = x` and
+  /// `get(null, d) = d`.
+  public func get<T>(x : ?T, default : T) : T =
+    switch x {
+      case null { default };
+      case (?x_) { x_ };
     };
-    case (_, _) {
-      null;
-    };
-  };
-};
 
-/// Applies a function to an optional value. Returns `null` if the argument is
-/// `null`, or the function returns `null`.
-public func chain<A, B>(x : ?A, f : A -> ?B) : ?B {
-  switch(x) {
-    case (?x_) {
-      f(x_);
+  /// Unwraps an optional value using a function, or returns the default, i.e.
+  /// `option(?x, f, d) = f x` and `option(null, f, d) = d`.
+  public func getMapped<A, B>(x : ?A, f : A -> B, default : B) : B =
+    switch x {
+      case null { default };
+      case (?x_) { f(x_) };
     };
-    case (null) {
-      null;
+
+  /// Applies a function to the wrapped value. `null`'s are left untouched.
+  /// ```motoko
+  /// import Option "mo:base/Option";
+  /// assert(Option.map<Nat, Nat>(?(42), func x = x+1) == ?(43));
+  /// assert(Option.map<Nat, Nat>(null, func x = x+1) == null);
+  /// ```
+  public func map<A, B>(x : ?A, f : A -> B) : ?B =
+    switch x {
+      case null { null };
+      case (?x_) { ?f(x_) };
+    };
+
+  /// Applies a function to the wrapped value, but discards the result. Use
+  /// `iterate` if you're only interested in the side effect `f` produces.
+  ///
+  /// ```motoko
+  /// import Option "mo:base/Option";
+  /// var counter : Nat = 0;
+  /// Option.iterate(?(5), func (x : Nat) { counter += x });
+  /// assert(counter == 5);
+  /// Option.iterate(null, func (x : Nat) { counter += x });
+  /// assert(counter == 5);
+  /// ```
+  public func iterate<A>(x : ?A, f : A -> ()) =
+    switch x {
+      case null {};
+      case (?x_) { f(x_) };
+    };
+
+  /// Applies an optional function to an optional value. Returns `null` if at
+  /// least one of the arguments is `null`.
+  public func apply<A, B>(x : ?A, f : ?(A -> B)) : ?B {
+    switch (f, x) {
+      case (?f_, ?x_) {
+	?f_(x_);
+      };
+      case (_, _) {
+	null;
+      };
     };
   };
-};
 
-/// Given an optional optional value, removes one layer of optionality.
-/// ```motoko
-/// import Option "mo:base/Option";
-/// assert(Option.flatten(?(?(42))) == ?(42));
-/// assert(Option.flatten(?(null)) == null);
-/// assert(Option.flatten(null) == null);
-/// ```
-public func flatten<A>(x : ??A) : ?A {
-  chain<?A, A>(x, func (x_ : ?A) : ?A {
-    x_;
-  });
-};
-
-/// Creates an optional value from a definite value.
-/// ```motoko
-/// import Option "mo:base/Option";
-/// assert(Option.make(42) == ?(42));
-/// ```
-public func make<A>(x: A) : ?A = ?x;
-
-/// Returns true if the argument is not `null`, otherwise returns false.
-public func isSome(x : ?Any) : Bool =
-  switch x {
-    case null { false };
-    case _ { true };
+  /// Applies a function to an optional value. Returns `null` if the argument is
+  /// `null`, or the function returns `null`.
+  public func chain<A, B>(x : ?A, f : A -> ?B) : ?B {
+    switch(x) {
+      case (?x_) {
+	f(x_);
+      };
+      case (null) {
+	null;
+      };
+    };
   };
 
-/// Returns true if the argument is `null`, otherwise returns false.
-public func isNull(x : ?Any) : Bool =
-  switch x {
-    case null { true };
-    case _ { false };
+  /// Given an optional optional value, removes one layer of optionality.
+  /// ```motoko
+  /// import Option "mo:base/Option";
+  /// assert(Option.flatten(?(?(42))) == ?(42));
+  /// assert(Option.flatten(?(null)) == null);
+  /// assert(Option.flatten(null) == null);
+  /// ```
+  public func flatten<A>(x : ??A) : ?A {
+    chain<?A, A>(x, func (x_ : ?A) : ?A {
+      x_;
+    });
   };
 
-/// Asserts that the value is not `null`; fails otherwise.
-/// Deprecated.
-public func assertSome(x : ?Any) =
-  switch x {
-    case null { P.unreachable() };
-    case _ {};
-  };
+  /// Creates an optional value from a definite value.
+  /// ```motoko
+  /// import Option "mo:base/Option";
+  /// assert(Option.make(42) == ?(42));
+  /// ```
+  public func make<A>(x: A) : ?A = ?x;
 
-/// Asserts that the value _is_ `null`; fails otherwise.
-/// Deprecated.
-public func assertNull(x : ?Any) =
-  switch x {
-    case null { };
-    case _ { P.unreachable() };
-  };
+  /// Returns true if the argument is not `null`, otherwise returns false.
+  public func isSome(x : ?Any) : Bool =
+    switch x {
+      case null { false };
+      case _ { true };
+    };
 
-/// Unwraps an optional value, i.e. `unwrap(?x) = x`.
-///
-/// WARNING: `unwrap(x)` will fail if the argument is `null`, and is generally considered bad style. Use `switch x` instead.
-public func unwrap<T>(x : ?T) : T =
-  switch x {
-    case null { P.unreachable() };
-    case (?x_) { x_ };
-  };
+  /// Returns true if the argument is `null`, otherwise returns false.
+  public func isNull(x : ?Any) : Bool =
+    switch x {
+      case null { true };
+      case _ { false };
+    };
+
+  /// Asserts that the value is not `null`; fails otherwise.
+  /// Deprecated.
+  public func assertSome(x : ?Any) =
+    switch x {
+      case null { P.unreachable() };
+      case _ {};
+    };
+
+  /// Asserts that the value _is_ `null`; fails otherwise.
+  /// Deprecated.
+  public func assertNull(x : ?Any) =
+    switch x {
+      case null { };
+      case _ { P.unreachable() };
+    };
+
+  /// Unwraps an optional value, i.e. `unwrap(?x) = x`.
+  ///
+  /// WARNING: `unwrap(x)` will fail if the argument is `null`, and is generally considered bad style. Use `switch x` instead.
+  public func unwrap<T>(x : ?T) : T =
+    switch x {
+      case null { P.unreachable() };
+      case (?x_) { x_ };
+    };
 }

--- a/src/Option.mo
+++ b/src/Option.mo
@@ -47,8 +47,8 @@ module {
   /// Applies a function to the wrapped value. `null`'s are left untouched.
   /// ```motoko
   /// import Option "mo:base/Option";
-  /// assert(Option.map<Nat, Nat>(?(42), func x = x+1) == ?(43));
-  /// assert(Option.map<Nat, Nat>(null, func x = x+1) == null);
+  /// assert(Option.map<Nat, Nat>(?(42), func x = x + 1) == ?(43));
+  /// assert(Option.map<Nat, Nat>(null, func x = x + 1) == null);
   /// ```
   public func map<A, B>(x : ?A, f : A -> B) : ?B =
     switch x {

--- a/src/Prelude.mo
+++ b/src/Prelude.mo
@@ -15,11 +15,11 @@ module {
   /// Each have calls are well-typed in all typing contexts, which
   /// trap in all execution contexts.
   public func nyi() : None {
-    assert false ; loop { }
+    assert false; loop { }
   };
 
   public func xxx() : None {
-    assert false ; loop { }
+    assert false; loop { }
   };
 
   /// Mark unreachable code with the `unreachable` function.
@@ -27,7 +27,7 @@ module {
   /// Calls are well-typed in all typing contexts, and they
   /// trap in all execution contexts.
   public func unreachable() : None {
-    assert false ; loop { }
+    assert false; loop { }
   };
 
 }

--- a/src/Prelude.mo
+++ b/src/Prelude.mo
@@ -8,22 +8,26 @@ import Prim "mo:⛔";
 
 module {
 
-/// Not yet implemented
-///
-/// Mark incomplete code with the `nyi` and `xxx` functions.
-///
-/// Each have calls are well-typed in all typing contexts, which
-/// trap in all execution contexts.
+  /// Not yet implemented
+  ///
+  /// Mark incomplete code with the `nyi` and `xxx` functions.
+  ///
+  /// Each have calls are well-typed in all typing contexts, which
+  /// trap in all execution contexts.
+  public func nyi() : None {
+    assert false ; loop { }
+  };
 
-public func nyi() : None
-  { assert false ; loop { } };
+  public func xxx() : None {
+    assert false ; loop { }
+  };
 
-public func xxx() : None
-  { assert false ; loop { } };
+  /// Mark unreachable code with the `unreachable` function.
+  ///
+  /// Calls are well-typed in all typing contexts, and they
+  /// trap in all execution contexts.
+  public func unreachable() : None {
+    assert false ; loop { }
+  };
 
-/// Mark unreachable code with the `unreachable` function.
-///
-/// Calls are well-typed in all typing contexts, and they
-/// trap in all execution contexts.
-public func unreachable() : None { assert false ; loop { } };
 }

--- a/src/Principal.mo
+++ b/src/Principal.mo
@@ -5,6 +5,10 @@ import Blob "Blob";
 import Hash "Hash";
 module {
 
+  /// Internet Computer principal identifiers.
+  /// Convert to `Blob` for access to bytes.
+  public type Principal = Prim.Types.Principal;
+
   /// Conversion.
   public let fromActor : (a : actor {}) -> Principal = Prim.principalOfActor;
 

--- a/src/Principal.mo
+++ b/src/Principal.mo
@@ -5,9 +5,11 @@ import Blob "Blob";
 import Hash "Hash";
 module {
 
+/*
   /// Internet Computer principal identifiers.
   /// Convert to `Blob` for access to bytes.
   public type Principal = Prim.Types.Principal;
+*/
 
   /// Conversion.
   public let fromActor : (a : actor {}) -> Principal = Prim.principalOfActor;

--- a/src/RBTree.mo
+++ b/src/RBTree.mo
@@ -32,12 +32,12 @@ module {
     };
 
     /// Get the value associated with a given key.
-    public func get(x:X) : ?Y {
+    public func get(x : X) : ?Y {
       getRec(x, compareTo, tree);
     };
 
     /// Replace the value associated with a given key.
-    public func replace(x:X, y:Y) : ?Y {
+    public func replace(x : X, y : Y) : ?Y {
       let (res, t) = insertRoot(x, compareTo, y, tree);
       tree := t;
       res
@@ -56,7 +56,7 @@ module {
     };
 
     /// Remove the entry associated with a given key.
-    public func remove(x:X) : ?Y {
+    public func remove(x : X) : ?Y {
       let (res, t) = removeRec(x, compareTo, tree);
       tree := t;
       res

--- a/src/RBTree.mo
+++ b/src/RBTree.mo
@@ -9,7 +9,7 @@ import O "Order";
 module {
 
   /// Node color: red or black.
-  public type Color = {#R; #B};
+  public type Color = { #R; #B };
 
   /// Ordered, (red-black) tree of entries.
   public type Tree<X, Y> = {
@@ -18,7 +18,7 @@ module {
   };
 
   /// Create an order map from an order function for its keys.
-  public class RBTree<X, Y>(compareTo:(X, X) -> O.Order) {
+  public class RBTree<X, Y>(compareTo : (X, X) -> O.Order) {
 
     var tree : Tree<X, Y> = (#leaf : Tree<X, Y>);
 
@@ -75,10 +75,10 @@ module {
   };
 
 
-  type IterRep<X, Y> = List.List<{#tr:Tree<X, Y>; #xy:(X, ?Y)}>;
+  type IterRep<X, Y> = List.List<{ #tr:Tree<X, Y>; #xy:(X, ?Y) }>;
 
   /// An iterator for the entries of the map, in ascending (`#fwd`) or descending (`#bwd`) order.
-  public func iter<X, Y>(t : Tree<X, Y>, dir : {#fwd; #bwd}) : I.Iter<(X, Y)> {
+  public func iter<X, Y>(t : Tree<X, Y>, dir : { #fwd; #bwd }) : I.Iter<(X, Y)> {
     object {
       var trees : IterRep<X, Y> = ?(#tr(t), null);
       public func next() : ?(X, Y) {

--- a/src/RBTree.mo
+++ b/src/RBTree.mo
@@ -8,201 +8,211 @@ import O "Order";
 
 module {
 
-/// Node color: Red or black.
-public type Color = {#R; #B};
+  /// Node color: red or black.
+  public type Color = {#R; #B};
 
-/// Ordered, (red-black) tree of entries.
-public type Tree<X, Y> = {
-  #node : (Color, Tree<X, Y>, (X, ?Y), Tree<X, Y>);
-  #leaf;
-};
-
-/// Create an order map from an order function for its keys.
-public class RBTree<X, Y>(compareTo:(X, X) -> O.Order) {
-
-  var tree: Tree<X, Y> = (#leaf : Tree<X, Y>);
-
-  /// Tree as share data.
-  ///
-  /// Get non-OO, purely-functional representation:
-  /// for drawing, pretty-printing and non-OO contexts
-  /// (e.g., async args and results):
-  public func share() : Tree<X, Y> {
-    tree
+  /// Ordered, (red-black) tree of entries.
+  public type Tree<X, Y> = {
+    #node : (Color, Tree<X, Y>, (X, ?Y), Tree<X, Y>);
+    #leaf;
   };
 
-  /// Get the value associated with a given key.
-  public func get(x:X) : ?Y =
-    getRec(x, compareTo, tree);
-  /// Replace the value associated with a given key.
-  public func replace(x:X, y:Y) : ?Y {
-    let (res, t) = insertRoot(x, compareTo, y, tree);
-    tree := t;
-    res
-  };
-  /// Put an entry: A value associated with a given key.
-  public func put(x:X, y:Y) {
-    let (res, t) = insertRoot(x, compareTo, y, tree);
-    tree := t;
-  };
-  /// Delete the entry associated with a given key.
-  public func delete(x:X) {
-    let (res, t) = removeRec(x, compareTo, tree);
-    tree := t
-  };
-  /// Remove the entry associated with a given key.
-  public func remove(x:X) : ?Y {
-    let (res, t) = removeRec(x, compareTo, tree);
-    tree := t;
-    res
-  };
+  /// Create an order map from an order function for its keys.
+  public class RBTree<X, Y>(compareTo:(X, X) -> O.Order) {
 
-  /// An iterator for the key-value entries of the map, in ascending key order.
-  ///
-  /// iterator is persistent, like the tree itself
-  public func entries() : I.Iter<(X, Y)> = iter(tree, #fwd);
+    var tree : Tree<X, Y> = (#leaf : Tree<X, Y>);
 
-  /// An iterator for the key-value entries of the map, in descending key order.
-  ///
-  /// iterator is persistent, like the tree itself
-  public func entriesRev() : I.Iter<(X, Y)> = iter(tree, #bwd);
-
-};
-
-
-type IterRep<X, Y> = List.List<{#tr:Tree<X, Y>; #xy:(X, ?Y)}>;
-
-/// An iterator for the entries of the map, in ascending (`#fwd`) or descending (`#bwd`) order.
-public func iter<X, Y>(t:Tree<X, Y>, dir:{#fwd; #bwd}) : I.Iter<(X, Y)> {
-  object {
-    var trees : IterRep<X, Y> = ?(#tr(t), null);
-    public func next() : ?(X, Y) {
-      switch (dir, trees) {
-      case (_, null) { null };
-      case (_, ?(#tr(#leaf), ts)){ 
-        trees := ts; 
-        next() 
-      };
-      case (_, ?(#xy(xy), ts)) { 
-        trees := ts; 
-        switch (xy.1) { 
-          case null { next() };
-          case (?y) { ?(xy.0, y) } 
-        } 
-      };
-      case (#fwd, ?(#tr(#node(_, l, xy, r)), ts)) { 
-        trees := ?(#tr(l), ?(#xy(xy), ?(#tr(r), ts))); 
-        next() 
-      };
-      case (#bwd, ?(#tr(#node(_, l, xy, r)), ts)) { 
-        trees := ?(#tr(r), ?(#xy(xy), ?(#tr(l), ts))); 
-        next() 
-      };
-      }
+    /// Tree as sharable data.
+    ///
+    /// Get non-OO, purely-functional representation:
+    /// for drawing, pretty-printing and non-OO contexts
+    /// (e.g., async args and results):
+    public func share() : Tree<X, Y> {
+      tree
     };
-  }
-};
 
-/// Remove the value associated with a given key.
-func removeRec<X, Y>(x:X, compareTo:(X, X) -> O.Order, t:Tree<X, Y>)
-  : (?Y, Tree<X, Y>)
-{
-  switch t {
-  case (#leaf) { (null, #leaf) };
-  case (#node(c, l, xy, r)) {
-         switch (compareTo(x, xy.0)) {
-         case (#less) {
-                let (yo, l2) = removeRec(x, compareTo, l);
-                (yo, #node(c, l2, xy, r))
-              };
-         case (#equal) {
-                (xy.1, #node(c, l, (x, null), r))
-              };
-         case (#greater) {
-                let (yo, r2) = removeRec(x, compareTo, r);
-                (yo, #node(c, l, xy, r2))
-              };
-         }
-       }
-  }
-};
+    /// Get the value associated with a given key.
+    public func get(x:X) : ?Y {
+      getRec(x, compareTo, tree);
+    };
+
+    /// Replace the value associated with a given key.
+    public func replace(x:X, y:Y) : ?Y {
+      let (res, t) = insertRoot(x, compareTo, y, tree);
+      tree := t;
+      res
+    };
+
+    /// Put an entry: A value associated with a given key.
+    public func put(x : X, y : Y) {
+      let (res, t) = insertRoot(x, compareTo, y, tree);
+      tree := t;
+    };
+
+    /// Delete the entry associated with a given key.
+    public func delete(x : X) {
+      let (res, t) = removeRec(x, compareTo, tree);
+      tree := t
+    };
+
+    /// Remove the entry associated with a given key.
+    public func remove(x:X) : ?Y {
+      let (res, t) = removeRec(x, compareTo, tree);
+      tree := t;
+      res
+    };
+
+    /// An iterator for the key-value entries of the map, in ascending key order.
+    ///
+    /// iterator is persistent, like the tree itself
+    public func entries() : I.Iter<(X, Y)> { iter(tree, #fwd) };
+
+    /// An iterator for the key-value entries of the map, in descending key order.
+    ///
+    /// iterator is persistent, like the tree itself
+    public func entriesRev() : I.Iter<(X, Y)> { iter(tree, #bwd) };
+
+  };
+
+
+  type IterRep<X, Y> = List.List<{#tr:Tree<X, Y>; #xy:(X, ?Y)}>;
+
+  /// An iterator for the entries of the map, in ascending (`#fwd`) or descending (`#bwd`) order.
+  public func iter<X, Y>(t : Tree<X, Y>, dir : {#fwd; #bwd}) : I.Iter<(X, Y)> {
+    object {
+      var trees : IterRep<X, Y> = ?(#tr(t), null);
+      public func next() : ?(X, Y) {
+        switch (dir, trees) {
+          case (_, null) { null };
+          case (_, ?(#tr(#leaf), ts)){
+            trees := ts;
+            next()
+          };
+          case (_, ?(#xy(xy), ts)) {
+            trees := ts;
+            switch (xy.1) {
+              case null { next() };
+              case (?y) { ?(xy.0, y) }
+            }
+          };
+          case (#fwd, ?(#tr(#node(_, l, xy, r)), ts)) {
+            trees := ?(#tr(l), ?(#xy(xy), ?(#tr(r), ts)));
+            next()
+          };
+          case (#bwd, ?(#tr(#node(_, l, xy, r)), ts)) {
+            trees := ?(#tr(r), ?(#xy(xy), ?(#tr(l), ts)));
+            next()
+          };
+        }
+      };
+    }
+  };
+
+  /// Remove the value associated with a given key.
+  func removeRec<X, Y>(x : X, compareTo : (X, X) -> O.Order, t : Tree<X, Y>)
+    : (?Y, Tree<X, Y>) {
+    switch t {
+      case (#leaf) { (null, #leaf) };
+      case (#node(c, l, xy, r)) {
+        switch (compareTo(x, xy.0)) {
+          case (#less) {
+            let (yo, l2) = removeRec(x, compareTo, l);
+            (yo, #node(c, l2, xy, r))
+          };
+          case (#equal) {
+            (xy.1, #node(c, l, (x, null), r))
+          };
+          case (#greater) {
+            let (yo, r2) = removeRec(x, compareTo, r);
+            (yo, #node(c, l, xy, r2))
+          };
+        }
+      }
+    }
+  };
 
 
 
-func bal<X, Y>(color:Color, lt:Tree<X, Y>, kv:(X, ?Y), rt:Tree<X, Y>) : Tree<X, Y> {
-  // thank you, algebraic pattern matching!
-  // following notes from [Ravi Chugh](https://www.classes.cs.uchicago.edu/archive/2019/spring/22300-1/lectures/RedBlackTrees/index.html)
-  switch (color, lt, kv, rt) {
-  case (#B, #node(#R, #node(#R, a, x, b), y, c), z, d) { #node(#R, #node(#B, a, x, b), y, #node(#B, c, z, d)) };
-  case (#B, #node(#R, a, x, #node(#R, b, y, c)), z, d) { #node(#R, #node(#B, a, x, b), y, #node(#B, c, z, d)) };
-  case (#B, a, x, #node(#R, #node(#R, b, y, c), z, d)) { #node(#R, #node(#B, a, x, b), y, #node(#B, c, z, d)) };
-  case (#B, a, x, #node(#R, b, y, #node(#R, c, z, d))) { #node(#R, #node(#B, a, x, b), y, #node(#B, c, z, d)) };
-  case _ { #node(color, lt, kv, rt) };
-  }
-};
+  func bal<X, Y>(color : Color, lt : Tree<X, Y>, kv : (X, ?Y), rt : Tree<X, Y>) : Tree<X, Y> {
+    // thank you, algebraic pattern matching!
+    // following notes from [Ravi Chugh](https://www.classes.cs.uchicago.edu/archive/2019/spring/22300-1/lectures/RedBlackTrees/index.html)
+    switch (color, lt, kv, rt) {
+      case (#B, #node(#R, #node(#R, a, x, b), y, c), z, d) {
+        #node(#R, #node(#B, a, x, b), y, #node(#B, c, z, d))
+      };
+      case (#B, #node(#R, a, x, #node(#R, b, y, c)), z, d) {
+        #node(#R, #node(#B, a, x, b), y, #node(#B, c, z, d))
+      };
+      case (#B, a, x, #node(#R, #node(#R, b, y, c), z, d)) {
+        #node(#R, #node(#B, a, x, b), y, #node(#B, c, z, d))
+      };
+      case (#B, a, x, #node(#R, b, y, #node(#R, c, z, d))) {
+        #node(#R, #node(#B, a, x, b), y, #node(#B, c, z, d))
+      };
+      case _ { #node(color, lt, kv, rt) };
+    }
+  };
 
-func insertRoot<X, Y>(x:X, compareTo:(X, X) -> O.Order, y:Y, t:Tree<X, Y>)
-  : (?Y, Tree<X, Y>)
-{
-  switch (insertRec(x, compareTo, y, t)) {
-  case (_, #leaf) { assert false; loop { } };
-  case (yo, #node(_, l, xy, r)) { (yo, #node(#B, l, xy, r)) };
-  }
-};
+  func insertRoot<X, Y>(x : X, compareTo : (X, X) -> O.Order, y : Y, t : Tree<X, Y>)
+    : (?Y, Tree<X, Y>) {
+    switch (insertRec(x, compareTo, y, t)) {
+      case (_, #leaf) { assert false; loop { } };
+      case (yo, #node(_, l, xy, r)) { (yo, #node(#B, l, xy, r)) };
+    }
+  };
 
-func insertRec<X, Y>(x:X, compareTo:(X, X) -> O.Order, y:Y, t:Tree<X, Y>)
-  : (?Y, Tree<X, Y>)
-{
-  switch t {
-  case (#leaf) { (null, #node(#R, #leaf, (x, ?y), #leaf)) };
-  case (#node(c, l, xy, r)) {
-         switch (compareTo(x, xy.0)) {
-         case (#less) {
-                let (yo, l2) = insertRec(x, compareTo, y, l);
-                (yo, bal(c, l2, xy, r))
-              };
-         case (#equal) {
-                (xy.1, #node(c, l, (x, ?y), r))
-              };
-         case (#greater) {
-                let (yo, r2) = insertRec(x, compareTo, y, r);
-                (yo, bal(c, l, xy, r2))
-              };
-         }
-       }
-  }
-};
+  func insertRec<X, Y>(x : X, compareTo : (X, X) -> O.Order, y : Y, t : Tree<X, Y>)
+    : (?Y, Tree<X, Y>) {
+    switch t {
+      case (#leaf) { (null, #node(#R, #leaf, (x, ?y), #leaf)) };
+      case (#node(c, l, xy, r)) {
+        switch (compareTo(x, xy.0)) {
+          case (#less) {
+            let (yo, l2) = insertRec(x, compareTo, y, l);
+            (yo, bal(c, l2, xy, r))
+          };
+          case (#equal) {
+            (xy.1, #node(c, l, (x, ?y), r))
+          };
+          case (#greater) {
+            let (yo, r2) = insertRec(x, compareTo, y, r);
+            (yo, bal(c, l, xy, r2))
+          };
+        }
+      }
+    }
+  };
 
-func getRec<X, Y>(x:X, compareTo:(X, X) -> O.Order, t:Tree<X, Y>) : ?Y {
-  switch t {
-  case (#leaf) { null };
-  case (#node(c, l, xy, r)) {
-         switch (compareTo(x, xy.0)) {
-         case (#less) { getRec(x, compareTo, l) };
-         case (#equal) { xy.1 };
-         case (#greater) { getRec(x, compareTo, r) };
-         }
-       };
-  }
-};
+  func getRec<X, Y>(x : X, compareTo : (X, X) -> O.Order, t : Tree<X, Y>) : ?Y {
+    switch t {
+      case (#leaf) { null };
+      case (#node(c, l, xy, r)) {
+        switch (compareTo(x, xy.0)) {
+          case (#less) { getRec(x, compareTo, l) };
+          case (#equal) { xy.1 };
+          case (#greater) { getRec(x, compareTo, r) };
+        }
+      };
+    }
+  };
 
-func height<X, Y>(t:Tree<X, Y>) : Nat {
-  switch t {
-    case (#leaf) { 0 };
-    case (#node(_, l, _, r)) {
-           Nat.max(height(l), height(r)) + 1
-         }
-  }
-};
+  func height<X, Y>(t : Tree<X, Y>) : Nat {
+    switch t {
+      case (#leaf) { 0 };
+      case (#node(_, l, _, r)) {
+        Nat.max(height(l), height(r)) + 1
+      }
+    }
+  };
 
-/// The size of the tree as the number of key-value entries.
-public func size<X, Y>(t:Tree<X, Y>) : Nat {
-  switch t {
-    case (#leaf) { 0 };
-    case (#node(_, l, _, r)) {
-           size(l) + size(r) + 1
-         };
-  }
-};
+  /// The size of the tree as the number of key-value entries.
+  public func size<X, Y>(t : Tree<X, Y>) : Nat {
+    switch t {
+      case (#leaf) { 0 };
+      case (#node(_, l, _, r)) {
+        size(l) + size(r) + 1
+      };
+    }
+  };
 
 }

--- a/src/Random.mo
+++ b/src/Random.mo
@@ -184,4 +184,5 @@ module {
     };
     P.unreachable()
   }
+
 }

--- a/src/Result.mo
+++ b/src/Result.mo
@@ -34,10 +34,10 @@ module {
   ) : Bool {
     switch (r1, r2) {
       case (#ok(ok1), #ok(ok2)) {
-	eqOk(ok1, ok2)
+        eqOk(ok1, ok2)
       };
       case (#err(err1), #err(err2)) {
-	eqErr(err1, err2);
+        eqErr(err1, err2);
       };
       case _ { false };
     };
@@ -53,10 +53,10 @@ module {
   ) : Order.Order {
     switch (r1, r2) {
       case (#ok(ok1), #ok(ok2)) {
-	compareOk(ok1, ok2)
+        compareOk(ok1, ok2)
       };
       case (#err(err1), #err(err2)) {
-	compareErr(err1, err2)
+        compareErr(err1, err2)
       };
       case (#ok(_), _) { #greater };
       case (#err(_), _) { #less };

--- a/src/Result.mo
+++ b/src/Result.mo
@@ -6,206 +6,205 @@ import Order "Order";
 
 module {
 
-/// `Result<Ok, Err>` is the type used for returning and propagating errors. It
-/// is a type with the variants, `#ok(Ok)`, representing success and containing
-/// a value, and `#err(Err)`, representing error and containing an error value.
-///
-/// The simplest way of working with `Result`s is to pattern match on them:
-///
-/// For example, given a function `createUser(user : User) : Result<Id, String>`
-/// where `String` is an error message we could use it like so:
-/// ```
-/// switch(createUser(myUser)) {
-///   case #ok(id) Debug.print("Created new user with id: " # id)
-///   case #err(msg) Debug.print("Failed to create user with the error: " # msg)
-/// }
-/// ```
-public type Result<Ok, Err> = {
-  #ok : Ok;
-  #err : Err;
-};
-
-// Compares two Result's for equality.
-public func equal<Ok, Err>(
-  eqOk : (Ok, Ok) -> Bool,
-  eqErr : (Err, Err) -> Bool,
-  r1 : Result<Ok, Err>,
-  r2 : Result<Ok, Err>
-) : Bool {
-  switch (r1, r2) {
-    case (#ok(ok1), #ok(ok2)) {
-      eqOk(ok1, ok2)
-    };
-    case (#err(err1), #err(err2)) {
-      eqErr(err1, err2);
-    };
-    case _ { false };
+  /// `Result<Ok, Err>` is the type used for returning and propagating errors. It
+  /// is a type with the variants, `#ok(Ok)`, representing success and containing
+  /// a value, and `#err(Err)`, representing error and containing an error value.
+  ///
+  /// The simplest way of working with `Result`s is to pattern match on them:
+  ///
+  /// For example, given a function `createUser(user : User) : Result<Id, String>`
+  /// where `String` is an error message we could use it like so:
+  /// ```
+  /// switch(createUser(myUser)) {
+  ///   case #ok(id) Debug.print("Created new user with id: " # id)
+  ///   case #err(msg) Debug.print("Failed to create user with the error: " # msg)
+  /// }
+  /// ```
+  public type Result<Ok, Err> = {
+    #ok : Ok;
+    #err : Err;
   };
-};
 
-// Compares two Results. `#ok` is larger than `#err`. This ordering is
-// arbitrary, but it lets you for example use Results as keys in ordered maps.
-public func compare<Ok, Err>(
-  compareOk : (Ok, Ok) -> Order.Order,
-  compareErr : (Err, Err) -> Order.Order,
-  r1 : Result<Ok, Err>,
-  r2 : Result<Ok, Err>
-) : Order.Order {
-  switch (r1, r2) {
-    case (#ok(ok1), #ok(ok2)) { 
-      compareOk(ok1, ok2) 
+  // Compares two Result's for equality.
+  public func equal<Ok, Err>(
+    eqOk : (Ok, Ok) -> Bool,
+    eqErr : (Err, Err) -> Bool,
+    r1 : Result<Ok, Err>,
+    r2 : Result<Ok, Err>
+  ) : Bool {
+    switch (r1, r2) {
+      case (#ok(ok1), #ok(ok2)) {
+	eqOk(ok1, ok2)
+      };
+      case (#err(err1), #err(err2)) {
+	eqErr(err1, err2);
+      };
+      case _ { false };
     };
-    case (#err(err1), #err(err2)) { 
-      compareErr(err1, err2) 
-    };
-    case (#ok(_), _) { #greater };
-    case (#err(_), _) { #less };
   };
-};
 
-/// Allows sequencing of `Result` values and functions that return
-/// `Result`'s themselves.
-/// ```motoko
-/// import Result "mo:base/Result";
-/// type Result<T,E> = Result.Result<T, E>;
-/// func largerThan10(x : Nat) : Result<Nat, Text> =
-///   if (x > 10) { #ok(x) } else { #err("Not larger than 10.") };
-///
-/// func smallerThan20(x : Nat) : Result<Nat, Text> =
-///   if (x < 20) { #ok(x) } else { #err("Not smaller than 20.") };
-///
-/// func between10And20(x : Nat) : Result<Nat, Text> =
-///   Result.chain(largerThan10(x), smallerThan20);
-///
-/// assert(between10And20(15) == #ok(15));
-/// assert(between10And20(9) == #err("Not larger than 10."));
-/// assert(between10And20(21) == #err("Not smaller than 20."));
-/// ```
-public func chain<R1, R2, Error>(
-  x : Result<R1, Error>,
-  y : R1 -> Result<R2, Error>
-) : Result<R2, Error> {
-  switch x {
-    case (#err(e)) { #err(e) };
-    case (#ok(r)) { y(r) };
-  }
-};
+  // Compares two Results. `#ok` is larger than `#err`. This ordering is
+  // arbitrary, but it lets you for example use Results as keys in ordered maps.
+  public func compare<Ok, Err>(
+    compareOk : (Ok, Ok) -> Order.Order,
+    compareErr : (Err, Err) -> Order.Order,
+    r1 : Result<Ok, Err>,
+    r2 : Result<Ok, Err>
+  ) : Order.Order {
+    switch (r1, r2) {
+      case (#ok(ok1), #ok(ok2)) {
+	compareOk(ok1, ok2)
+      };
+      case (#err(err1), #err(err2)) {
+	compareErr(err1, err2)
+      };
+      case (#ok(_), _) { #greater };
+      case (#err(_), _) { #less };
+    };
+  };
 
-/// Flattens a nested Result.
-///
-/// ```motoko
-/// import Result "mo:base/Result";
-/// assert(Result.flatten<Nat, Text>(#ok(#ok(10))) == #ok(10));
-/// assert(Result.flatten<Nat, Text>(#err("Wrong")) == #err("Wrong"));
-/// assert(Result.flatten<Nat, Text>(#ok(#err("Wrong"))) == #err("Wrong"));
-/// ```
-public func flatten<Ok, Error>(
-  result : Result<Result<Ok, Error>, Error>
-) : Result<Ok, Error> {
-  switch result {
-    case (#ok(ok)) { ok };
-    case (#err(err)) { #err(err) };
-  }
-};
+  /// Allows sequencing of `Result` values and functions that return
+  /// `Result`'s themselves.
+  /// ```motoko
+  /// import Result "mo:base/Result";
+  /// type Result<T,E> = Result.Result<T, E>;
+  /// func largerThan10(x : Nat) : Result<Nat, Text> =
+  ///   if (x > 10) { #ok(x) } else { #err("Not larger than 10.") };
+  ///
+  /// func smallerThan20(x : Nat) : Result<Nat, Text> =
+  ///   if (x < 20) { #ok(x) } else { #err("Not smaller than 20.") };
+  ///
+  /// func between10And20(x : Nat) : Result<Nat, Text> =
+  ///   Result.chain(largerThan10(x), smallerThan20);
+  ///
+  /// assert(between10And20(15) == #ok(15));
+  /// assert(between10And20(9) == #err("Not larger than 10."));
+  /// assert(between10And20(21) == #err("Not smaller than 20."));
+  /// ```
+  public func chain<R1, R2, Error>(
+    x : Result<R1, Error>,
+    y : R1 -> Result<R2, Error>
+  ) : Result<R2, Error> {
+    switch x {
+      case (#err(e)) { #err(e) };
+      case (#ok(r)) { y(r) };
+    }
+  };
+
+  /// Flattens a nested Result.
+  ///
+  /// ```motoko
+  /// import Result "mo:base/Result";
+  /// assert(Result.flatten<Nat, Text>(#ok(#ok(10))) == #ok(10));
+  /// assert(Result.flatten<Nat, Text>(#err("Wrong")) == #err("Wrong"));
+  /// assert(Result.flatten<Nat, Text>(#ok(#err("Wrong"))) == #err("Wrong"));
+  /// ```
+  public func flatten<Ok, Error>(
+    result : Result<Result<Ok, Error>, Error>
+  ) : Result<Ok, Error> {
+    switch result {
+      case (#ok(ok)) { ok };
+      case (#err(err)) { #err(err) };
+    }
+  };
 
 
-/// Maps the `Ok` type/value, leaving any `Error` type/value unchanged.
-public func mapOk<Ok1, Ok2, Error>(
-  x : Result<Ok1, Error>,
-  f : Ok1 -> Ok2
-) : Result<Ok2, Error> {
-  switch x {
-    case (#err(e)) { #err(e) };
-    case (#ok(r)) { #ok(f(r)) };
-  }
-};
+  /// Maps the `Ok` type/value, leaving any `Error` type/value unchanged.
+  public func mapOk<Ok1, Ok2, Error>(
+    x : Result<Ok1, Error>,
+    f : Ok1 -> Ok2
+  ) : Result<Ok2, Error> {
+    switch x {
+      case (#err(e)) { #err(e) };
+      case (#ok(r)) { #ok(f(r)) };
+    }
+  };
 
-/// Maps the `Err` type/value, leaving any `Ok` type/value unchanged.
-public func mapErr<Ok, Error1, Error2>(
-  x : Result<Ok, Error1>,
-  f : Error1 -> Error2
-) : Result<Ok, Error2> {
-  switch x {
-    case (#err(e)) { #err (f(e)) };
-    case (#ok(r)) { #ok(r) };
-  }
-};
+  /// Maps the `Err` type/value, leaving any `Ok` type/value unchanged.
+  public func mapErr<Ok, Error1, Error2>(
+    x : Result<Ok, Error1>,
+    f : Error1 -> Error2
+  ) : Result<Ok, Error2> {
+    switch x {
+      case (#err(e)) { #err (f(e)) };
+      case (#ok(r)) { #ok(r) };
+    }
+  };
 
-/// Create a result from an option, including an error value to handle the `null` case.
-/// ```motoko
-/// import Result "mo:base/Result";
-/// assert(Result.fromOption(?42, "err") == #ok(42));
-/// assert(Result.fromOption(null, "err") == #err("err"));
-/// ```
-public func fromOption<R, E>(x : ?R, err : E) : Result<R, E> {
-  switch x {
-    case (?x) { #ok(x) };
-    case null { #err(err) };
-  }
-};
+  /// Create a result from an option, including an error value to handle the `null` case.
+  /// ```motoko
+  /// import Result "mo:base/Result";
+  /// assert(Result.fromOption(?42, "err") == #ok(42));
+  /// assert(Result.fromOption(null, "err") == #err("err"));
+  /// ```
+  public func fromOption<R, E>(x : ?R, err : E) : Result<R, E> {
+    switch x {
+      case (?x) { #ok(x) };
+      case null { #err(err) };
+    }
+  };
 
-/// Create an option from a result, turning all #err into `null`.
-/// ```motoko
-/// import Result "mo:base/Result";
-/// assert(Result.toOption(#ok(42)) == ?42);
-/// assert(Result.toOption(#err("err")) == null);
-/// ```
-public func toOption<R, E>(r : Result<R, E>) : ?R {
-  switch r {
-    case (#ok(x)) { ?x };
-    case (#err(_)) { null };
-  }
-};
+  /// Create an option from a result, turning all #err into `null`.
+  /// ```motoko
+  /// import Result "mo:base/Result";
+  /// assert(Result.toOption(#ok(42)) == ?42);
+  /// assert(Result.toOption(#err("err")) == null);
+  /// ```
+  public func toOption<R, E>(r : Result<R, E>) : ?R {
+    switch r {
+      case (#ok(x)) { ?x };
+      case (#err(_)) { null };
+    }
+  };
 
-/// Applies a function to a successful value, but discards the result. Use
-/// `iterate` if you're only interested in the side effect `f` produces.
-///
-/// ```motoko
-/// import Result "mo:base/Result";
-/// var counter : Nat = 0;
-/// Result.iterate<Nat, Text>(#ok(5), func (x : Nat) { counter += x });
-/// assert(counter == 5);
-/// Result.iterate<Nat, Text>(#err("Wrong"), func (x : Nat) { counter += x });
-/// assert(counter == 5);
-/// ```
-public func iterate<Ok, Err>(res : Result<Ok, Err>, f : Ok -> ()) {
-  switch res {
-    case (#ok(ok)) { f(ok) };
-    case _ {};
-  }
-};
+  /// Applies a function to a successful value, but discards the result. Use
+  /// `iterate` if you're only interested in the side effect `f` produces.
+  ///
+  /// ```motoko
+  /// import Result "mo:base/Result";
+  /// var counter : Nat = 0;
+  /// Result.iterate<Nat, Text>(#ok(5), func (x : Nat) { counter += x });
+  /// assert(counter == 5);
+  /// Result.iterate<Nat, Text>(#err("Wrong"), func (x : Nat) { counter += x });
+  /// assert(counter == 5);
+  /// ```
+  public func iterate<Ok, Err>(res : Result<Ok, Err>, f : Ok -> ()) {
+    switch res {
+      case (#ok(ok)) { f(ok) };
+      case _ {};
+    }
+  };
 
-// Whether this Result is an `#ok`
-public func isOk(r : Result<Any, Any>) : Bool {
-  switch r {
-    case (#ok(_)) { true };
-    case (#err(_)) { false };
-  }
-};
+  // Whether this Result is an `#ok`
+  public func isOk(r : Result<Any, Any>) : Bool {
+    switch r {
+      case (#ok(_)) { true };
+      case (#err(_)) { false };
+    }
+  };
 
-// Whether this Result is an `#err`
-public func isErr(r : Result<Any, Any>) : Bool {
-  switch r {
-    case (#ok(_)) { false };
-    case (#err(_)) { true };
-  }
-};
+  // Whether this Result is an `#err`
+  public func isErr(r : Result<Any, Any>) : Bool {
+    switch r {
+      case (#ok(_)) { false };
+      case (#err(_)) { true };
+    }
+  };
 
-/// Asserts that its argument is an `#ok` result, traps otherwise.
-public func assertOk(r:Result<Any,Any>) {
-  switch(r) {
-    case (#err(_)) { assert false };
-    case (#ok(_)) {};
-  }
-};
+  /// Asserts that its argument is an `#ok` result, traps otherwise.
+  public func assertOk(r : Result<Any,Any>) {
+    switch(r) {
+      case (#err(_)) { assert false };
+      case (#ok(_)) {};
+    }
+  };
 
-/// Asserts that its argument is an `#err` result, traps otherwise.
-public func assertErr(r:Result<Any,Any>) {
-  switch(r) {
-    case (#err(_)) {};
-    case (#ok(_)) assert false;
-  }
-};
-
+  /// Asserts that its argument is an `#err` result, traps otherwise.
+  public func assertErr(r : Result<Any,Any>) {
+    switch(r) {
+      case (#err(_)) {};
+      case (#ok(_)) assert false;
+    }
+  };
 
 }

--- a/src/Stack.mo
+++ b/src/Stack.mo
@@ -4,17 +4,23 @@
 /// See [deque](Deque.html) for mixed LIFO/FIFO behavior.
 ///
 import List "List";
+
 module {
+
   public class Stack<T>() {
+
     var stack : List.List<T> = List.nil<T>();
+
     /// Push an element on the top of the stack.
     public func push(x:T) {
       stack := ?(x, stack)
     };
+
     /// True when the stack is empty.
     public func isEmpty() : Bool {
       List.isNil<T>(stack)
     };
+
     /// Return and retain the top element, or return null.
     public func peek() : ?T {
       switch stack {
@@ -22,6 +28,7 @@ module {
         case (?(h, t)) { ?h };
       }
     };
+
     /// Remove and return the top element, or return null.
     public func pop() : ?T {
       switch stack {

--- a/src/Stack.mo
+++ b/src/Stack.mo
@@ -1,7 +1,7 @@
 /// Stack collection (LIFO discipline).
 ///
 /// Minimal LIFO (last in first out) implementation, as a class.
-/// See [deque](Deque.html) for mixed LIFO/FIFO behavior.
+/// See library `Deque` for mixed LIFO/FIFO behavior.
 ///
 import List "List";
 

--- a/src/Text.mo
+++ b/src/Text.mo
@@ -2,10 +2,11 @@
 ///
 /// This type represents human-readable text as sequences of characters of type `Char`.
 /// If `t` is a value of type `Text`, then:
+///
 /// * `t.chars()` returns an _iterator_ of type `Iter<Char>` enumerating its characters from first to last.
 /// * `t.size()` returns the _size_ (or length) of `t` (and `t.chars()`) as a `Nat`.
 /// * `t1 # t2` concatenates texts `t1` and `t2`.
-
+///
 /// Represented as ropes of UTF-8 character sequences with O(1) concatenation.
 ///
 /// This module defines additional operations on `Text` values.

--- a/src/Text.mo
+++ b/src/Text.mo
@@ -261,20 +261,20 @@ module {
 
     public func next() : ?Char {
       switch (stack.peek()) {
-	case (?(buff, c)) {
-	  switch (buff.next()) {
-	    case null {
-	      ignore stack.pop();
-	      return ?c;
-	    };
-	    case oc {
-	      return oc;
-	    };
-	  }
-	};
-	case null {
-	  return cs.next();
-	};
+        case (?(buff, c)) {
+          switch (buff.next()) {
+            case null {
+              ignore stack.pop();
+              return ?c;
+            };
+            case oc {
+              return oc;
+            };
+          }
+        };
+        case null {
+          return cs.next();
+        };
       };
     };
   };

--- a/src/Text.mo
+++ b/src/Text.mo
@@ -4,6 +4,9 @@
 /// If `t` is a value of type `Text`, then:
 /// * `t.chars()` returns an _iterator_ of type `Iter<Char>` enumerating its characters from first to last.
 /// * `t.size()` returns the _size_ (or length) of `t` (and `t.chars()`) as a `Nat`.
+/// * `t1 # t2` concatenates texts `t1` and `t2`.
+
+/// Represented as ropes of UTF-8 character sequences with O(1) concatenation.
 ///
 /// This module defines additional operations on `Text` values.
 
@@ -14,6 +17,9 @@ import Stack "Stack";
 import Prim "mo:⛔";
 
 module {
+
+  /// Text values.
+  public type Text = Prim.Types.Text;
 
   /// Conversion.
   /// Returns the text value of size 1 containing the single character `c`.

--- a/src/Text.mo
+++ b/src/Text.mo
@@ -1,6 +1,6 @@
 /// Text values
 ///
-/// This type represents human-readable text as sequences of characters of type [`Char`](Char.html) .
+/// This type represents human-readable text as sequences of characters of type `Char`.
 /// If `t` is a value of type `Text`, then:
 /// * `t.chars()` returns an _iterator_ of type `Iter<Char>` enumerating its characters from first to last.
 /// * `t.size()` returns the _size_ (or length) of `t` (and `t.chars()`) as a `Nat`.

--- a/src/Text.mo
+++ b/src/Text.mo
@@ -19,8 +19,10 @@ import Prim "mo:⛔";
 
 module {
 
+/*
   /// Text values.
   public type Text = Prim.Types.Text;
+*/
 
   /// Conversion.
   /// Returns the text value of size 1 containing the single character `c`.

--- a/src/Trie.mo
+++ b/src/Trie.mo
@@ -1125,7 +1125,7 @@ module {
   ) : Trie2D<K1, K2, V> {
     let inner = find<K1, Trie<K2, V>>(t, k1, k1_eq);
     let (updated_inner, _) = switch inner {
-      case (null)   { put<K2, V>(#empty, k2, k2_eq, v) };
+      case (null) { put<K2, V>(#empty, k2, k2_eq, v) };
       case (?inner) { put<K2, V>(inner, k2, k2_eq, v) };
     };
     let (updated_outer, _) = put<K1, Trie<K2, V>>(t, k1, k1_eq, updated_inner);

--- a/src/Trie.mo
+++ b/src/Trie.mo
@@ -251,7 +251,7 @@ module {
           switch (ListUtil.lenClamp<(Key<K>, V)>(kvs, MAX_LEAF_SIZE)) {
             case null {} /* fall through to branch case. */;
             case (?len) {
-              return #leaf({size = len; keyvals = kvs})
+              return #leaf({ size = len; keyvals = kvs })
             };
           }
         };
@@ -259,7 +259,7 @@ module {
           if ( c == 0 ) {
             return #empty
           } else if ( c <= MAX_LEAF_SIZE ) {
-            return #leaf({size = c; keyvals = kvs})
+            return #leaf({ size = c; keyvals = kvs })
           } else {
           /* fall through to branch case */
           }
@@ -269,9 +269,9 @@ module {
       if ( ls == 0 and rs == 0 ) {
         #empty
       } else if (rs == 0 and ls <= MAX_LEAF_SIZE) {
-        #leaf({size = ls; keyvals = l})
+        #leaf({ size = ls; keyvals = l })
       } else if (ls == 0 and rs <= MAX_LEAF_SIZE) {
-        #leaf({size = rs; keyvals = r})
+        #leaf({ size = rs; keyvals = r })
       } else {
         branch<K, V>(rec(?ls, l, bitpos + 1), rec(?rs, r, bitpos + 1))
       }
@@ -375,7 +375,8 @@ module {
     label profile_trie_splitList : (Nat, AssocList<Key<K>, V>, Nat, AssocList<Key<K>, V>)
     {
      func rec(l : AssocList<Key<K>, V>) : (Nat, AssocList<Key<K>, V>, Nat, AssocList<Key<K>, V>) =
-       label profile_trie_sized_split_rec : (Nat, AssocList<Key<K>, V>, Nat, AssocList<Key<K>, V>) {
+       label profile_trie_sized_split_rec :
+         (Nat, AssocList<Key<K>, V>, Nat, AssocList<Key<K>, V>) {
          switch l {
            case null { (0, null, 0, null) };
            case (?((k, v), t)) {
@@ -417,7 +418,7 @@ module {
               AssocList.disj<Key<K>, V, V, V>(
                 l1.keyvals, l2.keyvals,
                 key_eq,
-                func (x:?V, y:?V):V {
+                func (x : ?V, y : ?V):V {
                   switch (x, y) {
                     case (null, null) { P.unreachable() };
                     case (null, ?v) { v };
@@ -716,10 +717,10 @@ module {
     /*- "`foldUp` squared" (imagine two nested loops): */
     foldUp<K1, V1, Trie<K3, V3>>(
       tl, merge,
-      func (k1:K1, v1:V1) : Trie<K3, V3> {
+      func (k1 : K1, v1 : V1) : Trie<K3, V3> {
         foldUp<K2, V2, Trie<K3, V3>>(
           tr, merge,
-          func (k2:K2, v2:V2) : Trie<K3, V3> {
+          func (k2 : K2, v2 : V2) : Trie<K3, V3> {
             switch (op(k1, v1, k2, v2)) {
               case null { #empty };
               case (?(k3, v3)) { (put<K3, V3>(#empty, k3, k3_eq, v3)).0 };

--- a/src/Trie.mo
+++ b/src/Trie.mo
@@ -123,23 +123,25 @@ module {
           ( List.all<(Key<K>, V)>(
               l.keyvals,
               func ((k:Key<K>, v:V)) : Bool {
-                //{ Prim.debugPrint "testing hash..."; true }
-                //and
+              // { Prim.debugPrint "testing hash..."; true }
+              // and
                 ((k.hash & mask) == bits)
-                or
-                (do { Prim.debugPrint("\nmalformed hash!:\n");
-                   Prim.debugPrintInt(Prim.nat32ToNat(k.hash));
-                   Prim.debugPrint("\n (key hash) != (path bits): \n");
-                   Prim.debugPrintInt(Prim.nat32ToNat(bits));
-                   Prim.debugPrint("\nmask  : ");
-                   Prim.debugPrintInt(Prim.nat32ToNat(mask));
-                   Prim.debugPrint("\n");
-                   false
-                 })
+              // or
+              // (do {
+	      //    Prim.debugPrint("\nmalformed hash!:\n");
+              //    Prim.debugPrintInt(Prim.nat32ToNat(k.hash));
+              //    Prim.debugPrint("\n (key hash) != (path bits): \n");
+              //    Prim.debugPrintInt(Prim.nat32ToNat(bits));
+              //    Prim.debugPrint("\nmask  : ");
+              //    Prim.debugPrintInt(Prim.nat32ToNat(mask));
+              //    Prim.debugPrint("\n");
+              //    false
+              //  })
                  }
                )
-            or
-            (do { Prim.debugPrint("one or more hashes are malformed"); false })
+          // or
+          // (do { Prim.debugPrint("one or more hashes are malformed"); false }
+	    )
           )
         };
         case (#branch(b)) {
@@ -151,7 +153,9 @@ module {
           let mask1 = mask | (Prim.natToNat32(1) << bitpos1);
           let bits1 = bits | (Prim.natToNat32(1) << bitpos1);
           let sum = size<K, V>(b.left) + size<K,V>(b.right);
-          (b.size == sum or (do { Prim.debugPrint("malformed size"); false }))
+          (b.size == sum
+       //  or (do { Prim.debugPrint("malformed size"); false })
+	   )
           and
           rec(b.left,  ?bitpos1, bits,  mask1)
           and
@@ -313,7 +317,7 @@ module {
       }
      };
      let (to, vo) = rec(t, 0);
-     //assert(isValid<K,V>(to, false));
+   //assert(isValid<K,V>(to, false));
      (to, vo)
    };
 

--- a/src/Trie.mo
+++ b/src/Trie.mo
@@ -122,7 +122,7 @@ module {
           and
           ( List.all<(Key<K>, V)>(
               l.keyvals,
-              func ((k:Key<K>, v:V)) : Bool {
+              func ((k : Key<K>, v  :V)) : Bool {
               // { Prim.debugPrint "testing hash..."; true }
               // and
                 ((k.hash & mask) == bits)
@@ -215,7 +215,7 @@ module {
     /* Deprecated: List.lenIsEqLessThan */
     /// Test the list length against a maximum value and return true if
     /// the list length is less than or equal to the value specified.
-    public func lenIsEqLessThan<T>(l : List <T>, i : Nat) : Bool {
+    public func lenIsEqLessThan<T>(l : List<T>, i : Nat) : Bool {
       switch l {
         case null { true };
         case (?(_, t)) {
@@ -245,7 +245,7 @@ module {
 
   public func fromList<K, V>(kvc : ?Nat, kvs : AssocList<Key<K>, V>, bitpos : Nat) : Trie<K, V> =
     label profile_trie_fromList_begin : (Trie<K, V>) {
-    func rec(kvc:?Nat, kvs:AssocList<Key<K>, V>, bitpos : Nat) : Trie<K, V> {
+    func rec(kvc : ?Nat, kvs : AssocList<Key<K>, V>, bitpos : Nat) : Trie<K, V> {
       switch kvc {
         case null {
           switch (ListUtil.lenClamp<(Key<K>, V)>(kvs, MAX_LEAF_SIZE)) {
@@ -552,8 +552,8 @@ module {
   public func disj<K, V, W, X>(
     tl : Trie<K, V>,
     tr : Trie<K, W>,
-    k_eq : (K, K)->Bool,
-    vbin : (?V, ?W)->X
+    k_eq : (K, K) -> Bool,
+    vbin : (?V, ?W) -> X
   ) : Trie<K, X> {
     let key_eq = equalKey<K>(k_eq);
 
@@ -591,8 +591,8 @@ module {
      func lf2(kvs : AssocList<Key<K>, W>) : Trie<K, W> = leaf<K, W>(kvs, bitpos);
      switch (tl, tr) {
        case (#empty, #empty) { #empty };
-       case (#empty, _   )   { recR(tr, bitpos) };
-       case (_,    #empty)   { recL(tl, bitpos) };
+       case (#empty, _) { recR(tr, bitpos) };
+       case (_, #empty) { recL(tl, bitpos) };
        case (#leaf(l1), #leaf(l2)) {
          lf3(AssocList.disj<Key<K>, V, W, X>(l1.keyvals, l2.keyvals, key_eq, vbin), bitpos)
        };
@@ -629,8 +629,8 @@ module {
   public func join<K, V, W, X>(
     tl : Trie<K, V>,
     tr : Trie<K, W>,
-    k_eq : (K, K)->Bool,
-    vbin: (V, W)->X
+    k_eq : (K, K) -> Bool,
+    vbin : (V, W) -> X
   ) : Trie<K, X> =
   label profile_trie_join : Trie<K, X> {
     let key_eq = equalKey<K>(k_eq);
@@ -679,7 +679,7 @@ module {
         case (#leaf(l)) {
           AssocList.fold<Key<K>, V, X>(
             l.keyvals, empty,
-            func (k : Key<K>, v : V, x : X) :X { bin(leaf(k.key, v), x) }
+            func (k : Key<K>, v : V, x : X) : X { bin(leaf(k.key, v), x) }
           )
         };
         case (#branch(b)) { bin(rec(b.left), rec(b.right)) };
@@ -825,10 +825,10 @@ module {
     /// This position is meaningful only when the build contains multiple uses of one or more keys, otherwise it is not.
     public func nth<K, V>(tb : Build<K, V>, i : Nat) : ?(K, ?Hash.Hash, V) =
       label profile_triebuild_nth : (?(K, ?Hash.Hash, V)) {
-        func rec(tb:Build<K, V>, i:Nat) : ?(K, ?Hash.Hash, V) = label profile_triebuild_nth_rec : (?(K, ?Hash.Hash, V)) {
+        func rec(tb : Build<K, V>, i : Nat) : ?(K, ?Hash.Hash, V) = label profile_triebuild_nth_rec : (?(K, ?Hash.Hash, V)) {
           switch tb {
             case (#skip) { P.unreachable() };
-            case (#put (k, h, v)) label profile_trie_nth_rec_end : (?(K, ?Hash.Hash, V)) {
+            case (#put(k, h, v)) label profile_trie_nth_rec_end : (?(K, ?Hash.Hash, V)) {
               assert(i == 0);
               ?(k, h, v)
              };
@@ -913,7 +913,7 @@ module {
 
   /// Test whether all key-value pairs have a given property.
   public func all<K, V>(t : Trie<K, V>, f : (K, V) -> Bool) : Bool {
-    func rec(t:Trie<K, V>) : Bool {
+    func rec(t : Trie<K, V>) : Bool {
       switch t {
         case (#empty) { true };
         case (#leaf(l)) {
@@ -933,7 +933,7 @@ module {
   /// can inject tries into arrays using functions like `Array.tabulate`.
   public func nth<K, V>(t : Trie<K, V>, i : Nat) : ?(Key<K>, V) =
     label profile_trie_nth : (?(Key<K>, V)) {
-      func rec(t:Trie<K, V>, i:Nat) : ?(Key<K>, V) = label profile_trie_nth_rec : (?(Key<K>, V)) {
+      func rec(t : Trie<K, V>, i : Nat) : ?(Key<K>, V) = label profile_trie_nth_rec : (?(Key<K>, V)) {
         switch t {
           case (#empty) { P.unreachable() };
           case (#leaf(l)) { List.get<(Key<K>, V)>(l.keyvals, i) };
@@ -977,7 +977,7 @@ module {
     label profile_trie_toArray_begin : [W] {
       let a = A.tabulate<W> (
         size<K, V>(t),
-        func (i:Nat) : W = label profile_trie_toArray_nth : W {
+        func (i : Nat) : W = label profile_trie_toArray_nth : W {
           let (k, v) = Option.unwrap<(Key<K>, V)>(nth<K, V>(t, i));
           f(k.key, v)
         }
@@ -1080,7 +1080,7 @@ module {
               keq(k1.key, k2.key) and veq(v1, v2)
           )
         };
-        case (#branch(b1),#branch(b2)) {
+        case (#branch(b1), #branch(b2)) {
           rec(b1.left, b2.left) and rec(b2.right, b2.right)
         };
         case _ { false };
@@ -1197,7 +1197,7 @@ module {
     k2_eq: (K2, K2) -> Bool
   ) : (Trie2D<K1, K2, V>, ?V)  {
     switch (find<K1, Trie<K2, V>>(t, k1, k1_eq)) {
-      case (null)   {
+      case (null) {
         (t, null)
       };
       case (?inner) {
@@ -1219,7 +1219,7 @@ module {
     k3:Key<K3>, k3_eq : (K3, K3) -> Bool,
   ) : (Trie3D<K1, K2, K3, V>, ?V) {
     switch (find<K1, Trie2D<K2, K3, V>>(t, k1, k1_eq)) {
-      case (null)   {
+      case (null) {
         (t, null)
       };
       case (?inner) {

--- a/src/Trie.mo
+++ b/src/Trie.mo
@@ -115,7 +115,7 @@ module {
           }
         };
         case (#leaf(l)) {
-          let len = List.size<(Key<K>,V)>(l.keyvals);
+          let len = List.size<(Key<K>, V)>(l.keyvals);
           ((len <= MAX_LEAF_SIZE) or (not enforceNormal))
           and
           len == l.size
@@ -128,7 +128,7 @@ module {
                 ((k.hash & mask) == bits)
               // or
               // (do {
-	      //    Prim.debugPrint("\nmalformed hash!:\n");
+              //    Prim.debugPrint("\nmalformed hash!:\n");
               //    Prim.debugPrintInt(Prim.nat32ToNat(k.hash));
               //    Prim.debugPrint("\n (key hash) != (path bits): \n");
               //    Prim.debugPrintInt(Prim.nat32ToNat(bits));
@@ -141,7 +141,7 @@ module {
                )
           // or
           // (do { Prim.debugPrint("one or more hashes are malformed"); false }
-	    )
+            )
           )
         };
         case (#branch(b)) {
@@ -152,10 +152,10 @@ module {
             };
           let mask1 = mask | (Prim.natToNat32(1) << bitpos1);
           let bits1 = bits | (Prim.natToNat32(1) << bitpos1);
-          let sum = size<K, V>(b.left) + size<K,V>(b.right);
+          let sum = size<K, V>(b.left) + size<K, V>(b.right);
           (b.size == sum
        //  or (do { Prim.debugPrint("malformed size"); false })
-	   )
+           )
           and
           rec(b.left,  ?bitpos1, bits,  mask1)
           and
@@ -194,7 +194,7 @@ module {
 
   /// Construct a branch node, computing the size stored there.
   public func branch<K, V>(l : Trie<K, V>, r : Trie<K, V>) : Trie<K, V> =
-    label profile_trie_branch : Trie<K,V> {
+    label profile_trie_branch : Trie<K, V> {
       let sum = size<K, V>(l) + size<K, V>(r);
       #branch {
         size = sum;
@@ -252,7 +252,7 @@ module {
           switch (ListUtil.lenClamp<(Key<K>, V)>(kvs, MAX_LEAF_SIZE)) {
             case null {} /* fall through to branch case. */;
             case (?len) {
-              return #leaf({size=len; keyvals=kvs})
+              return #leaf({size = len; keyvals = kvs})
             };
           }
         };
@@ -260,21 +260,21 @@ module {
           if ( c == 0 ) {
             return #empty
           } else if ( c <= MAX_LEAF_SIZE ) {
-            return #leaf({size=c; keyvals=kvs})
+            return #leaf({size = c; keyvals = kvs})
           } else {
           /* fall through to branch case */
           }
         };
       };
-      let (ls, l, rs, r) = splitList<K,V>(kvs, bitpos);
+      let (ls, l, rs, r) = splitList<K, V>(kvs, bitpos);
       if ( ls == 0 and rs == 0 ) {
         #empty
       } else if (rs == 0 and ls <= MAX_LEAF_SIZE) {
-        #leaf({size=ls; keyvals=l})
+        #leaf({size = ls; keyvals = l})
       } else if (ls == 0 and rs <= MAX_LEAF_SIZE) {
-        #leaf({size=rs; keyvals=r})
+        #leaf({size = rs; keyvals = r})
       } else {
-        branch<K,V>(rec(?ls, l, bitpos + 1), rec(?rs, r, bitpos + 1))
+        branch<K, V>(rec(?ls, l, bitpos + 1), rec(?rs, r, bitpos + 1))
       }
     };
     rec(kvc, kvs, bitpos)
@@ -290,34 +290,34 @@ module {
      label profile_trie_replace : (Trie<K, V>, ?V) {
      let key_eq = equalKey<K>(k_eq);
 
-     func rec(t : Trie<K,V>, bitpos : Nat) : (Trie<K, V>, ?V) =
+     func rec(t : Trie<K, V>, bitpos : Nat) : (Trie<K, V>, ?V) =
        label profile_trie_replace_rec : (Trie<K, V>, ?V) {
         switch t {
           case (#empty) label profile_trie_replace_rec_empty : (Trie<K, V>, ?V) {
-            let (kvs, _) = AssocList.replace<Key<K>,V>(null, k, key_eq, v);
-            (leaf<K,V>(kvs, bitpos), null)
+            let (kvs, _) = AssocList.replace<Key<K>, V>(null, k, key_eq, v);
+            (leaf<K, V>(kvs, bitpos), null)
           };
           case (#branch(b)) label profile_trie_replace_rec_branch : (Trie<K, V>, ?V) {
             let bit = Hash.bit(k.hash, bitpos);
-            // rebuild either the left or right path with the (k,v) pair
+            // rebuild either the left or right path with the (k, v) pair
             if (not bit) {
-              let (l, v_) = rec(b.left, bitpos+1);
-              (branch<K,V>(l, b.right), v_)
+              let (l, v_) = rec(b.left, bitpos + 1);
+              (branch<K, V>(l, b.right), v_)
             }
             else {
-              let (r, v_) = rec(b.right, bitpos+1);
-              (branch<K,V>(b.left, r), v_)
+              let (r, v_) = rec(b.right, bitpos + 1);
+              (branch<K, V>(b.left, r), v_)
             }
           };
        case (#leaf(l)) label profile_trie_replace_rec_leaf : (Trie<K, V>, ?V) {
          let (kvs2, old_val) =
-           AssocList.replace<Key<K>,V>(l.keyvals, k, key_eq, v);
-         (leaf<K,V>(kvs2, bitpos), old_val)
+           AssocList.replace<Key<K>, V>(l.keyvals, k, key_eq, v);
+         (leaf<K, V>(kvs2, bitpos), old_val)
         };
       }
      };
      let (to, vo) = rec(t, 0);
-   //assert(isValid<K,V>(to, false));
+   //assert(isValid<K, V>(to, false));
      (to, vo)
    };
 
@@ -331,7 +331,7 @@ module {
   public func find<K, V>(t : Trie<K, V>, k : Key<K>, k_eq : (K, K) -> Bool) : ?V =
     label profile_trie_find : (?V) {
       let key_eq = equalKey<K>(k_eq);
-      func rec(t : Trie<K,V>, bitpos : Nat) : ?V = label profile_trie_find_rec : (?V) {
+      func rec(t : Trie<K, V>, bitpos : Nat) : ?V = label profile_trie_find_rec : (?V) {
         switch t {
           case (#empty) {
             label profile_trie_find_end_null : (?V)
@@ -339,17 +339,17 @@ module {
           };
           case (#leaf(l)) {
             label profile_trie_find_end_assocList_find : (?V)
-            { AssocList.find<Key<K>,V>(l.keyvals, k, key_eq) }
+            { AssocList.find<Key<K>, V>(l.keyvals, k, key_eq) }
           };
           case (#branch(b)) {
             let bit = Hash.bit(k.hash, bitpos);
             if (not bit) {
               label profile_trie_find_branch_left : (?V)
-              { rec(b.left, bitpos+1) }
+              { rec(b.left, bitpos + 1) }
             }
             else {
               label profile_trie_find_branch_right : (?V)
-              { rec(b.right, bitpos+1) }
+              { rec(b.right, bitpos + 1) }
             }
           };
         }
@@ -359,9 +359,9 @@ module {
 
 
 
-  func splitAssocList<K,V>(al : AssocList<Key<K>, V>, bitpos : Nat)
+  func splitAssocList<K, V>(al : AssocList<Key<K>, V>, bitpos : Nat)
      : (AssocList<Key<K>, V>, AssocList<Key<K>, V>) =
-   label profile_trie_splitAssocList : (AssocList<Key<K>, V>, AssocList<Key<K>,V>)
+   label profile_trie_splitAssocList : (AssocList<Key<K>, V>, AssocList<Key<K>, V>)
    {
      List.partition<(Key<K>, V)>(
        al,
@@ -379,12 +379,12 @@ module {
        label profile_trie_sized_split_rec : (Nat, AssocList<Key<K>, V>, Nat, AssocList<Key<K>, V>) {
          switch l {
            case null { (0, null, 0, null) };
-           case (?((k,v),t)) {
+           case (?((k, v), t)) {
              let (cl, l, cr, r) = rec(t) ;
              if (not Hash.bit(k.hash, bitpos)){
-               (cl + 1, ?((k,v),l), cr, r)
+               (cl + 1, ?((k, v), l), cr, r)
              } else {
-               (cl, l, cr + 1, ?((k,v),r))
+               (cl, l, cr + 1, ?((k, v), r))
              }
            };
          }
@@ -407,7 +407,7 @@ module {
   public func merge<K, V>(tl:Trie<K, V>, tr:Trie<K, V>, k_eq : (K, K) -> Bool) : Trie<K, V> =
     label profile_trie_merge : Trie<K, V> {
       let key_eq = equalKey<K>(k_eq);
-      func br(l : Trie<K, V>, r : Trie<K,V>) : Trie<K, V> = branch<K, V>(l, r);
+      func br(l : Trie<K, V>, r : Trie<K, V>) : Trie<K, V> = branch<K, V>(l, r);
       func rec(bitpos : Nat, tl : Trie<K, V>, tr:Trie<K, V>) : Trie<K, V> {
         func lf(kvs : AssocList<Key<K>, V>) : Trie<K, V> = leaf<K, V>(kvs, bitpos);
         switch (tl, tr) {
@@ -415,7 +415,7 @@ module {
           case (_, #empty) { return tl };
           case (#leaf(l1), #leaf(l2)) {
             lf(
-              AssocList.disj<Key<K>,V,V,V>(
+              AssocList.disj<Key<K>, V, V, V>(
                 l1.keyvals, l2.keyvals,
                 key_eq,
                 func (x:?V, y:?V):V {
@@ -452,14 +452,14 @@ module {
     label profile_trie_mergeDisjoint : Trie<K, V> {
       let key_eq = equalKey<K>(k_eq);
 
-      func br(l : Trie<K, V>, r : Trie<K, V>) : Trie<K, V> = branch<K, V>(l,r);
+      func br(l : Trie<K, V>, r : Trie<K, V>) : Trie<K, V> = branch<K, V>(l, r);
 
-      func rec(bitpos : Nat, tl : Trie<K,V>, tr : Trie<K,V>) : Trie<K,V> = label profile_trie_mergeDisjoint_rec : Trie<K, V> {
+      func rec(bitpos : Nat, tl : Trie<K, V>, tr : Trie<K, V>) : Trie<K, V> = label profile_trie_mergeDisjoint_rec : Trie<K, V> {
         func lf(kvs : AssocList<Key<K>, V>) : Trie<K, V> = leaf<K, V>(kvs, bitpos);
         switch (tl, tr) {
-          case (#empty, _) label profile_trie_mergeDisjoint_rec_emptyL : Trie<K,V> { return tr };
-          case (_, #empty) label profile_trie_mergeDisjoint_rec_emptyR : Trie<K,V> { return tl };
-          case (#leaf(l1), #leaf(l2)) label profile_trie_mergeDisjoint_rec_leafPair : Trie<K,V> {
+          case (#empty, _) label profile_trie_mergeDisjoint_rec_emptyL : Trie<K, V> { return tr };
+          case (_, #empty) label profile_trie_mergeDisjoint_rec_emptyR : Trie<K, V> { return tl };
+          case (#leaf(l1), #leaf(l2)) label profile_trie_mergeDisjoint_rec_leafPair : Trie<K, V> {
             lf(
               AssocList.disjDisjoint<Key<K>, V, V, V>(
                 l1.keyvals, l2.keyvals,
@@ -482,7 +482,7 @@ module {
             rec(bitpos, tl, br(lf(ll), lf(lr)))
           };
           case (#branch(b1), #branch(b2)) label profile_trie_mergeDisjoint_rec_branchPair : Trie<K, V> {
-            branch<K,V>(
+            branch<K, V>(
               rec(bitpos + 1, b1.left, b2.left),
               rec(bitpos + 1, b1.right, b2.right)
             )
@@ -499,11 +499,11 @@ module {
     let key_eq = equalKey<K>(k_eq);
 
     func br1(l : Trie<K, V>, r : Trie<K, V>) : Trie<K, V> = branch<K, V>(l, r);
-    func br2(l : Trie<K, W>, r : Trie<K,W>) : Trie<K, W> = branch<K, W>(l, r);
+    func br2(l : Trie<K, W>, r : Trie<K, W>) : Trie<K, W> = branch<K, W>(l, r);
 
     func rec(bitpos : Nat, tl : Trie<K, V>, tr : Trie<K, W>) : Trie<K, V> {
-      func lf1(kvs : AssocList<Key<K>, V>) : Trie<K,V> = leaf<K, V>(kvs, bitpos);
-      func lf2(kvs : AssocList<Key<K>, W>) : Trie<K,W> = leaf<K, W>(kvs, bitpos);
+      func lf1(kvs : AssocList<Key<K>, V>) : Trie<K, V> = leaf<K, V>(kvs, bitpos);
+      func lf2(kvs : AssocList<Key<K>, W>) : Trie<K, W> = leaf<K, W>(kvs, bitpos);
       switch (tl, tr) {
         case (#empty, _) { return #empty };
         case (_, #empty) { return tl };
@@ -557,11 +557,11 @@ module {
   ) : Trie<K, X> {
     let key_eq = equalKey<K>(k_eq);
 
-    func br1(l : Trie<K, V>, r : Trie<K, V>) : Trie<K,V> = branch<K, V>(l,r);
-    func br2(l : Trie<K, W>, r : Trie<K, W>) : Trie<K,W> = branch<K, W>(l,r);
+    func br1(l : Trie<K, V>, r : Trie<K, V>) : Trie<K, V> = branch<K, V>(l, r);
+    func br2(l : Trie<K, W>, r : Trie<K, W>) : Trie<K, W> = branch<K, W>(l, r);
 
-    func br3(l : Trie<K, X>, r : Trie<K, X>) : Trie<K,X> = branch<K, X>(l,r);
-    func lf3(kvs : AssocList<Key<K>, X>, bitpos : Nat) : Trie<K, X> = leaf<K,X>(kvs, bitpos);
+    func br3(l : Trie<K, X>, r : Trie<K, X>) : Trie<K, X> = branch<K, X>(l, r);
+    func lf3(kvs : AssocList<Key<K>, X>, bitpos : Nat) : Trie<K, X> = leaf<K, X>(kvs, bitpos);
 
     /* empty right case; build from left only: */
     func recL(t : Trie<K, V>, bitpos : Nat) : Trie<K, X> {
@@ -570,7 +570,7 @@ module {
         case (#leaf(l)) {
           lf3(AssocList.disj<Key<K>, V, W, X>(l.keyvals, null, key_eq, vbin), bitpos)
         };
-        case (#branch(b)) { br3(recL(b.left,bitpos+1),recL(b.right,bitpos+1)) };
+        case (#branch(b)) { br3(recL(b.left, bitpos + 1),recL(b.right, bitpos + 1)) };
       }
     };
 
@@ -581,7 +581,7 @@ module {
        case (#leaf(l)) {
          lf3(AssocList.disj<Key<K>, V, W, X>(null, l.keyvals, key_eq, vbin), bitpos)
        };
-       case (#branch(b)) { br3(recR(b.left,bitpos+1),recR(b.right,bitpos+1)) };
+       case (#branch(b)) { br3(recR(b.left, bitpos + 1),recR(b.right, bitpos + 1)) };
      }
    };
 
@@ -594,14 +594,14 @@ module {
        case (#empty, _   )   { recR(tr, bitpos) };
        case (_,    #empty)   { recL(tl, bitpos) };
        case (#leaf(l1), #leaf(l2)) {
-         lf3(AssocList.disj<Key<K>,V,W,X>(l1.keyvals, l2.keyvals, key_eq, vbin), bitpos)
+         lf3(AssocList.disj<Key<K>, V, W, X>(l1.keyvals, l2.keyvals, key_eq, vbin), bitpos)
        };
        case (#leaf(l), _) {
-         let (ll, lr) = splitAssocList<K,V>(l.keyvals, bitpos);
+         let (ll, lr) = splitAssocList<K, V>(l.keyvals, bitpos);
          rec(bitpos, br1(lf1(ll), lf1(lr)), tr)
        };
        case (_, #leaf(l)) {
-         let (ll, lr) = splitAssocList<K,W>(l.keyvals, bitpos);
+         let (ll, lr) = splitAssocList<K, W>(l.keyvals, bitpos);
          rec(bitpos, tl, br2(lf2(ll), lf2(lr)))
        };
        case (#branch(b1), #branch(b2)) {
@@ -631,31 +631,31 @@ module {
     tr : Trie<K, W>,
     k_eq : (K, K)->Bool,
     vbin: (V, W)->X
-  ) : Trie<K,X> =
-  label profile_trie_join : Trie<K,X> {
+  ) : Trie<K, X> =
+  label profile_trie_join : Trie<K, X> {
     let key_eq = equalKey<K>(k_eq);
 
     func br1(l : Trie<K, V>, r : Trie<K, V>) : Trie<K, V> = branch<K, V>(l, r);
     func br2(l : Trie<K, W>, r : Trie<K, W>) : Trie<K, W> = branch<K, W>(l, r);
     func br3(l : Trie<K, X>, r : Trie<K, X>) : Trie<K, X> = branch<K, X>(l, r);
 
-    func rec(bitpos:Nat, tl:Trie<K,V>, tr:Trie<K,W>) : Trie<K,X> = label profile_trie_join_rec : Trie<K,X> {
-      func lf1(kvs:AssocList<Key<K>,V>) : Trie<K,V> = leaf<K,V>(kvs, bitpos);
-      func lf2(kvs:AssocList<Key<K>,W>) : Trie<K,W> = leaf<K,W>(kvs, bitpos);
-      func lf3(kvs:AssocList<Key<K>,X>) : Trie<K,X> = leaf<K,X>(kvs, bitpos);
+    func rec(bitpos : Nat, tl : Trie<K, V>, tr : Trie<K, W>) : Trie<K, X> = label profile_trie_join_rec : Trie<K, X> {
+      func lf1(kvs : AssocList<Key<K>, V>) : Trie<K, V> = leaf<K, V>(kvs, bitpos);
+      func lf2(kvs : AssocList<Key<K>, W>) : Trie<K, W> = leaf<K, W>(kvs, bitpos);
+      func lf3(kvs : AssocList<Key<K>, X>) : Trie<K, X> = leaf<K, X>(kvs, bitpos);
 
       switch (tl, tr) {
         case (#empty, _) { #empty };
         case (_, #empty) { #empty };
         case (#leaf(l1), #leaf(l2)) {
-          lf3(AssocList.join<Key<K>,V,W,X>(l1.keyvals, l2.keyvals, key_eq, vbin))
+          lf3(AssocList.join<Key<K>, V, W, X>(l1.keyvals, l2.keyvals, key_eq, vbin))
         };
         case (#leaf(l), _) {
-          let (ll, lr) = splitAssocList<K,V>(l.keyvals, bitpos);
+          let (ll, lr) = splitAssocList<K, V>(l.keyvals, bitpos);
           rec(bitpos, br1(lf1(ll), lf1(lr)), tr)
         };
         case (_, #leaf(l)) {
-          let (ll, lr) = splitAssocList<K,W>(l.keyvals, bitpos);
+          let (ll, lr) = splitAssocList<K, W>(l.keyvals, bitpos);
           rec(bitpos, tl, br2(lf2(ll), lf2(lr)))
         };
         case (#branch(b1), #branch(b2)) {
@@ -679,7 +679,7 @@ module {
         case (#leaf(l)) {
           AssocList.fold<Key<K>, V, X>(
             l.keyvals, empty,
-            func (k : Key<K>, v : V, x : X) :X { bin(leaf(k.key,v),x) }
+            func (k : Key<K>, v : V, x : X) :X { bin(leaf(k.key, v), x) }
           )
         };
         case (#branch(b)) { bin(rec(b.left), rec(b.right)) };
@@ -708,16 +708,16 @@ module {
     tr : Trie<K2, V2>,
     op : (K1, V1, K2, V2) -> ?(Key<K3>, V3),
     k3_eq : (K3, K3) -> Bool
-  )  : Trie<K3,V3>  {
+  )  : Trie<K3, V3>  {
 
     /*- binary case: merge disjoint results: */
-    func merge (a:Trie<K3,V3>, b:Trie<K3,V3>) : Trie<K3,V3> =
-      mergeDisjoint<K3,V3>(a, b, k3_eq);
+    func merge (a:Trie<K3, V3>, b:Trie<K3, V3>) : Trie<K3, V3> =
+      mergeDisjoint<K3, V3>(a, b, k3_eq);
 
     /*- "`foldUp` squared" (imagine two nested loops): */
     foldUp<K1, V1, Trie<K3, V3>>(
       tl, merge,
-      func (k1:K1, v1:V1) : Trie<K3,V3> {
+      func (k1:K1, v1:V1) : Trie<K3, V3> {
         foldUp<K2, V2, Trie<K3, V3>>(
           tr, merge,
           func (k2:K2, v2:V2) : Trie<K3, V3> {
@@ -774,8 +774,8 @@ module {
 
     /// Build sequence of two sub-builds
     public func seq<K, V>(l : Build<K, V>, r : Build<K, V>) : Build<K, V> =
-      label profile_trie_seq : Build<K,V> {
-        let sum = size<K,V>(l) + size<K,V>(r);
+      label profile_trie_seq : Build<K, V> {
+        let sum = size<K, V>(l) + size<K, V>(r);
         #seq({ size = sum; left = l; right = r })
       };
 
@@ -786,17 +786,17 @@ module {
       tl : Trie<K1, V1>,
       tr : Trie<K2, V2>,
       op : (K1, V1, K2, V2) -> ?(K3, V3),
-      k3_eq :(K3,K3) -> Bool
-    ) : Build<K3,V3> {
+      k3_eq : (K3, K3) -> Bool
+    ) : Build<K3, V3> {
 
       func outer_bin (a : Build<K3, V3>, b : Build<K3, V3>)
-        : Build<K3,V3> =
-        label profile_trie_prod_outer_seqOfBranch : Build<K3,V3> {
+        : Build<K3, V3> =
+        label profile_trie_prod_outer_seqOfBranch : Build<K3, V3> {
           seq<K3, V3>(a, b)
         };
 
       func inner_bin (a : Build<K3, V3>, b : Build<K3, V3>)
-        : Build<K3,V3> =
+        : Build<K3, V3> =
         label profile_trie_prod_inner_seqOfBranch : Build<K3, V3> {
           seq<K3, V3>(a, b)
         };
@@ -825,22 +825,22 @@ module {
     /// This position is meaningful only when the build contains multiple uses of one or more keys, otherwise it is not.
     public func nth<K, V>(tb : Build<K, V>, i : Nat) : ?(K, ?Hash.Hash, V) =
       label profile_triebuild_nth : (?(K, ?Hash.Hash, V)) {
-        func rec(tb:Build<K,V>, i:Nat) : ?(K, ?Hash.Hash, V) = label profile_triebuild_nth_rec : (?(K, ?Hash.Hash, V)) {
+        func rec(tb:Build<K, V>, i:Nat) : ?(K, ?Hash.Hash, V) = label profile_triebuild_nth_rec : (?(K, ?Hash.Hash, V)) {
           switch tb {
             case (#skip) { P.unreachable() };
-            case (#put (k,h,v)) label profile_trie_nth_rec_end : (?(K, ?Hash.Hash, V)) {
+            case (#put (k, h, v)) label profile_trie_nth_rec_end : (?(K, ?Hash.Hash, V)) {
               assert(i == 0);
-              ?(k,h,v)
+              ?(k, h, v)
              };
              case (#seq(s)) label profile_trie_nth_rec_seq : (?(K, ?Hash.Hash, V)) {
-               let size_left = size<K,V>(s.left);
+               let size_left = size<K, V>(s.left);
                if (i < size_left) { rec(s.left,  i) }
                else { rec(s.right, i - size_left) }
              };
           }
         };
 
-        if (i >= size<K,V>(tb)) {
+        if (i >= size<K, V>(tb)) {
           return null
         };
         rec(tb, i)
@@ -850,10 +850,10 @@ module {
     /// work of actually merging any tries; rather, just record the work for
     /// latter (if ever).
     public func projectInner<K1, K2, V>(t : Trie<K1, Build<K2, V>>)
-      : Build<K2,V> {
+      : Build<K2, V> {
       foldUp<K1, Build<K2, V>, Build<K2, V>>(
         t,
-        func (t1 : Build<K2, V>, t2 : Build<K2, V>) : Build<K2 ,V> { seq<K2, V>(t1, t2) },
+        func (t1 : Build<K2, V>, t2 : Build<K2, V>) : Build<K2, V> { seq<K2, V>(t1, t2) },
         func (_ : K1, t : Build<K2, V>): Build<K2, V> { t },
         #skip
       )
@@ -861,13 +861,13 @@ module {
 
     /// Gather the collection of key-value pairs into an array of a (possibly-distinct) type.
     public func toArray<K, V, W>(tb : Build<K, V>, f: (K, V) -> W) : [W] {
-      let c = size<K,V>(tb);
+      let c = size<K, V>(tb);
       let a = A.init<?W>(c, null);
       var i = 0;
-      func rec(tb:Build<K,V>) = label profile_triebuild_toArray2_rec {
+      func rec(tb:Build<K, V>) = label profile_triebuild_toArray2_rec {
         switch tb {
           case (#skip) {};
-          case (#put(k,_,v)) { a[i] := ?f(k,v); i := i + 1 };
+          case (#put(k, _, v)) { a[i] := ?f(k, v); i := i + 1 };
           case (#seq(s)) { rec(s.left); rec(s.right) };
         }
       };
@@ -880,7 +880,7 @@ module {
   /// Fold over the key-value pairs of the trie, using an accumulator.
   /// The key-value pairs have no reliable or meaningful ordering.
   public func fold<K, V, X>(t : Trie<K, V>, f : (K, V, X) -> X, x : X) : X {
-    func rec(t:Trie<K,V>, x:X) : X {
+    func rec(t:Trie<K, V>, x:X) : X {
       switch t {
         case (#empty) { x };
         case (#leaf(l)) {
@@ -889,7 +889,7 @@ module {
            func (k : Key<K>, v : V, x : X) : X = f(k.key, v, x)
           )
         };
-        case (#branch(b)) { rec(b.left, rec(b.right,x)) };
+        case (#branch(b)) { rec(b.left, rec(b.right, x)) };
       };
     };
     rec(t, x)
@@ -901,8 +901,8 @@ module {
       switch t {
         case (#empty) { false };
         case (#leaf(l)) {
-          List.some<(Key<K>,V)>(
-            l.keyvals, func ((k:Key<K>,v:V)):Bool=f(k.key,v)
+          List.some<(Key<K>, V)>(
+            l.keyvals, func ((k:Key<K>, v:V)):Bool=f(k.key, v)
           )
         };
         case (#branch(b)) { rec(b.left) or rec(b.right) };
@@ -912,13 +912,13 @@ module {
   };
 
   /// Test whether all key-value pairs have a given property.
-  public func all<K,V>(t : Trie<K, V>, f : (K, V) -> Bool) : Bool {
+  public func all<K, V>(t : Trie<K, V>, f : (K, V) -> Bool) : Bool {
     func rec(t:Trie<K, V>) : Bool {
       switch t {
         case (#empty) { true };
         case (#leaf(l)) {
           List.all<(Key<K>, V)>(
-            l.keyvals, func ((k : Key<K>, v : V)) : Bool=f(k.key,v)
+            l.keyvals, func ((k : Key<K>, v : V)) : Bool=f(k.key, v)
           )
         };
         case (#branch(b)) { rec(b.left) and rec(b.right) };
@@ -931,20 +931,20 @@ module {
   ///
   /// Note: This position is not meaningful; it's only here so that we
   /// can inject tries into arrays using functions like `Array.tabulate`.
-  public func nth<K,V>(t : Trie<K, V>, i : Nat) : ?(Key<K>, V) =
+  public func nth<K, V>(t : Trie<K, V>, i : Nat) : ?(Key<K>, V) =
     label profile_trie_nth : (?(Key<K>, V)) {
-      func rec(t:Trie<K,V>, i:Nat) : ?(Key<K>, V) = label profile_trie_nth_rec : (?(Key<K>, V)) {
+      func rec(t:Trie<K, V>, i:Nat) : ?(Key<K>, V) = label profile_trie_nth_rec : (?(Key<K>, V)) {
         switch t {
           case (#empty) { P.unreachable() };
-          case (#leaf(l)) { List.get<(Key<K>,V)>(l.keyvals, i) };
+          case (#leaf(l)) { List.get<(Key<K>, V)>(l.keyvals, i) };
           case (#branch(b)) {
-            let size_left = size<K,V>(b.left);
+            let size_left = size<K, V>(b.left);
             if (i < size_left) { rec(b.left,  i) }
             else { rec(b.right, i - size_left) }
           }
         }
       };
-      if (i >= size<K,V>(t)) {
+      if (i >= size<K, V>(t)) {
         return null
       };
       rec(t, i)
@@ -976,9 +976,9 @@ module {
   public func toArray<K, V, W>(t : Trie<K, V>, f : (K, V)-> W):[W] =
     label profile_trie_toArray_begin : [W] {
       let a = A.tabulate<W> (
-        size<K,V>(t),
+        size<K, V>(t),
         func (i:Nat) : W = label profile_trie_toArray_nth : W {
-          let (k,v) = Option.unwrap<(Key<K>, V)>(nth<K, V>(t, i));
+          let (k, v) = Option.unwrap<(Key<K>, V)>(nth<K, V>(t, i));
           f(k.key, v)
         }
       );
@@ -995,26 +995,26 @@ module {
 
   /// filter the key-value pairs by a given predicate.
   public func filter<K, V>(t : Trie<K, V>, f : (K, V) -> Bool) : Trie<K, V> {
-    func rec(t : Trie<K, V>, bitpos : Nat) : Trie<K,V> {
+    func rec(t : Trie<K, V>, bitpos : Nat) : Trie<K, V> {
       switch t {
         case (#empty) { #empty };
         case (#leaf(l)) {
-          leaf<K,V>(
+          leaf<K, V>(
             List.filter<(Key<K>, V)>(
               l.keyvals,
-              func ((k : Key<K>, v : V)) : Bool = f(k.key,v)
+              func ((k : Key<K>, v : V)) : Bool = f(k.key, v)
             ),
             bitpos
           )
         };
         case (#branch(b)) {
-          let fl = rec(b.left, bitpos+1);
-          let fr = rec(b.right, bitpos+1);
-          switch (isEmpty<K,V>(fl), isEmpty<K,V>(fr)) {
+          let fl = rec(b.left, bitpos + 1);
+          let fr = rec(b.right, bitpos + 1);
+          switch (isEmpty<K, V>(fl), isEmpty<K, V>(fr)) {
             case (true, true) { #empty };
             case (false, true) { fr };
             case (true, false) { fl };
-            case (false, false) { branch<K,V>(fl, fr) };
+            case (false, false) { branch<K, V>(fl, fr) };
           };
         }
       }
@@ -1024,12 +1024,12 @@ module {
 
   /// map and filter the key-value pairs by a given predicate.
   public func mapFilter<K, V, W>(t : Trie<K, V>, f : (K, V) -> ?W) : Trie<K, W> {
-    func rec(t:Trie<K,V>, bitpos:Nat) : Trie<K,W> {
+    func rec(t : Trie<K, V>, bitpos : Nat) : Trie<K, W> {
       switch t {
         case (#empty) { #empty };
         case (#leaf(l)) {
-          leaf<K,W>(
-            List.mapFilter<(Key<K>,V),(Key<K>,W)>(
+          leaf<K, W>(
+            List.mapFilter<(Key<K>, V),(Key<K>, W)>(
               l.keyvals,
               // retain key and hash, but update key's value using f:
               func ((k : Key<K>, v : V)) : ?(Key<K>, W) {
@@ -1075,9 +1075,9 @@ module {
       switch (tl, tr) {
         case (#empty, #empty) { true };
         case (#leaf(l1), #leaf(l2)) {
-          List.equal<(Key<K>,V)>(l1.keyvals, l2.keyvals,
-            func ((k1:Key<K>, v1:V), (k2:Key<K>, v2:V)) : Bool =
-              keq(k1.key, k2.key) and veq(v1,v2)
+          List.equal<(Key<K>, V)>(l1.keyvals, l2.keyvals,
+            func ((k1 : Key<K>, v1 : V), (k2 : Key<K>, v2 : V)) : Bool =
+              keq(k1.key, k2.key) and veq(v1, v2)
           )
         };
         case (#branch(b1),#branch(b2)) {
@@ -1092,12 +1092,12 @@ module {
   /// replace the given key's value in the trie,
   /// and only if successful, do the success continuation,
   /// otherwise, return the failure value
-  public func replaceThen<K,V,X>(
+  public func replaceThen<K, V, X>(
     t : Trie<K, V>, k : Key<K>, k_eq : (K, K) -> Bool, v2 : V,
     success: (Trie<K, V>, V) -> X,
     fail: () -> X
   ) : X {
-    let (t2, ov) = replace<K,V>(t, k, k_eq, ?v2);
+    let (t2, ov) = replace<K, V>(t, k, k_eq, ?v2);
     switch ov {
       case (null) { /* no prior value; failure to remove */ fail() };
       case (?v1) { success(t2, v1) };
@@ -1120,10 +1120,10 @@ module {
     k1 : Key<K1>,
     k1_eq : (K1, K1)->Bool,
     k2 : Key<K2>,
-    k2_eq : (K2,K2)->Bool,
+    k2_eq : (K2, K2)->Bool,
     v:V
   ) : Trie2D<K1, K2, V> {
-    let inner = find<K1,Trie<K2, V>>(t, k1, k1_eq);
+    let inner = find<K1, Trie<K2, V>>(t, k1, k1_eq);
     let (updated_inner, _) = switch inner {
       case (null)   { put<K2, V>(#empty, k2, k2_eq, v) };
       case (?inner) { put<K2, V>(inner, k2, k2_eq, v) };
@@ -1142,14 +1142,14 @@ module {
     k3 : Key<K3>,
     k3_eq : (K3, K3)->Bool,
     v : V
-  ) : Trie3D<K1,K2,K3,V> {
+  ) : Trie3D<K1, K2, K3, V> {
     let inner1 = find<K1, Trie2D<K2, K3, V>>(t, k1, k1_eq);
     let (updated_inner1, _) = switch inner1 {
       case (null) {
         put<K2, Trie<K3, V>>(
           #empty, k2, k2_eq,
-           (put<K3,V>(#empty, k3, k3_eq, v)).0
-             )
+           (put<K3, V>(#empty, k3, k3_eq, v)).0
+        )
       };
       case (?inner1) {
         let inner2 = find<K2, Trie<K3, V>>(inner1, k2, k2_eq);
@@ -1157,7 +1157,7 @@ module {
           case (null) { put<K3, V>(#empty, k3, k3_eq, v) };
           case (?inner2) { put<K3, V>(inner2, k3, k3_eq, v) };
         };
-        put<K2,Trie<K3,V>>( inner1, k2, k2_eq, updated_inner2 )
+        put<K2, Trie<K3, V>>(inner1, k2, k2_eq, updated_inner2 )
       };
     };
     let (updated_outer, _) = put<K1, Trie2D<K2, K3, V>>(t, k1, k1_eq, updated_inner1);
@@ -1165,8 +1165,8 @@ module {
   };
 
   /// remove the given key's value in the trie; return the new trie
-  public func remove<K,V>(t : Trie<K,V>, k : Key<K>, k_eq: (K, K) -> Bool) : (Trie<K, V>, ?V) {
-    replace<K,V>(t, k, k_eq, null)
+  public func remove<K, V>(t : Trie<K, V>, k : Key<K>, k_eq: (K, K) -> Bool) : (Trie<K, V>, ?V) {
+    replace<K, V>(t, k, k_eq, null)
   };
 
   /// remove the given key's value in the trie,
@@ -1176,7 +1176,7 @@ module {
     t : Trie<K, V>,
     k : Key<K>,
     k_eq: (K, K) -> Bool,
-    success: (Trie<K,V>, V) -> X,
+    success: (Trie<K, V>, V) -> X,
     fail: () -> X
   ) : X {
     let (t2, ov) = replace<K, V>(t, k, k_eq, null);
@@ -1196,13 +1196,13 @@ module {
     k2 : Key<K2>,
     k2_eq: (K2, K2) -> Bool
   ) : (Trie2D<K1, K2, V>, ?V)  {
-    switch (find<K1,Trie<K2,V>>(t, k1, k1_eq)) {
+    switch (find<K1, Trie<K2, V>>(t, k1, k1_eq)) {
       case (null)   {
-         (t, null)
+        (t, null)
       };
       case (?inner) {
-        let (updated_inner, ov) = remove<K2,V>(inner, k2, k2_eq);
-        let (updated_outer, _) = put<K1,Trie<K2,V>>(t, k1, k1_eq, updated_inner);
+        let (updated_inner, ov) = remove<K2, V>(inner, k2, k2_eq);
+        let (updated_outer, _) = put<K1, Trie<K2, V>>(t, k1, k1_eq, updated_inner);
         (updated_outer, ov)
       };
     }
@@ -1216,8 +1216,8 @@ module {
     k1_eq : (K1, K1) -> Bool,
     k2 : Key<K2>,
     k2_eq: (K2, K2) -> Bool,
-    k3:Key<K3>, k3_eq : (K3, K3)->Bool,
-   ) : (Trie3D<K1, K2, K3, V>, ?V) {
+    k3:Key<K3>, k3_eq : (K3, K3) -> Bool,
+  ) : (Trie3D<K1, K2, K3, V>, ?V) {
     switch (find<K1, Trie2D<K2, K3, V>>(t, k1, k1_eq)) {
       case (null)   {
         (t, null)
@@ -1237,11 +1237,13 @@ module {
     t : Trie2D<K1, K2, V>,
     k1_eq : (K1, K1) -> Bool,
     k2_eq : (K2, K2) -> Bool
-  ) : Trie<K2,V> {
+  ) : Trie<K2, V> {
     foldUp<K1, Trie<K2, V>, Trie<K2, V>>(
       t,
-      func (t1 : Trie<K2, V>, t2 : Trie<K2, V>) : Trie<K2, V> { mergeDisjoint<K2, V>(t1, t2, k2_eq) },
-      func (_ : K1, t : Trie<K2, V>): Trie<K2, V> { t },
+      func (t1 : Trie<K2, V>, t2 : Trie<K2, V>) : Trie<K2, V> {
+        mergeDisjoint<K2, V>(t1, t2, k2_eq)
+      },
+      func (_ : K1, t : Trie<K2, V>) : Trie<K2, V> { t },
       #empty
     )
   };

--- a/src/Trie.mo
+++ b/src/Trie.mo
@@ -140,8 +140,7 @@ module {
                  }
                )
           // or
-          // (do { Prim.debugPrint("one or more hashes are malformed"); false }
-            )
+          // (do { Prim.debugPrint("one or more hashes are malformed"); false })
           )
         };
         case (#branch(b)) {

--- a/src/Trie.mo
+++ b/src/Trie.mo
@@ -251,7 +251,7 @@ module {
               return #leaf({size=len; keyvals=kvs})
             };
           }
-      	};
+        };
         case (?c) {
           if ( c == 0 ) {
             return #empty
@@ -420,7 +420,7 @@ module {
                     case (null, ?v) { v };
                     case (?v, _) { v };
                   }
-	        }
+                }
               )
             )
           };
@@ -1033,7 +1033,7 @@ module {
                   case (null) { null };
                   case (?w) { ?({key = k.key; hash = k.hash}, w) };
                 }
-	      }
+              }
             ),
             bitpos
           )

--- a/src/Trie.mo
+++ b/src/Trie.mo
@@ -19,280 +19,281 @@ import AssocList "AssocList";
 
 module {
 
-///
-/// ## Representation
-///
-///
-/// A hash trie is a binary trie, where each (internal) branch node
-/// represents having distinguished its key-value pairs on a single bit of
-/// the keys.
-///
-/// By following paths in the trie, we determine an increasingly smaller
-/// and smaller subset of the keys.
-///
-/// Each leaf node consists of an association list of key-value pairs.
-///
-/// We say that a leaf is valid if it contains no more than MAX_LEAF_SIZE
-/// key-value pairs.
-///
-/// Each non-empty trie node stores a size; we discuss that more below.
-///
-/// ### Adaptive depth
-///
-/// For small mappings, the trie structure consists of a single
-/// leaf, which contains up to MAX_LEAF_SIZE key-value pairs.
-///
-/// By construction, the algorithms enforce an invariant that no
-/// leaf ever contains more than MAX_LEAF_SIZE key-value pairs: the
-/// function `leaf` accepts a list, but subdivides it with branches until
-/// it can actually construct valid leaves.  Ongce distinguished, subsets
-/// of keys tend to remain distinguished by the presence of these branches.
-///
-/// ### Cached sizes
-///
-/// At each branch and leaf, we use a stored size to support a
-/// memory-efficient `toArray` function, which itself relies on
-/// per-element projection via `nth`; in turn, `nth` directly uses the
-/// O(1)-time function `size` for achieving an acceptable level of
-/// algorithmic efficiently.  Notably, leaves are generally lists of
-/// key-value pairs, and we do not store a size for each Cons cell in the
-/// list.
-///
+  ///
+  /// ## Representation
+  ///
+  ///
+  /// A hash trie is a binary trie, where each (internal) branch node
+  /// represents having distinguished its key-value pairs on a single bit of
+  /// the keys.
+  ///
+  /// By following paths in the trie, we determine an increasingly smaller
+  /// and smaller subset of the keys.
+  ///
+  /// Each leaf node consists of an association list of key-value pairs.
+  ///
+  /// We say that a leaf is valid if it contains no more than MAX_LEAF_SIZE
+  /// key-value pairs.
+  ///
+  /// Each non-empty trie node stores a size; we discuss that more below.
+  ///
+  /// ### Adaptive depth
+  ///
+  /// For small mappings, the trie structure consists of a single
+  /// leaf, which contains up to MAX_LEAF_SIZE key-value pairs.
+  ///
+  /// By construction, the algorithms enforce an invariant that no
+  /// leaf ever contains more than MAX_LEAF_SIZE key-value pairs: the
+  /// function `leaf` accepts a list, but subdivides it with branches until
+  /// it can actually construct valid leaves.  Ongce distinguished, subsets
+  /// of keys tend to remain distinguished by the presence of these branches.
+  ///
+  /// ### Cached sizes
+  ///
+  /// At each branch and leaf, we use a stored size to support a
+  /// memory-efficient `toArray` function, which itself relies on
+  /// per-element projection via `nth`; in turn, `nth` directly uses the
+  /// O(1)-time function `size` for achieving an acceptable level of
+  /// algorithmic efficiently.  Notably, leaves are generally lists of
+  /// key-value pairs, and we do not store a size for each Cons cell in the
+  /// list.
+  ///
 
-let MAX_LEAF_SIZE = 8; // to do -- further profiling and tuning
+  let MAX_LEAF_SIZE = 8; // to do -- further profiling and tuning
 
-/// binary hash tries: either empty, a leaf node, or a branch node
-public type Trie<K,V> = {
-  #empty  ;
-  #leaf   : Leaf<K,V> ;
-  #branch : Branch<K,V> ;
-};
+  /// binary hash tries: either empty, a leaf node, or a branch node
+  public type Trie<K, V> = {
+    #empty;
+    #leaf : Leaf<K, V>;
+    #branch : Branch<K, V>;
+  };
 
-/// leaf nodes of trie consist of key-value pairs as a list.
-public type Leaf<K,V> = {
-  size   : Nat ;
-  keyvals : AssocList<Key<K>,V> ;
-};
+  /// leaf nodes of trie consist of key-value pairs as a list.
+  public type Leaf<K, V> = {
+    size : Nat ;
+    keyvals : AssocList<Key<K>, V> ;
+  };
 
-/// branch nodes of the trie discriminate on a bit position of the keys' hashes.
-/// we never store this bitpos; rather,
-/// we enforce a style where this position is always known from context.
-public type Branch<K,V> = {
-  size : Nat ;
-  left  : Trie<K,V> ;
-  right : Trie<K,V> ;
-};
+  /// branch nodes of the trie discriminate on a bit position of the keys' hashes.
+  /// we never store this bitpos; rather,
+  /// we enforce a style where this position is always known from context.
+  public type Branch<K, V> = {
+    size : Nat;
+    left : Trie<K, V>;
+    right : Trie<K, V>;
+  };
 
-public type AssocList<K,V> = AssocList.AssocList<K,V>;
+  public type AssocList<K, V> = AssocList.AssocList<K, V>;
 
-//// A `Key` for the trie has an associated hash value
-public type Key<K> = {
-  /// `hash` permits fast inequality checks, and permits collisions
-  hash: Hash.Hash;
-  /// `key` permits percise equality checks, but only used after equal hashes.
-  key: K;
-};
+  //// A `Key` for the trie has an associated hash value
+  public type Key<K> = {
+    /// `hash` permits fast inequality checks, and permits collisions
+    hash: Hash.Hash;
+    /// `key` permits percise equality checks, but only used after equal hashes.
+    key: K;
+  };
 
-type List<T> = List.List<T>;
+  type List<T> = List.List<T>;
 
-/// Equality function for two `Key<K>`s, in terms of equality of `K`'s.
-public func equalKey<K>(keq:(K,K) -> Bool) : ((Key<K>,Key<K>) -> Bool) {
-  func (key1:Key<K>, key2:Key<K>) : Bool {
-    label profile_trie_equalKey : Bool {
-      Hash.equal(key1.hash, key2.hash) and keq(key1.key, key2.key)
-    }
-  }
-};
-
-/// checks the invariants of the trie structure, including the placement of keys at trie paths
-public func isValid<K,V> (t:Trie<K,V>, enforceNormal:Bool) : Bool {
-  func rec(t:Trie<K,V>, bitpos:?Hash.Hash, bits:Hash.Hash, mask:Hash.Hash) : Bool {
-    switch t {
-    case (#empty) {
-           switch bitpos {
-             case null { true };
-             case (?_) { not enforceNormal };
-           }
-         };
-    case (#leaf(l)) {
-           let len = List.size<(Key<K>,V)>(l.keyvals);
-           ((len <= MAX_LEAF_SIZE) or (not enforceNormal))
-           and
-           len == l.size
-           and
-           ( List.all<(Key<K>,V)>(
-               l.keyvals,
-               func ((k:Key<K>,v:V)):Bool{
-                 //{ Prim.debugPrint "testing hash..."; true }
-                 //and
-                 ((k.hash & mask) == bits)
-                 or
-                 (do { Prim.debugPrint("\nmalformed hash!:\n");
-                     Prim.debugPrintInt(Prim.nat32ToNat(k.hash));
-                     Prim.debugPrint("\n (key hash) != (path bits): \n");
-                     Prim.debugPrintInt(Prim.nat32ToNat(bits));
-                     Prim.debugPrint("\nmask  : ");
-                     Prim.debugPrintInt(Prim.nat32ToNat(mask));
-                     Prim.debugPrint("\n");
-                     false 
-                   })
-               }
-             ) or
-           (do { Prim.debugPrint("one or more hashes are malformed"); false })
-           )
-         };
-    case (#branch(b)) {
-           let bitpos1 = switch bitpos {
-           case null  {Prim.natToNat32(0)};
-           case (?bp) {Prim.natToNat32(Prim.nat32ToNat(bp) + 1)}
-           };
-           let mask1 = mask | (Prim.natToNat32(1) << bitpos1);
-           let bits1 = bits | (Prim.natToNat32(1) << bitpos1);
-           let sum = size<K,V>(b.left) + size<K,V>(b.right);
-           (b.size == sum or (do { Prim.debugPrint("malformed size"); false }))
-           and
-           rec(b.left,  ?bitpos1, bits,  mask1)
-           and
-           rec(b.right, ?bitpos1, bits1, mask1)
-         };
+  /// Equality function for two `Key<K>`s, in terms of equality of `K`'s.
+  public func equalKey<K>(keq : (K, K) -> Bool) : ((Key<K>, Key<K>) -> Bool) {
+    func (key1 : Key<K>, key2 : Key<K>) : Bool {
+      label profile_trie_equalKey : Bool {
+        Hash.equal(key1.hash, key2.hash) and keq(key1.key, key2.key)
+      }
     }
   };
-  rec(t, null, 0, 0)
-};
 
-
-/// A 2D trie maps dimension-1 keys to another
-/// layer of tries, each keyed on the dimension-2 keys.
-public type Trie2D<K1, K2, V> = Trie<K1, Trie<K2,V> >;
-
-/// A 3D trie maps dimension-1 keys to another
-/// layer of 2D tries, each keyed on the dimension-2 and dimension-3 keys.
-public type Trie3D<K1, K2, K3, V> = Trie<K1, Trie2D<K2, K3, V> >;
-
-/// An empty trie.
-public func empty<K,V>() : Trie<K,V> =
-   #empty;
-
-///  Get the number of key-value pairs in the trie, in constant time.
-
-//  ### Implementation notes
-//
-//  `nth` directly uses this function `size` for achieving an
-//  acceptable level of algorithmic efficiently.
-public func size<K,V>(t: Trie<K,V>) : Nat = label profile_trie_size : Nat {
-   switch t {
-     case (#empty) { 0 };
-     case (#leaf(l)) { l.size };
-     case (#branch(b)) { b.size };
-   }
- };
-
-/// Construct a branch node, computing the size stored there.
-public func branch<K,V>(l:Trie<K,V>, r:Trie<K,V>) : Trie<K,V> = label profile_trie_branch : Trie<K,V> {
-   let sum = size<K,V>(l) + size<K,V>(r);
-   #branch(
-     {
-       size=sum;
-       left=l;
-       right=r
-     }
-   );
- };
-
-/// Construct a leaf node, computing the size stored there.
-///
-/// This helper function automatically enforces the MAX_LEAF_SIZE
-/// by constructing branches as necessary; to do so, it also needs the bitpos
-/// of the leaf.
-public func leaf<K,V>(kvs:AssocList<Key<K>,V>, bitpos:Nat) : Trie<K,V> = label trie_leaf : Trie<K,V> {
-   fromList<K,V>(null, kvs, bitpos)
- };
-
-module ListUtil {
-  /* Deprecated: List.lenIsEqLessThan */
-  /// Test the list length against a maximum value and return true if
-  /// the list length is less than or equal to the value specified.
-  public func lenIsEqLessThan<T>(l : List <T>, i : Nat) : Bool {
-    switch l {
-      case null { true };
-      case (?(_, t)) {
-        if (i == 0) { false }
-        else { lenIsEqLessThan<T>(t, i - 1) }
-      };
-    };
-  };
-  /* Deprecated: List.lenClamp */
-  /// Return the list length unless the number of items in the list exceeds
-  /// a maximum value. If the list length exceed the maximum, the function
-  /// returns `null`.
-  public func lenClamp<T>(l : List<T>, max : Nat) : ?Nat {
-    func rec(l : List<T>, max : Nat, i : Nat) : ?Nat {
-      switch l {
-        case null { ?i };
-        case (?(_, t)) {
-          if ( i > max ) { null }
-          else { rec(t, max, i + 1) }
+  /// checks the invariants of the trie structure, including the placement of keys at trie paths
+  public func isValid<K, V>(t : Trie<K, V>, enforceNormal : Bool) : Bool {
+    func rec(t : Trie<K, V>, bitpos : ?Hash.Hash, bits : Hash.Hash, mask : Hash.Hash) : Bool {
+      switch t {
+        case (#empty) {
+          switch bitpos {
+            case null { true };
+            case (?_) { not enforceNormal };
+          }
+        };
+        case (#leaf(l)) {
+          let len = List.size<(Key<K>,V)>(l.keyvals);
+          ((len <= MAX_LEAF_SIZE) or (not enforceNormal))
+          and
+          len == l.size
+          and
+          ( List.all<(Key<K>, V)>(
+              l.keyvals,
+              func ((k:Key<K>, v:V)) : Bool {
+                //{ Prim.debugPrint "testing hash..."; true }
+                //and
+                ((k.hash & mask) == bits)
+                or
+                (do { Prim.debugPrint("\nmalformed hash!:\n");
+                   Prim.debugPrintInt(Prim.nat32ToNat(k.hash));
+                   Prim.debugPrint("\n (key hash) != (path bits): \n");
+                   Prim.debugPrintInt(Prim.nat32ToNat(bits));
+                   Prim.debugPrint("\nmask  : ");
+                   Prim.debugPrintInt(Prim.nat32ToNat(mask));
+                   Prim.debugPrint("\n");
+                   false
+                 })
+                 }
+               )
+            or
+            (do { Prim.debugPrint("one or more hashes are malformed"); false })
+          )
+        };
+        case (#branch(b)) {
+          let bitpos1 =
+            switch bitpos {
+              case null  {Prim.natToNat32(0)};
+              case (?bp) {Prim.natToNat32(Prim.nat32ToNat(bp) + 1)}
+            };
+          let mask1 = mask | (Prim.natToNat32(1) << bitpos1);
+          let bits1 = bits | (Prim.natToNat32(1) << bitpos1);
+          let sum = size<K, V>(b.left) + size<K,V>(b.right);
+          (b.size == sum or (do { Prim.debugPrint("malformed size"); false }))
+          and
+          rec(b.left,  ?bitpos1, bits,  mask1)
+          and
+          rec(b.right, ?bitpos1, bits1, mask1)
         };
       }
     };
-    rec(l, max, 0)
+    rec(t, null, 0, 0)
   };
-};
 
-public func fromList<K,V>(kvc:?Nat, kvs:AssocList<Key<K>,V>, bitpos:Nat) : Trie<K,V> =
-   label profile_trie_fromList_begin : (Trie<K,V>) {
-   func rec(kvc:?Nat, kvs:AssocList<Key<K>,V>, bitpos:Nat) : Trie<K,V> {
-     switch kvc {
-     case null {
-            switch (ListUtil.lenClamp<(Key<K>,V)>(kvs, MAX_LEAF_SIZE)) {
-              case null {} /* fall through to branch case. */;
-              case (?len) {
-                     return #leaf({size=len; keyvals=kvs})
-                   };
-            }
+
+  /// A 2D trie maps dimension-1 keys to another
+  /// layer of tries, each keyed on the dimension-2 keys.
+  public type Trie2D<K1, K2, V> = Trie<K1, Trie<K2, V>>;
+
+  /// A 3D trie maps dimension-1 keys to another
+  /// layer of 2D tries, each keyed on the dimension-2 and dimension-3 keys.
+  public type Trie3D<K1, K2, K3, V> = Trie<K1, Trie2D<K2, K3, V> >;
+
+  /// An empty trie.
+  public func empty<K, V>() : Trie<K, V> { #empty; };
+
+  ///  Get the number of key-value pairs in the trie, in constant time.
+
+  //  ### Implementation notes
+  //
+  //  `nth` directly uses this function `size` for achieving an
+  //  acceptable level of algorithmic efficiently.
+  public func size<K, V>(t : Trie<K, V>) : Nat = label profile_trie_size : Nat {
+    switch t {
+      case (#empty) { 0 };
+      case (#leaf(l)) { l.size };
+      case (#branch(b)) { b.size };
+    }
+  };
+
+  /// Construct a branch node, computing the size stored there.
+  public func branch<K, V>(l : Trie<K, V>, r : Trie<K, V>) : Trie<K, V> =
+    label profile_trie_branch : Trie<K,V> {
+      let sum = size<K, V>(l) + size<K, V>(r);
+      #branch {
+        size = sum;
+        left = l;
+        right = r
+      };
+    };
+
+  /// Construct a leaf node, computing the size stored there.
+  ///
+  /// This helper function automatically enforces the MAX_LEAF_SIZE
+  /// by constructing branches as necessary; to do so, it also needs the bitpos
+  /// of the leaf.
+  public func leaf<K, V>(kvs : AssocList<Key<K>, V>, bitpos : Nat) : Trie<K, V> = label trie_leaf : Trie<K, V> {
+    fromList<K, V>(null, kvs, bitpos)
+  };
+
+  module ListUtil {
+    /* Deprecated: List.lenIsEqLessThan */
+    /// Test the list length against a maximum value and return true if
+    /// the list length is less than or equal to the value specified.
+    public func lenIsEqLessThan<T>(l : List <T>, i : Nat) : Bool {
+      switch l {
+        case null { true };
+        case (?(_, t)) {
+          if (i == 0) { false }
+          else { lenIsEqLessThan<T>(t, i - 1) }
+        };
+      };
+    };
+    /* Deprecated: List.lenClamp */
+    /// Return the list length unless the number of items in the list exceeds
+    /// a maximum value. If the list length exceed the maximum, the function
+    /// returns `null`.
+    public func lenClamp<T>(l : List<T>, max : Nat) : ?Nat {
+      func rec(l : List<T>, max : Nat, i : Nat) : ?Nat {
+        switch l {
+          case null { ?i };
+          case (?(_, t)) {
+            if ( i > max ) { null }
+            else { rec(t, max, i + 1) }
           };
-     case (?c) {
-       if ( c == 0 ) {
-         return #empty
-       } else if ( c <= MAX_LEAF_SIZE ) {
-         return #leaf({size=c; keyvals=kvs})
-       } else {
-         /* fall through to branch case */
-       }
-     };
-     };
-     let (ls, l, rs, r) = splitList<K,V>(kvs, bitpos);
-     if ( ls == 0 and rs == 0 ) {
-       #empty
-     } else if (rs == 0 and ls <= MAX_LEAF_SIZE) {
-       #leaf({size=ls; keyvals=l})
-     } else if (ls == 0 and rs <= MAX_LEAF_SIZE) {
-       #leaf({size=rs; keyvals=r})
-     } else {
-       branch<K,V>(rec(?ls, l, bitpos + 1), rec(?rs, r, bitpos + 1))
-     }
-   };
-   rec(kvc, kvs, bitpos)
- };
+        }
+      };
+      rec(l, max, 0)
+    };
+  };
 
-/// clone the trie efficiently, via sharing.
-///
-/// Purely-functional representation permits _O(1)_ copy, via persistent sharing.
-public func clone<K, V>(t : Trie<K, V>) : Trie<K, V> = t;
 
-/// replace the given key's value option with the given one, returning the previous one
-public func replace<K,V>(t : Trie<K,V>, k:Key<K>, k_eq:(K,K)->Bool, v:?V) : (Trie<K,V>, ?V) =
-   label profile_trie_replace : (Trie<K,V>, ?V) {
-   let key_eq = equalKey<K>(k_eq);
+  public func fromList<K, V>(kvc : ?Nat, kvs : AssocList<Key<K>, V>, bitpos : Nat) : Trie<K, V> =
+    label profile_trie_fromList_begin : (Trie<K, V>) {
+    func rec(kvc:?Nat, kvs:AssocList<Key<K>, V>, bitpos : Nat) : Trie<K, V> {
+      switch kvc {
+        case null {
+          switch (ListUtil.lenClamp<(Key<K>, V)>(kvs, MAX_LEAF_SIZE)) {
+            case null {} /* fall through to branch case. */;
+            case (?len) {
+              return #leaf({size=len; keyvals=kvs})
+            };
+          }
+      	};
+        case (?c) {
+          if ( c == 0 ) {
+            return #empty
+          } else if ( c <= MAX_LEAF_SIZE ) {
+            return #leaf({size=c; keyvals=kvs})
+          } else {
+          /* fall through to branch case */
+          }
+        };
+      };
+      let (ls, l, rs, r) = splitList<K,V>(kvs, bitpos);
+      if ( ls == 0 and rs == 0 ) {
+        #empty
+      } else if (rs == 0 and ls <= MAX_LEAF_SIZE) {
+        #leaf({size=ls; keyvals=l})
+      } else if (ls == 0 and rs <= MAX_LEAF_SIZE) {
+        #leaf({size=rs; keyvals=r})
+      } else {
+        branch<K,V>(rec(?ls, l, bitpos + 1), rec(?rs, r, bitpos + 1))
+      }
+    };
+    rec(kvc, kvs, bitpos)
+  };
 
-   func rec(t : Trie<K,V>, bitpos:Nat) : (Trie<K,V>, ?V) =
-     label profile_trie_replace_rec : (Trie<K,V>, ?V) {
-      switch t {
-      case (#empty) label profile_trie_replace_rec_empty : (Trie<K,V>, ?V) {
+  /// clone the trie efficiently, via sharing.
+  ///
+  /// Purely-functional representation permits _O(1)_ copy, via persistent sharing.
+  public func clone<K, V>(t : Trie<K, V>) : Trie<K, V> = t;
+
+  /// replace the given key's value option with the given one, returning the previous one
+  public func replace<K, V>(t : Trie<K, V>, k : Key<K>, k_eq : (K, K) -> Bool, v : ?V) : (Trie<K, V>, ?V) =
+     label profile_trie_replace : (Trie<K, V>, ?V) {
+     let key_eq = equalKey<K>(k_eq);
+
+     func rec(t : Trie<K,V>, bitpos : Nat) : (Trie<K, V>, ?V) =
+       label profile_trie_replace_rec : (Trie<K, V>, ?V) {
+        switch t {
+          case (#empty) label profile_trie_replace_rec_empty : (Trie<K, V>, ?V) {
             let (kvs, _) = AssocList.replace<Key<K>,V>(null, k, key_eq, v);
             (leaf<K,V>(kvs, bitpos), null)
           };
-     case (#branch(b)) label profile_trie_replace_rec_branch : (Trie<K,V>, ?V) {
+          case (#branch(b)) label profile_trie_replace_rec_branch : (Trie<K, V>, ?V) {
             let bit = Hash.bit(k.hash, bitpos);
             // rebuild either the left or right path with the (k,v) pair
             if (not bit) {
@@ -304,304 +305,305 @@ public func replace<K,V>(t : Trie<K,V>, k:Key<K>, k_eq:(K,K)->Bool, v:?V) : (Tri
               (branch<K,V>(b.left, r), v_)
             }
           };
-     case (#leaf(l)) label profile_trie_replace_rec_leaf : (Trie<K,V>, ?V) {
-            let (kvs2, old_val) =
-              AssocList.replace<Key<K>,V>(l.keyvals, k, key_eq, v);
-            (leaf<K,V>(kvs2, bitpos), old_val)
-          };
-     }
+       case (#leaf(l)) label profile_trie_replace_rec_leaf : (Trie<K, V>, ?V) {
+         let (kvs2, old_val) =
+           AssocList.replace<Key<K>,V>(l.keyvals, k, key_eq, v);
+         (leaf<K,V>(kvs2, bitpos), old_val)
+        };
+      }
+     };
+     let (to, vo) = rec(t, 0);
+     //assert(isValid<K,V>(to, false));
+     (to, vo)
    };
-   let (to, vo) = rec(t, 0);
-   //assert(isValid<K,V>(to, false));
-   (to, vo)
- };
 
-/// put the given key's value in the trie; return the new trie, and the previous value associated with the key, if any
-public func put<K,V>(t : Trie<K,V>, k:Key<K>, k_eq:(K,K)->Bool, v:V) : (Trie<K,V>, ?V) =
-   label profile_trie_put : (Trie<K,V>, ?V) {
-   replace<K,V>(t, k, k_eq, ?v)
- };
+  /// put the given key's value in the trie; return the new trie, and the previous value associated with the key, if any
+  public func put<K, V>(t : Trie<K, V>, k : Key<K>, k_eq : (K, K) -> Bool, v : V) : (Trie<K, V>, ?V) =
+    label profile_trie_put : (Trie<K, V>, ?V) {
+      replace<K, V>(t, k, k_eq, ?v)
+    };
 
-///  find the given key's value in the trie, or return null if nonexistent
-public func find<K,V>(t : Trie<K,V>, k:Key<K>, k_eq:(K,K) -> Bool) : ?V = label profile_trie_find : (?V) {
-   let key_eq = equalKey<K>(k_eq);
-   func rec(t : Trie<K,V>, bitpos:Nat) : ?V = label profile_trie_find_rec : (?V) {
-     switch t {
-       case (#empty) {
-              label profile_trie_find_end_null : (?V)
-              { null }
-            };
-       case (#leaf(l)) {
-              label profile_trie_find_end_assocList_find : (?V)
-              { AssocList.find<Key<K>,V>(l.keyvals, k, key_eq) }
-            };
-       case (#branch(b)) {
+  ///  find the given key's value in the trie, or return null if nonexistent
+  public func find<K, V>(t : Trie<K, V>, k : Key<K>, k_eq : (K, K) -> Bool) : ?V =
+    label profile_trie_find : (?V) {
+      let key_eq = equalKey<K>(k_eq);
+      func rec(t : Trie<K,V>, bitpos : Nat) : ?V = label profile_trie_find_rec : (?V) {
+        switch t {
+          case (#empty) {
+            label profile_trie_find_end_null : (?V)
+            { null }
+          };
+          case (#leaf(l)) {
+            label profile_trie_find_end_assocList_find : (?V)
+            { AssocList.find<Key<K>,V>(l.keyvals, k, key_eq) }
+          };
+          case (#branch(b)) {
             let bit = Hash.bit(k.hash, bitpos);
             if (not bit) {
-                label profile_trie_find_branch_left : (?V)
-                { rec(b.left, bitpos+1) }
-              }
+              label profile_trie_find_branch_left : (?V)
+              { rec(b.left, bitpos+1) }
+            }
             else {
-                label profile_trie_find_branch_right : (?V)
-                { rec(b.right, bitpos+1) }
-              }
-             };
-     }
-   };
-   rec(t, 0)
- };
-
-
-
-func splitAssocList<K,V>(al:AssocList<Key<K>,V>, bitpos:Nat)
-   : (AssocList<Key<K>,V>, AssocList<Key<K>,V>) =
-   label profile_trie_splitAssocList : (AssocList<Key<K>,V>, AssocList<Key<K>,V>)
- {
-   List.partition<(Key<K>,V)>(
-     al,
-     func ((k : Key<K>, v : V)) : Bool {
-       not Hash.bit(k.hash, bitpos)
-     }
-   )
- };
-
-func splitList<K,V>(l:AssocList<Key<K>,V>, bitpos:Nat)
-   : (Nat, AssocList<Key<K>,V>, Nat, AssocList<Key<K>,V>) =
-   label profile_trie_splitList : (Nat, AssocList<Key<K>,V>, Nat, AssocList<Key<K>,V>)
- {
-   func rec(l : AssocList<Key<K>,V>) : (Nat, AssocList<Key<K>,V>, Nat, AssocList<Key<K>,V>) =
-     label profile_trie_sized_split_rec : (Nat, AssocList<Key<K>,V>, Nat, AssocList<Key<K>,V>) {
-     switch l {
-     case null { (0, null, 0, null) };
-     case (?((k,v),t)) {
-            let (cl, l, cr, r) = rec(t) ;
-            if (not Hash.bit(k.hash, bitpos)){
-              (cl + 1, ?((k,v),l), cr, r)
-            } else {
-              (cl, l, cr + 1, ?((k,v),r))
+              label profile_trie_find_branch_right : (?V)
+              { rec(b.right, bitpos+1) }
             }
           };
-     }
+        }
+      };
+      rec(t, 0)
+    };
+
+
+
+  func splitAssocList<K,V>(al : AssocList<Key<K>, V>, bitpos : Nat)
+     : (AssocList<Key<K>, V>, AssocList<Key<K>, V>) =
+   label profile_trie_splitAssocList : (AssocList<Key<K>, V>, AssocList<Key<K>,V>)
+   {
+     List.partition<(Key<K>, V)>(
+       al,
+       func ((k : Key<K>, v : V)) : Bool {
+         not Hash.bit(k.hash, bitpos)
+       }
+     )
    };
-   rec(l)
- };
 
-///   merge tries, preferring the right trie where there are collisions
-///   in common keys.
-///
-///   note: the `disj` operation generalizes this `merge`
-///   operation in various ways, and does not (in general) lose
-///   information; this operation is a simpler, special case.
-///
-///   See also:
-///
-///   - `disj`
-///   - `join`
-///   - `prod`
-public func merge<K,V>(tl:Trie<K,V>, tr:Trie<K,V>, k_eq:(K,K)->Bool) : Trie<K,V> = label profile_trie_merge : Trie<K,V> {
-    let key_eq = equalKey<K>(k_eq);
-    func br(l:Trie<K,V>, r:Trie<K,V>) : Trie<K,V> = branch<K,V>(l,r);
-    func rec(bitpos:Nat, tl:Trie<K,V>, tr:Trie<K,V>) : Trie<K,V> {
-      func lf(kvs:AssocList<Key<K>,V>) : Trie<K,V> = leaf<K,V>(kvs, bitpos);
-      switch (tl, tr) {
-        case (#empty, _) { return tr };
-        case (_, #empty) { return tl };
-        case (#leaf(l1), #leaf(l2)) {
-               lf(
-                 AssocList.disj<Key<K>,V,V,V>(
-                   l1.keyvals, l2.keyvals,
-                   key_eq,
-                   func (x:?V, y:?V):V {
-                     switch (x, y) {
-                     case (null, null) { P.unreachable() };
-                     case (null, ?v) { v };
-                     case (?v, _) { v };
-                     }}
-                 )
-               )
-             };
-        case (#leaf(l), _) {
-               let (ll, lr) = splitAssocList<K,V>(l.keyvals, bitpos);
-               rec(bitpos, br(lf(ll), lf(lr)), tr)
-             };
-        case (_, #leaf(l)) {
-               let (ll, lr) = splitAssocList<K,V>(l.keyvals, bitpos);
-               rec(bitpos, tl, br(lf(ll), lf(lr)))
-             };
-        case (#branch(b1), #branch(b2)) {
-               br(rec(bitpos + 1, b1.left, b2.left),
-                  rec(bitpos + 1, b1.right, b2.right))
-             };
-      }
+  func splitList<K, V>(l : AssocList<Key<K>, V>, bitpos : Nat)
+    : (Nat, AssocList<Key<K>, V>, Nat, AssocList<Key<K>, V>) =
+    label profile_trie_splitList : (Nat, AssocList<Key<K>, V>, Nat, AssocList<Key<K>, V>)
+    {
+     func rec(l : AssocList<Key<K>, V>) : (Nat, AssocList<Key<K>, V>, Nat, AssocList<Key<K>, V>) =
+       label profile_trie_sized_split_rec : (Nat, AssocList<Key<K>, V>, Nat, AssocList<Key<K>, V>) {
+         switch l {
+           case null { (0, null, 0, null) };
+           case (?((k,v),t)) {
+             let (cl, l, cr, r) = rec(t) ;
+             if (not Hash.bit(k.hash, bitpos)){
+               (cl + 1, ?((k,v),l), cr, r)
+             } else {
+               (cl, l, cr + 1, ?((k,v),r))
+             }
+           };
+         }
+       };
+     rec(l)
+   };
+
+  ///   merge tries, preferring the right trie where there are collisions
+  ///   in common keys.
+  ///
+  ///   note: the `disj` operation generalizes this `merge`
+  ///   operation in various ways, and does not (in general) lose
+  ///   information; this operation is a simpler, special case.
+  ///
+  ///   See also:
+  ///
+  ///   - `disj`
+  ///   - `join`
+  ///   - `prod`
+  public func merge<K, V>(tl:Trie<K, V>, tr:Trie<K, V>, k_eq : (K, K) -> Bool) : Trie<K, V> =
+    label profile_trie_merge : Trie<K, V> {
+      let key_eq = equalKey<K>(k_eq);
+      func br(l : Trie<K, V>, r : Trie<K,V>) : Trie<K, V> = branch<K, V>(l, r);
+      func rec(bitpos : Nat, tl : Trie<K, V>, tr:Trie<K, V>) : Trie<K, V> {
+        func lf(kvs : AssocList<Key<K>, V>) : Trie<K, V> = leaf<K, V>(kvs, bitpos);
+        switch (tl, tr) {
+          case (#empty, _) { return tr };
+          case (_, #empty) { return tl };
+          case (#leaf(l1), #leaf(l2)) {
+            lf(
+              AssocList.disj<Key<K>,V,V,V>(
+                l1.keyvals, l2.keyvals,
+                key_eq,
+                func (x:?V, y:?V):V {
+                  switch (x, y) {
+                    case (null, null) { P.unreachable() };
+                    case (null, ?v) { v };
+                    case (?v, _) { v };
+                  }
+	        }
+              )
+            )
+          };
+          case (#leaf(l), _) {
+            let (ll, lr) = splitAssocList<K, V>(l.keyvals, bitpos);
+            rec(bitpos, br(lf(ll), lf(lr)), tr)
+          };
+          case (_, #leaf(l)) {
+            let (ll, lr) = splitAssocList<K, V>(l.keyvals, bitpos);
+            rec(bitpos, tl, br(lf(ll), lf(lr)))
+          };
+          case (#branch(b1), #branch(b2)) {
+            br(rec(bitpos + 1, b1.left, b2.left),
+               rec(bitpos + 1, b1.right, b2.right))
+          };
+        }
+      };
+      rec(0, tl, tr)
     };
-    rec(0, tl, tr)
-  };
 
-/// like `merge`, it merges tries, but unlike `merge`, it signals a
-/// dynamic error if there are collisions in common keys between the
-/// left and right inputs.
-public func mergeDisjoint<K,V>(tl:Trie<K,V>, tr:Trie<K,V>, k_eq:(K,K)->Bool): Trie<K,V> =
-    label profile_trie_mergeDisjoint : Trie<K,V> {
-    let key_eq = equalKey<K>(k_eq);
-    func br(l:Trie<K,V>, r:Trie<K,V>) : Trie<K,V> = branch<K,V>(l,r);
-    func rec(bitpos:Nat, tl:Trie<K,V>, tr:Trie<K,V>) : Trie<K,V> = label profile_trie_mergeDisjoint_rec : Trie<K,V> {
-      func lf(kvs:AssocList<Key<K>,V>) : Trie<K,V> = leaf<K,V>(kvs, bitpos);
-      switch (tl, tr) {
-        case (#empty, _) label profile_trie_mergeDisjoint_rec_emptyL : Trie<K,V> { return tr };
-        case (_, #empty) label profile_trie_mergeDisjoint_rec_emptyR : Trie<K,V> { return tl };
-        case (#leaf(l1), #leaf(l2)) label profile_trie_mergeDisjoint_rec_leafPair : Trie<K,V> {
-               lf(
-                 AssocList.disjDisjoint<Key<K>,V,V,V>(
-                   l1.keyvals, l2.keyvals,
-                   func (x:?V, y:?V):V {
-                     switch (x, y) {
-                     case (null, ?v) { v };
-                     case (?v, null) { v };
-                     case (_, _) { P.unreachable() };
-                     }
-                   }
-                 )
-               )
-             };
-        case (#leaf(l), _) label profile_trie_mergeDisjoint_rec_splitLeafL : Trie<K,V> {
-               let (ll, lr) = splitAssocList<K,V>(l.keyvals, bitpos);
-               rec(bitpos, br(lf(ll), lf(lr)), tr)
-             };
-        case (_, #leaf(l)) label profile_trie_mergeDisjoint_rec_splitLeafR : Trie<K,V> {
-               let (ll, lr) = splitAssocList<K,V>(l.keyvals, bitpos);
-               rec(bitpos, tl, br(lf(ll), lf(lr)))
-             };
-        case (#branch(b1), #branch(b2)) label profile_trie_mergeDisjoint_rec_branchPair : Trie<K,V> {
-               branch<K,V>(
-                 rec(bitpos + 1, b1.left, b2.left),
-                 rec(bitpos + 1, b1.right, b2.right)
-               )
-             };
+  /// like `merge`, it merges tries, but unlike `merge`, it signals a
+  /// dynamic error if there are collisions in common keys between the
+  /// left and right inputs.
+  public func mergeDisjoint<K, V>(tl : Trie<K, V>, tr : Trie<K, V>, k_eq : (K, K) -> Bool) : Trie<K, V> =
+    label profile_trie_mergeDisjoint : Trie<K, V> {
+      let key_eq = equalKey<K>(k_eq);
 
-      }
+      func br(l : Trie<K, V>, r : Trie<K, V>) : Trie<K, V> = branch<K, V>(l,r);
+
+      func rec(bitpos : Nat, tl : Trie<K,V>, tr : Trie<K,V>) : Trie<K,V> = label profile_trie_mergeDisjoint_rec : Trie<K, V> {
+        func lf(kvs : AssocList<Key<K>, V>) : Trie<K, V> = leaf<K, V>(kvs, bitpos);
+        switch (tl, tr) {
+          case (#empty, _) label profile_trie_mergeDisjoint_rec_emptyL : Trie<K,V> { return tr };
+          case (_, #empty) label profile_trie_mergeDisjoint_rec_emptyR : Trie<K,V> { return tl };
+          case (#leaf(l1), #leaf(l2)) label profile_trie_mergeDisjoint_rec_leafPair : Trie<K,V> {
+            lf(
+              AssocList.disjDisjoint<Key<K>, V, V, V>(
+                l1.keyvals, l2.keyvals,
+                func (x : ?V, y : ?V) : V {
+                  switch (x, y) {
+                    case (null, ?v) { v };
+                    case (?v, null) { v };
+                    case (_, _) { P.unreachable() };
+                  }
+                }
+              )
+            )
+          };
+          case (#leaf(l), _) label profile_trie_mergeDisjoint_rec_splitLeafL : Trie<K, V> {
+            let (ll, lr) = splitAssocList<K, V>(l.keyvals, bitpos);
+            rec(bitpos, br(lf(ll), lf(lr)), tr)
+          };
+          case (_, #leaf(l)) label profile_trie_mergeDisjoint_rec_splitLeafR : Trie<K, V> {
+            let (ll, lr) = splitAssocList<K, V>(l.keyvals, bitpos);
+            rec(bitpos, tl, br(lf(ll), lf(lr)))
+          };
+          case (#branch(b1), #branch(b2)) label profile_trie_mergeDisjoint_rec_branchPair : Trie<K, V> {
+            branch<K,V>(
+              rec(bitpos + 1, b1.left, b2.left),
+              rec(bitpos + 1, b1.right, b2.right)
+            )
+          };
+        }
+      };
+      rec(0, tl, tr)
     };
-    rec(0, tl, tr)
-  };
 
-/// The key-value pairs of the final trie consists of those pairs of
-/// the left trie whose keys are not present in the right trie; the
-/// values of the right trie are irrelevant.
-public func diff<K,V,W>(tl:Trie<K,V>, tr:Trie<K,W>, k_eq:(K,K)->Bool): Trie<K,V> {
+  /// The key-value pairs of the final trie consists of those pairs of
+  /// the left trie whose keys are not present in the right trie; the
+  /// values of the right trie are irrelevant.
+  public func diff<K, V, W>(tl : Trie<K, V>, tr : Trie<K, W>, k_eq : ( K, K) -> Bool): Trie<K, V> {
     let key_eq = equalKey<K>(k_eq);
 
-    func br1(l:Trie<K,V>, r:Trie<K,V>) : Trie<K,V> = branch<K,V>(l,r);
-    func br2(l:Trie<K,W>, r:Trie<K,W>) : Trie<K,W> = branch<K,W>(l,r);
+    func br1(l : Trie<K, V>, r : Trie<K, V>) : Trie<K, V> = branch<K, V>(l, r);
+    func br2(l : Trie<K, W>, r : Trie<K,W>) : Trie<K, W> = branch<K, W>(l, r);
 
-    func rec(bitpos:Nat, tl:Trie<K,V>, tr:Trie<K,W>) : Trie<K,V> {
-      func lf1(kvs:AssocList<Key<K>,V>) : Trie<K,V> = leaf<K,V>(kvs, bitpos);
-      func lf2(kvs:AssocList<Key<K>,W>) : Trie<K,W> = leaf<K,W>(kvs, bitpos);
-
+    func rec(bitpos : Nat, tl : Trie<K, V>, tr : Trie<K, W>) : Trie<K, V> {
+      func lf1(kvs : AssocList<Key<K>, V>) : Trie<K,V> = leaf<K, V>(kvs, bitpos);
+      func lf2(kvs : AssocList<Key<K>, W>) : Trie<K,W> = leaf<K, W>(kvs, bitpos);
       switch (tl, tr) {
         case (#empty, _) { return #empty };
         case (_, #empty) { return tl };
         case (#leaf(l1), #leaf(l2)) {
-               lf1(
-                 AssocList.diff<Key<K>,V,W>(
-                   l1.keyvals, l2.keyvals,
-                   key_eq,
-                 )
-               )
-             };
+          lf1(
+             AssocList.diff<Key<K>, V, W>(
+               l1.keyvals, l2.keyvals,
+               key_eq,
+             )
+           )
+        };
         case (#leaf(l), _) {
-               let (ll, lr) = splitAssocList<K,V>(l.keyvals, bitpos);
-               rec(bitpos, br1(lf1(ll), lf1(lr)), tr)
-             };
+          let (ll, lr) = splitAssocList<K, V>(l.keyvals, bitpos);
+          rec(bitpos, br1(lf1(ll), lf1(lr)), tr)
+        };
         case (_, #leaf(l)) {
-               let (ll, lr) = splitAssocList<K,W>(l.keyvals, bitpos);
-               rec(bitpos, tl, br2(lf2(ll), lf2(lr)))
-             };
+          let (ll, lr) = splitAssocList<K, W>(l.keyvals, bitpos);
+          rec(bitpos, tl, br2(lf2(ll), lf2(lr)))
+        };
         case (#branch(b1), #branch(b2)) {
-               br1(rec(bitpos + 1, b1.left, b2.left),
-                   rec(bitpos + 1, b1.right, b2.right))
-             };
+          br1(rec(bitpos + 1, b1.left, b2.left),
+              rec(bitpos + 1, b1.right, b2.right))
+        };
       }
     };
     rec(0, tl, tr)
   };
 
-/// This operation generalizes the notion of "set union" to finite maps.
-///
-/// Produces a "disjunctive image" of the two tries, where the values of
-/// matching keys are combined with the given binary operator.
-///
-/// For unmatched key-value pairs, the operator is still applied to
-/// create the value in the image.  To accomodate these various
-/// situations, the operator accepts optional values, but is never
-/// applied to (null, null).
-///
-/// Implements the database idea of an ["outer join"](https://stackoverflow.com/questions/38549/what-is-the-difference-between-inner-join-and-outer-join).
-///
-/// See also:
-///
-/// - `join`
-/// - `merge`
-/// - `prod`
-public func disj<K,V,W,X>(
-    tl   : Trie<K,V>,
-    tr   : Trie<K,W>,
-    k_eq : (K,K)->Bool,
-    vbin : (?V,?W)->X
-  )
-    : Trie<K,X>
-  {
+  /// This operation generalizes the notion of "set union" to finite maps.
+  ///
+  /// Produces a "disjunctive image" of the two tries, where the values of
+  /// matching keys are combined with the given binary operator.
+  ///
+  /// For unmatched key-value pairs, the operator is still applied to
+  /// create the value in the image.  To accomodate these various
+  /// situations, the operator accepts optional values, but is never
+  /// applied to (null, null).
+  ///
+  /// Implements the database idea of an ["outer join"](https://stackoverflow.com/questions/38549/what-is-the-difference-between-inner-join-and-outer-join).
+  ///
+  /// See also:
+  ///
+  /// - `join`
+  /// - `merge`
+  /// - `prod`
+  public func disj<K, V, W, X>(
+    tl : Trie<K, V>,
+    tr : Trie<K, W>,
+    k_eq : (K, K)->Bool,
+    vbin : (?V, ?W)->X
+  ) : Trie<K, X> {
     let key_eq = equalKey<K>(k_eq);
 
-    func br1(l:Trie<K,V>, r:Trie<K,V>) : Trie<K,V> = branch<K,V>(l,r);
-    func br2(l:Trie<K,W>, r:Trie<K,W>) : Trie<K,W> = branch<K,W>(l,r);
+    func br1(l : Trie<K, V>, r : Trie<K, V>) : Trie<K,V> = branch<K, V>(l,r);
+    func br2(l : Trie<K, W>, r : Trie<K, W>) : Trie<K,W> = branch<K, W>(l,r);
 
-    func br3(l:Trie<K,X>, r:Trie<K,X>) : Trie<K,X> = branch<K,X>(l,r);
-    func lf3(kvs:AssocList<Key<K>,X>, bitpos:Nat) : Trie<K,X> = leaf<K,X>(kvs, bitpos);
+    func br3(l : Trie<K, X>, r : Trie<K, X>) : Trie<K,X> = branch<K, X>(l,r);
+    func lf3(kvs : AssocList<Key<K>, X>, bitpos : Nat) : Trie<K, X> = leaf<K,X>(kvs, bitpos);
 
     /* empty right case; build from left only: */
-    func recL(t:Trie<K,V>, bitpos:Nat) : Trie<K,X> {
+    func recL(t : Trie<K, V>, bitpos : Nat) : Trie<K, X> {
       switch t {
-      case (#empty) { #empty };
-      case (#leaf(l)) {
-             lf3(AssocList.disj<Key<K>,V,W,X>(l.keyvals, null, key_eq, vbin), bitpos)
-           };
-      case (#branch(b)) { br3(recL(b.left,bitpos+1),recL(b.right,bitpos+1)) };
-      }
-    };
-    /* empty left case; build from right only: */
-    func recR(t:Trie<K,W>, bitpos:Nat) : Trie<K,X> {
-      switch t {
-      case (#empty) { #empty };
-      case (#leaf(l)) {
-             lf3(AssocList.disj<Key<K>,V,W,X>(null, l.keyvals, key_eq, vbin), bitpos)
-           };
-      case (#branch(b)) { br3(recR(b.left,bitpos+1),recR(b.right,bitpos+1)) };
+        case (#empty) { #empty };
+        case (#leaf(l)) {
+          lf3(AssocList.disj<Key<K>, V, W, X>(l.keyvals, null, key_eq, vbin), bitpos)
+        };
+        case (#branch(b)) { br3(recL(b.left,bitpos+1),recL(b.right,bitpos+1)) };
       }
     };
 
-    /* main recursion */
-    func rec(bitpos:Nat, tl:Trie<K,V>, tr:Trie<K,W>) : Trie<K,X> {
-      func lf1(kvs:AssocList<Key<K>,V>) : Trie<K,V> = leaf<K,V>(kvs, bitpos);
-      func lf2(kvs:AssocList<Key<K>,W>) : Trie<K,W> = leaf<K,W>(kvs, bitpos);
-      switch (tl, tr) {
-      case (#empty, #empty) { #empty };
-      case (#empty, _   )   { recR(tr, bitpos) };
-      case (_,    #empty)   { recL(tl, bitpos) };
-      case (#leaf(l1), #leaf(l2)) {
-             lf3(AssocList.disj<Key<K>,V,W,X>(l1.keyvals, l2.keyvals, key_eq, vbin), bitpos)
-           };
-      case (#leaf(l), _) {
-             let (ll, lr) = splitAssocList<K,V>(l.keyvals, bitpos);
-             rec(bitpos, br1(lf1(ll), lf1(lr)), tr)
-           };
-      case (_, #leaf(l)) {
-             let (ll, lr) = splitAssocList<K,W>(l.keyvals, bitpos);
-             rec(bitpos, tl, br2(lf2(ll), lf2(lr)))
-           };
-      case (#branch(b1), #branch(b2)) {
-             br3(rec(bitpos + 1, b1.left, b2.left),
-                 rec(bitpos + 1, b1.right, b2.right))
-           };
+   /* empty left case; build from right only: */
+   func recR(t : Trie<K, W>, bitpos : Nat) : Trie<K, X> {
+     switch t {
+       case (#empty) { #empty };
+       case (#leaf(l)) {
+         lf3(AssocList.disj<Key<K>, V, W, X>(null, l.keyvals, key_eq, vbin), bitpos)
+       };
+       case (#branch(b)) { br3(recR(b.left,bitpos+1),recR(b.right,bitpos+1)) };
+     }
+   };
 
+   /* main recursion */
+   func rec(bitpos : Nat, tl : Trie<K, V>, tr : Trie<K, W>) : Trie<K, X> {
+     func lf1(kvs : AssocList<Key<K>, V>) : Trie<K, V> = leaf<K, V>(kvs, bitpos);
+     func lf2(kvs : AssocList<Key<K>, W>) : Trie<K, W> = leaf<K, W>(kvs, bitpos);
+     switch (tl, tr) {
+       case (#empty, #empty) { #empty };
+       case (#empty, _   )   { recR(tr, bitpos) };
+       case (_,    #empty)   { recL(tl, bitpos) };
+       case (#leaf(l1), #leaf(l2)) {
+         lf3(AssocList.disj<Key<K>,V,W,X>(l1.keyvals, l2.keyvals, key_eq, vbin), bitpos)
+       };
+       case (#leaf(l), _) {
+         let (ll, lr) = splitAssocList<K,V>(l.keyvals, bitpos);
+         rec(bitpos, br1(lf1(ll), lf1(lr)), tr)
+       };
+       case (_, #leaf(l)) {
+         let (ll, lr) = splitAssocList<K,W>(l.keyvals, bitpos);
+         rec(bitpos, tl, br2(lf2(ll), lf2(lr)))
+       };
+       case (#branch(b1), #branch(b2)) {
+         br3(rec(bitpos + 1, b1.left, b2.left),
+             rec(bitpos + 1, b1.right, b2.right))
+       };
       }
     };
 
@@ -620,19 +622,18 @@ public func disj<K,V,W,X>(
   /// - `disj`
   /// - `merge`
   /// - `prod`
-  public func join<K,V,W,X>(
-    tl:Trie<K,V>,
-    tr:Trie<K,W>,
-    k_eq:(K,K)->Bool,
-    vbin:(V,W)->X
-  )
-    : Trie<K,X> = label profile_trie_join : Trie<K,X>
-  {
+  public func join<K, V, W, X>(
+    tl : Trie<K, V>,
+    tr : Trie<K, W>,
+    k_eq : (K, K)->Bool,
+    vbin: (V, W)->X
+  ) : Trie<K,X> =
+  label profile_trie_join : Trie<K,X> {
     let key_eq = equalKey<K>(k_eq);
 
-    func br1(l:Trie<K,V>, r:Trie<K,V>) : Trie<K,V> = branch<K,V>(l,r);
-    func br2(l:Trie<K,W>, r:Trie<K,W>) : Trie<K,W> = branch<K,W>(l,r);
-    func br3(l:Trie<K,X>, r:Trie<K,X>) : Trie<K,X> = branch<K,X>(l,r);
+    func br1(l : Trie<K, V>, r : Trie<K, V>) : Trie<K, V> = branch<K, V>(l, r);
+    func br2(l : Trie<K, W>, r : Trie<K, W>) : Trie<K, W> = branch<K, W>(l, r);
+    func br3(l : Trie<K, X>, r : Trie<K, X>) : Trie<K, X> = branch<K, X>(l, r);
 
     func rec(bitpos:Nat, tl:Trie<K,V>, tr:Trie<K,W>) : Trie<K,X> = label profile_trie_join_rec : Trie<K,X> {
       func lf1(kvs:AssocList<Key<K>,V>) : Trie<K,V> = leaf<K,V>(kvs, bitpos);
@@ -640,26 +641,26 @@ public func disj<K,V,W,X>(
       func lf3(kvs:AssocList<Key<K>,X>) : Trie<K,X> = leaf<K,X>(kvs, bitpos);
 
       switch (tl, tr) {
-      case (#empty, _) { #empty };
-      case (_, #empty) { #empty };
-      case (#leaf(l1), #leaf(l2)) {
-             lf3(AssocList.join<Key<K>,V,W,X>(l1.keyvals, l2.keyvals, key_eq, vbin))
-           };
-      case (#leaf(l), _) {
-             let (ll, lr) = splitAssocList<K,V>(l.keyvals, bitpos);
-             rec(bitpos, br1(lf1(ll), lf1(lr)), tr)
-           };
-      case (_, #leaf(l)) {
-             let (ll, lr) = splitAssocList<K,W>(l.keyvals, bitpos);
-             rec(bitpos, tl, br2(lf2(ll), lf2(lr)))
-           };
-      case (#branch(b1), #branch(b2)) {
-             br3(rec(bitpos + 1, b1.left, b2.left),
-                 rec(bitpos + 1, b1.right, b2.right))
-           };
-
+        case (#empty, _) { #empty };
+        case (_, #empty) { #empty };
+        case (#leaf(l1), #leaf(l2)) {
+          lf3(AssocList.join<Key<K>,V,W,X>(l1.keyvals, l2.keyvals, key_eq, vbin))
+        };
+        case (#leaf(l), _) {
+          let (ll, lr) = splitAssocList<K,V>(l.keyvals, bitpos);
+          rec(bitpos, br1(lf1(ll), lf1(lr)), tr)
+        };
+        case (_, #leaf(l)) {
+          let (ll, lr) = splitAssocList<K,W>(l.keyvals, bitpos);
+          rec(bitpos, tl, br2(lf2(ll), lf2(lr)))
+        };
+        case (#branch(b1), #branch(b2)) {
+          br3(rec(bitpos + 1, b1.left, b2.left),
+            rec(bitpos + 1, b1.right, b2.right))
+        };
       }
     };
+
     rec(0, tl, tr)
   };
 
@@ -667,18 +668,17 @@ public func disj<K,V,W,X>(
   /// tries.  Many common operations are instantiations of this function,
   /// either as clients, or as hand-specialized versions (e.g., see , map,
   /// mapFilter, some and all below).
-  public func foldUp<K,V,X>(t:Trie<K,V>, bin:(X,X)->X, leaf:(K,V)->X, empty:X) : X {
-    func rec(t:Trie<K,V>) : X {
+  public func foldUp<K, V, X>(t : Trie<K, V>, bin : (X, X) -> X, leaf : (K, V) -> X, empty : X) : X {
+    func rec(t : Trie<K, V>) : X {
       switch t {
-      case (#empty) { empty };
-      case (#leaf(l)) {
-             AssocList.fold<Key<K>,V,X>(
-               l.keyvals, empty,
-               func (k:Key<K>, v:V, x:X):X =
-                 bin(leaf(k.key,v),x)
-             )
-           };
-      case (#branch(b)) { bin(rec(b.left), rec(b.right)) };
+        case (#empty) { empty };
+        case (#leaf(l)) {
+          AssocList.fold<Key<K>, V, X>(
+            l.keyvals, empty,
+            func (k : Key<K>, v : V, x : X) :X { bin(leaf(k.key,v),x) }
+          )
+        };
+        case (#branch(b)) { bin(rec(b.left), rec(b.right)) };
       }
     };
     rec(t)
@@ -699,14 +699,13 @@ public func disj<K,V,W,X>(
   /// - `disj`
   /// - `join`
   /// - `merge`
-  public func prod<K1,V1,K2,V2,K3,V3>(
-    tl    :Trie<K1,V1>,
-    tr    :Trie<K2,V2>,
-    op    :(K1,V1,K2,V2) -> ?(Key<K3>,V3),
-    k3_eq :(K3,K3) -> Bool
-  )
-    : Trie<K3,V3>
-  {
+  public func prod<K1, V1, K2, V2, K3, V3>(
+    tl : Trie<K1, V1>,
+    tr : Trie<K2, V2>,
+    op : (K1, V1, K2, V2) -> ?(Key<K3>, V3),
+    k3_eq : (K3, K3) -> Bool
+  )  : Trie<K3,V3>  {
+
     /*- binary case: merge disjoint results: */
     func merge (a:Trie<K3,V3>, b:Trie<K3,V3>) : Trie<K3,V3> =
       mergeDisjoint<K3,V3>(a, b, k3_eq);
@@ -719,8 +718,8 @@ public func disj<K,V,W,X>(
           tr, merge,
           func (k2:K2, v2:V2) : Trie<K3, V3> {
             switch (op(k1, v1, k2, v2)) {
-            case null { #empty };
-            case (?(k3, v3)) { (put<K3, V3>(#empty, k3, k3_eq, v3)).0 };
+              case null { #empty };
+              case (?(k3, v3)) { (put<K3, V3>(#empty, k3, k3_eq, v3)).0 };
             }
           },
           #empty
@@ -729,7 +728,6 @@ public func disj<K,V,W,X>(
       #empty
     )
   };
-
 
   /// Represent the construction of tries as data.
   ///
@@ -749,70 +747,66 @@ public func disj<K,V,W,X>(
   /// own.
   ///
   public module Build {
-
     /// The build of a trie, as an AST for a simple DSL.
-    public type Build<K,V> = {
+    public type Build<K, V> = {
       #skip ;
       #put : (K, ?Hash.Hash, V) ;
       #seq : {
-        size : Nat ;
-        left  : Build<K,V> ;
-        right : Build<K,V> ;
+        size : Nat;
+        left : Build<K, V>;
+        right : Build<K, V>;
       } ;
     };
 
     /// Size of the build, measured in `#put` operations
-    public func size<K,V>(tb:Build<K,V>) : Nat =
+    public func size<K, V>(tb : Build<K, V>) : Nat =
       label profile_trie_buildSize : Nat {
       switch tb {
-      case (#skip) { 0 };
-      case (#put(_, _, _)) { 1 };
-      case (#seq(seq)) { seq.size };
+        case (#skip) { 0 };
+        case (#put(_, _, _)) { 1 };
+        case (#seq(seq)) { seq.size };
       }
     };
 
     /// Build sequence of two sub-builds
-    public func seq<K,V>(l:Build<K,V>, r:Build<K,V>) : Build<K,V> =
+    public func seq<K, V>(l : Build<K, V>, r : Build<K, V>) : Build<K, V> =
       label profile_trie_seq : Build<K,V> {
-      let sum = size<K,V>(l) + size<K,V>(r);
-      #seq({ size = sum; left = l; right = r })
-    };
+        let sum = size<K,V>(l) + size<K,V>(r);
+        #seq({ size = sum; left = l; right = r })
+      };
 
     /// Like [`prod`](#prod), except do not actually do the put calls, just
     /// record them, as a (binary tree) data structure, isomorphic to the
     /// recursion of this function (which is balanced, in expectation).
-    public func prod<K1,V1,K2,V2,K3,V3>(
-      tl    :Trie<K1,V1>,
-      tr    :Trie<K2,V2>,
-      op    :(K1,V1,K2,V2) -> ?(K3,V3),
+    public func prod<K1, V1, K2, V2, K3, V3>(
+      tl : Trie<K1, V1>,
+      tr : Trie<K2, V2>,
+      op : (K1, V1, K2, V2) -> ?(K3, V3),
       k3_eq :(K3,K3) -> Bool
-    )
-      : Build<K3,V3>
-    {
-      func outer_bin (a:Build<K3,V3>,
-                b:Build<K3,V3>)
+    ) : Build<K3,V3> {
+
+      func outer_bin (a : Build<K3, V3>, b : Build<K3, V3>)
         : Build<K3,V3> =
         label profile_trie_prod_outer_seqOfBranch : Build<K3,V3> {
-        seq<K3, V3>(a, b)
-      };
+          seq<K3, V3>(a, b)
+        };
 
-      func inner_bin (a:Build<K3,V3>,
-                b:Build<K3,V3>)
+      func inner_bin (a : Build<K3, V3>, b : Build<K3, V3>)
         : Build<K3,V3> =
-        label profile_trie_prod_inner_seqOfBranch : Build<K3,V3> {
-        seq<K3, V3>(a, b)
-      };
+        label profile_trie_prod_inner_seqOfBranch : Build<K3, V3> {
+          seq<K3, V3>(a, b)
+        };
 
       /// double-nested folds
       foldUp<K1, V1, Build<K3, V3>>(
         tl, outer_bin,
-        func (k1:K1, v1:V1) : Build<K3,V3> {
+        func (k1 : K1, v1 : V1) : Build<K3, V3> {
           foldUp<K2, V2, Build<K3, V3>>(
             tr, inner_bin,
-            func (k2:K2, v2:V2) : Build<K3, V3> {
+            func (k2 : K2, v2 : V2) : Build<K3, V3> {
               switch (op(k1, v1, k2, v2)) {
-              case null { #skip };
-              case (?(k3, v3)) { #put(k3, null, v3) };
+                case null { #skip };
+                case (?(k3, v3)) { #put(k3, null, v3) };
               }
             },
             #skip
@@ -825,42 +819,44 @@ public func disj<K,V,W,X>(
     /// Project the nth key-value pair from the trie build.
     ///
     /// This position is meaningful only when the build contains multiple uses of one or more keys, otherwise it is not.
-    public func nth<K,V>(tb:Build<K,V>, i:Nat) : ?(K, ?Hash.Hash, V) = label profile_triebuild_nth : (?(K, ?Hash.Hash, V)) {
-      func rec(tb:Build<K,V>, i:Nat) : ?(K, ?Hash.Hash, V) = label profile_triebuild_nth_rec : (?(K, ?Hash.Hash, V)) {
-        switch tb {
-        case (#skip) { P.unreachable() };
-        case (#put (k,h,v)) label profile_trie_nth_rec_end : (?(K, ?Hash.Hash, V)) {
-               assert(i == 0);
-               ?(k,h,v)
+    public func nth<K, V>(tb : Build<K, V>, i : Nat) : ?(K, ?Hash.Hash, V) =
+      label profile_triebuild_nth : (?(K, ?Hash.Hash, V)) {
+        func rec(tb:Build<K,V>, i:Nat) : ?(K, ?Hash.Hash, V) = label profile_triebuild_nth_rec : (?(K, ?Hash.Hash, V)) {
+          switch tb {
+            case (#skip) { P.unreachable() };
+            case (#put (k,h,v)) label profile_trie_nth_rec_end : (?(K, ?Hash.Hash, V)) {
+              assert(i == 0);
+              ?(k,h,v)
              };
-        case (#seq(s)) label profile_trie_nth_rec_seq : (?(K, ?Hash.Hash, V)) {
+             case (#seq(s)) label profile_trie_nth_rec_seq : (?(K, ?Hash.Hash, V)) {
                let size_left = size<K,V>(s.left);
                if (i < size_left) { rec(s.left,  i) }
-               else                { rec(s.right, i - size_left) }
+               else { rec(s.right, i - size_left) }
              };
-        }
+          }
+        };
+
+        if (i >= size<K,V>(tb)) {
+          return null
+        };
+        rec(tb, i)
       };
-      if (i >= size<K,V>(tb)) {
-        return null
-      };
-      rec(tb, i)
-    };
 
     /// Like [`mergeDisjoint`](#mergedisjoint), except that it avoids the
     /// work of actually merging any tries; rather, just record the work for
     /// latter (if ever).
-    public func projectInner<K1,K2,V>(t : Trie<K1,Build<K2,V>>)
-      : Build<K2,V>
-    {
-      foldUp<K1, Build<K2,V>, Build<K2,V>>
-      ( t,
-        func (t1:Build<K2,V>, t2:Build<K2,V>):Build<K2,V> { seq<K2,V>(t1, t2) },
-        func (_:K1, t:Build<K2,V>): Build<K2,V> { t },
-        #skip )
+    public func projectInner<K1, K2, V>(t : Trie<K1, Build<K2, V>>)
+      : Build<K2,V> {
+      foldUp<K1, Build<K2, V>, Build<K2, V>>(
+        t,
+        func (t1 : Build<K2, V>, t2 : Build<K2, V>) : Build<K2 ,V> { seq<K2, V>(t1, t2) },
+        func (_ : K1, t : Build<K2, V>): Build<K2, V> { t },
+        #skip
+      )
     };
 
     /// Gather the collection of key-value pairs into an array of a (possibly-distinct) type.
-    public func toArray<K,V,W>(tb:Build<K,V>,f:(K,V)->W):[W] {
+    public func toArray<K, V, W>(tb : Build<K, V>, f: (K, V) -> W) : [W] {
       let c = size<K,V>(tb);
       let a = A.init<?W>(c, null);
       var i = 0;
@@ -872,231 +868,231 @@ public func disj<K,V,W,X>(
         }
       };
       rec(tb);
-      A.tabulate<W>(c, func(i:Nat) : W = Option.unwrap<W>(a[i]))
+      A.tabulate<W>(c, func(i : Nat) : W = Option.unwrap<W>(a[i]))
     };
 
   };
 
   /// Fold over the key-value pairs of the trie, using an accumulator.
   /// The key-value pairs have no reliable or meaningful ordering.
-  public func fold<K,V,X>(t:Trie<K,V>, f:(K,V,X)->X, x:X) : X {
+  public func fold<K, V, X>(t : Trie<K, V>, f : (K, V, X) -> X, x : X) : X {
     func rec(t:Trie<K,V>, x:X) : X {
       switch t {
-      case (#empty) { x };
-      case (#leaf(l)) {
-             AssocList.fold<Key<K>,V,X>(
-               l.keyvals, x,
-               func (k:Key<K>, v:V, x:X):X = f(k.key,v,x)
-             )
-           };
-      case (#branch(b)) { rec(b.left,rec(b.right,x)) };
+        case (#empty) { x };
+        case (#leaf(l)) {
+          AssocList.fold<Key<K>, V, X>(
+           l.keyvals, x,
+           func (k : Key<K>, v : V, x : X) : X = f(k.key, v, x)
+          )
+        };
+        case (#branch(b)) { rec(b.left, rec(b.right,x)) };
       };
     };
     rec(t, x)
   };
 
-
   /// Test whether a given key-value pair is present, or not.
-  public func some<K,V>(t:Trie<K,V>, f:(K,V)->Bool) : Bool {
-    func rec(t:Trie<K,V>) : Bool {
+  public func some<K, V>(t : Trie<K, V>, f : (K, V) -> Bool) : Bool {
+    func rec(t : Trie<K, V>) : Bool {
       switch t {
-      case (#empty) { false };
-      case (#leaf(l)) {
-             List.some<(Key<K>,V)>(
-               l.keyvals, func ((k:Key<K>,v:V)):Bool=f(k.key,v)
-             )
-           };
-      case (#branch(b)) { rec(b.left) or rec(b.right) };
+        case (#empty) { false };
+        case (#leaf(l)) {
+          List.some<(Key<K>,V)>(
+            l.keyvals, func ((k:Key<K>,v:V)):Bool=f(k.key,v)
+          )
+        };
+        case (#branch(b)) { rec(b.left) or rec(b.right) };
       };
     };
     rec(t)
   };
 
   /// Test whether all key-value pairs have a given property.
-  public func all<K,V>(t:Trie<K,V>, f:(K,V)->Bool) : Bool {
-    func rec(t:Trie<K,V>) : Bool {
+  public func all<K,V>(t : Trie<K, V>, f : (K, V) -> Bool) : Bool {
+    func rec(t:Trie<K, V>) : Bool {
       switch t {
-      case (#empty) { true };
-      case (#leaf(l)) {
-             List.all<(Key<K>,V)>(
-               l.keyvals, func ((k:Key<K>,v:V)):Bool=f(k.key,v)
-             )
-           };
-      case (#branch(b)) { rec(b.left) and rec(b.right) };
+        case (#empty) { true };
+        case (#leaf(l)) {
+          List.all<(Key<K>, V)>(
+            l.keyvals, func ((k : Key<K>, v : V)) : Bool=f(k.key,v)
+          )
+        };
+        case (#branch(b)) { rec(b.left) and rec(b.right) };
       };
     };
     rec(t)
   };
 
-   /// Project the nth key-value pair from the trie.
-   ///
-   /// Note: This position is not meaningful; it's only here so that we
-   /// can inject tries into arrays using functions like `Array.tabulate`.
-  public func nth<K,V>(t:Trie<K,V>, i:Nat) : ?(Key<K>, V) = label profile_trie_nth : (?(Key<K>, V)) {
-    func rec(t:Trie<K,V>, i:Nat) : ?(Key<K>, V) = label profile_trie_nth_rec : (?(Key<K>, V)) {
-      switch t {
-      case (#empty) { P.unreachable() };
-      case (#leaf(l)) { List.get<(Key<K>,V)>(l.keyvals, i) };
-      case (#branch(b)) {
-             let size_left = size<K,V>(b.left);
-             if (i < size_left) { rec(b.left,  i) }
-             else                { rec(b.right, i - size_left) }
-           }
-      }
-    };
-    if (i >= size<K,V>(t)) {
-      return null
-    };
-    rec(t, i)
+  /// Project the nth key-value pair from the trie.
+  ///
+  /// Note: This position is not meaningful; it's only here so that we
+  /// can inject tries into arrays using functions like `Array.tabulate`.
+  public func nth<K,V>(t : Trie<K, V>, i : Nat) : ?(Key<K>, V) =
+    label profile_trie_nth : (?(Key<K>, V)) {
+      func rec(t:Trie<K,V>, i:Nat) : ?(Key<K>, V) = label profile_trie_nth_rec : (?(Key<K>, V)) {
+        switch t {
+          case (#empty) { P.unreachable() };
+          case (#leaf(l)) { List.get<(Key<K>,V)>(l.keyvals, i) };
+          case (#branch(b)) {
+            let size_left = size<K,V>(b.left);
+            if (i < size_left) { rec(b.left,  i) }
+            else { rec(b.right, i - size_left) }
+          }
+        }
+      };
+      if (i >= size<K,V>(t)) {
+        return null
+      };
+      rec(t, i)
   };
 
 
-   /// Gather the collection of key-value pairs into an array of a (possibly-distinct) type.
-   ///
-   /// ### Implementation notes:
-   ///
-   /// we use this function repeatedly in the Produce Exchange example
-   /// application, often on very large tries.
-   ///
-   /// Performance Profiling shows that it is important that this be
-   /// memory efficient, and reasonably time efficient, at large scales.
-   ///
-   /// To do so, we use a single array allocation (for the returned array) and we
-   /// sacrifice some efficiency in reading the input trie, and instead use function `nth` to
-   /// project each element with an independent trie traversal.
-   ///
-   /// This approach is somewhat forced on us by the type signature of
-   /// A.tabulate, and the desire to only allocate one array; that requirement rules
-   /// out iterative mutation of an optionally-null array, since an imperative
-   /// approach which would give us the wrong return type.
-   ///
-   /// Since we want to  statically rule out null output elements, and since the AS type system
-   /// cannot do that for an imperative approach unless we assume more about
-   /// the type W (e.g., the existence of "default values"), we settle for using `nth`.
-  public func toArray<K,V,W>(t:Trie<K,V>,f:(K,V)->W):[W] =
+  /// Gather the collection of key-value pairs into an array of a (possibly-distinct) type.
+  ///
+  /// ### Implementation notes:
+  ///
+  /// we use this function repeatedly in the Produce Exchange example
+  /// application, often on very large tries.
+  ///
+  /// Performance Profiling shows that it is important that this be
+  /// memory efficient, and reasonably time efficient, at large scales.
+  ///
+  /// To do so, we use a single array allocation (for the returned array) and we
+  /// sacrifice some efficiency in reading the input trie, and instead use function `nth` to
+  /// project each element with an independent trie traversal.
+  ///
+  /// This approach is somewhat forced on us by the type signature of
+  /// A.tabulate, and the desire to only allocate one array; that requirement rules
+  /// out iterative mutation of an optionally-null array, since an imperative
+  /// approach which would give us the wrong return type.
+  ///
+  /// Since we want to  statically rule out null output elements, and since the AS type system
+  /// cannot do that for an imperative approach unless we assume more about
+  /// the type W (e.g., the existence of "default values"), we settle for using `nth`.
+  public func toArray<K, V, W>(t : Trie<K, V>, f : (K, V)-> W):[W] =
     label profile_trie_toArray_begin : [W] {
-    let a = A.tabulate<W> (
-      size<K,V>(t),
-      func (i:Nat) : W = label profile_trie_toArray_nth : W {
-        let (k,v) = Option.unwrap<(Key<K>,V)>(nth<K,V>(t, i));
-        f(k.key, v)
-      }
-    );
-    label profile_trie_toArray_end : [W] 
-    { a }
-  };
+      let a = A.tabulate<W> (
+        size<K,V>(t),
+        func (i:Nat) : W = label profile_trie_toArray_nth : W {
+          let (k,v) = Option.unwrap<(Key<K>, V)>(nth<K, V>(t, i));
+          f(k.key, v)
+        }
+      );
+      label profile_trie_toArray_end : [W]
+      { a }
+    };
 
   /// Test for "deep emptiness": subtrees that have branching structure,
   /// but no leaves.  These can result from naive filtering operations;
   /// filter uses this function to avoid creating such subtrees.
-  public func isEmpty<K,V>(t:Trie<K,V>) : Bool =
-    size<K,V>(t) == 0;
+  public func isEmpty<K, V>(t : Trie<K, V>) : Bool {
+    size<K, V>(t) == 0
+  };
 
   /// filter the key-value pairs by a given predicate.
-  public func filter<K,V>(t:Trie<K,V>, f:(K,V)->Bool) : Trie<K,V> {
-    func rec(t:Trie<K,V>, bitpos:Nat) : Trie<K,V> {
+  public func filter<K, V>(t : Trie<K, V>, f : (K, V) -> Bool) : Trie<K, V> {
+    func rec(t : Trie<K, V>, bitpos : Nat) : Trie<K,V> {
       switch t {
-      case (#empty) { #empty };
-	    case (#leaf(l)) {
-             leaf<K,V>(
-               List.filter<(Key<K>,V)>(
-                 l.keyvals,
-                 func ((k:Key<K>,v:V)):Bool = f(k.key,v)
-               ),
-               bitpos
-             )
-           };
-	    case (#branch(b)) {
-		         let fl = rec(b.left, bitpos+1);
-		         let fr = rec(b.right, bitpos+1);
-		         switch (isEmpty<K,V>(fl),
-			               isEmpty<K,V>(fr)) {
-		         case (true,  true)  { #empty };
-		         case (false, true)  { fr };
-		         case (true,  false) { fl };
-		         case (false, false) { branch<K,V>(fl, fr) };
-		         };
-	         }
+        case (#empty) { #empty };
+        case (#leaf(l)) {
+          leaf<K,V>(
+            List.filter<(Key<K>, V)>(
+              l.keyvals,
+              func ((k : Key<K>, v : V)) : Bool = f(k.key,v)
+            ),
+            bitpos
+          )
+        };
+        case (#branch(b)) {
+          let fl = rec(b.left, bitpos+1);
+          let fr = rec(b.right, bitpos+1);
+          switch (isEmpty<K,V>(fl), isEmpty<K,V>(fr)) {
+            case (true, true) { #empty };
+            case (false, true) { fr };
+            case (true, false) { fl };
+            case (false, false) { branch<K,V>(fl, fr) };
+          };
+        }
       }
     };
     rec(t, 0)
   };
 
   /// map and filter the key-value pairs by a given predicate.
-  public func mapFilter<K,V,W>(t:Trie<K,V>, f:(K,V)->?W) : Trie<K,W> {
+  public func mapFilter<K, V, W>(t : Trie<K, V>, f : (K, V) -> ?W) : Trie<K, W> {
     func rec(t:Trie<K,V>, bitpos:Nat) : Trie<K,W> {
       switch t {
-      case (#empty) { #empty };
-	    case (#leaf(l)) {
-             leaf<K,W>(
-               List.mapFilter<(Key<K>,V),(Key<K>,W)>(
-                 l.keyvals,
-                 // retain key and hash, but update key's value using f:
-                 func ((k:Key<K>,v:V)):?(Key<K>,W) {
-                   switch (f(k.key,v)) {
-                   case (null) { null };
-                   case (?w) { ?({key=k.key; hash=k.hash}, w) };
-                   }}
-               ),
-               bitpos
-             )
-           };
-	    case (#branch(b)) {
-		         let fl = rec(b.left, bitpos + 1);
-		         let fr = rec(b.right, bitpos + 1);
-		         switch (isEmpty<K,W>(fl),
-			               isEmpty<K,W>(fr)) {
-		         case (true,  true)  { #empty };
-		         case (false, true)  { fr };
-		         case (true,  false) { fl };
-		         case (false, false) { branch<K,W>(fl, fr) };
-		         };
-	         }
+        case (#empty) { #empty };
+        case (#leaf(l)) {
+          leaf<K,W>(
+            List.mapFilter<(Key<K>,V),(Key<K>,W)>(
+              l.keyvals,
+              // retain key and hash, but update key's value using f:
+              func ((k : Key<K>, v : V)) : ?(Key<K>, W) {
+                switch (f(k.key, v)) {
+                  case (null) { null };
+                  case (?w) { ?({key = k.key; hash = k.hash}, w) };
+                }
+	      }
+            ),
+            bitpos
+          )
+        };
+        case (#branch(b)) {
+          let fl = rec(b.left, bitpos + 1);
+          let fr = rec(b.right, bitpos + 1);
+          switch (isEmpty<K, W>(fl), isEmpty<K, W>(fr)) {
+            case (true, true) { #empty };
+            case (false, true) { fr };
+            case (true, false) { fl };
+            case (false, false) { branch<K, W>(fl, fr) };
+          };
+        }
       }
     };
-    rec(t, 0)
+
+   rec(t, 0)
   };
 
   /// Test for equality, but naively, based on structure.
   /// Does not attempt to remove "junk" in the tree;
   /// For instance, a "smarter" approach would equate
-  ///   `#bin{left=#empty;right=#empty}`
+  ///   `#bin {left = #empty; right = #empty}`
   /// with
   ///   `#empty`.
   /// We do not observe that equality here.
-  public func equalStructure<K,V>(
-    tl:Trie<K,V>,
-    tr:Trie<K,V>,
-    keq:(K,K)->Bool,
-    veq:(V,V)->Bool
+  public func equalStructure<K, V>(
+    tl : Trie<K, V>,
+    tr : Trie<K, V>,
+    keq : (K, K) -> Bool,
+    veq : (V, V) -> Bool
   ) : Bool {
-    func rec(tl:Trie<K,V>, tr:Trie<K,V>) : Bool {
+    func rec(tl : Trie<K, V>, tr : Trie<K, V>) : Bool {
       switch (tl, tr) {
-      case (#empty, #empty) { true };
-      case (#leaf(l1), #leaf(l2)) {
-             List.equal<(Key<K>,V)>
-             (l1.keyvals, l2.keyvals,
-              func ((k1:Key<K>, v1:V), (k2:Key<K>, v2:V)) : Bool =
-                keq(k1.key, k2.key) and veq(v1,v2)
-             )
-           };
-      case (#branch(b1),#branch(b2)) {
-             rec(b1.left, b2.left) and rec(b2.right, b2.right)
-           };
-      case _ { false };
+        case (#empty, #empty) { true };
+        case (#leaf(l1), #leaf(l2)) {
+          List.equal<(Key<K>,V)>(l1.keyvals, l2.keyvals,
+            func ((k1:Key<K>, v1:V), (k2:Key<K>, v2:V)) : Bool =
+              keq(k1.key, k2.key) and veq(v1,v2)
+          )
+        };
+        case (#branch(b1),#branch(b2)) {
+          rec(b1.left, b2.left) and rec(b2.right, b2.right)
+        };
+        case _ { false };
       }
     };
-    rec(tl,tr)
+    rec(tl, tr)
   };
 
   /// replace the given key's value in the trie,
   /// and only if successful, do the success continuation,
   /// otherwise, return the failure value
-  public func replaceThen<K,V,X>(t : Trie<K,V>, k:Key<K>, k_eq:(K,K)->Bool, v2:V,
-                         success: (Trie<K,V>, V) -> X,
-                         fail: () -> X)
-    : X
-  {
+  public func replaceThen<K,V,X>(
+    t : Trie<K, V>, k : Key<K>, k_eq : (K, K) -> Bool, v2 : V,
+    success: (Trie<K, V>, V) -> X,
+    fail: () -> X
+  ) : X {
     let (t2, ov) = replace<K,V>(t, k, k_eq, ?v2);
     switch ov {
       case (null) { /* no prior value; failure to remove */ fail() };
@@ -1105,8 +1101,8 @@ public func disj<K,V,W,X>(
   };
 
   /// put the given key's value in the trie; return the new trie; assert that no prior value is associated with the key
-  public func putFresh<K,V>(t : Trie<K,V>, k:Key<K>, k_eq:(K,K)->Bool, v:V) : Trie<K,V> {
-    let (t2, none) = replace<K,V>(t, k, k_eq, ?v);
+  public func putFresh<K, V>(t : Trie<K, V>,  k : Key<K>, k_eq : (K, K) -> Bool, v : V) : Trie<K, V> {
+    let (t2, none) = replace<K, V>(t, k, k_eq, ?v);
     switch none {
       case (null) {};
       case (?_) assert false;
@@ -1115,66 +1111,71 @@ public func disj<K,V,W,X>(
   };
 
   /// put the given key's value in the 2D trie; return the new 2D trie.
-  public func put2D<K1,K2,V>(t : Trie2D<K1,K2,V>,
-                              k1:Key<K1>, k1_eq:(K1,K1)->Bool,
-                              k2:Key<K2>, k2_eq:(K2,K2)->Bool,
-                              v:V)
-    : Trie2D<K1,K2,V>
-  {
-    let inner = find<K1,Trie<K2,V>>(t, k1, k1_eq);
+  public func put2D<K1, K2, V>(
+    t : Trie2D<K1, K2, V>,
+    k1 : Key<K1>,
+    k1_eq : (K1, K1)->Bool,
+    k2 : Key<K2>,
+    k2_eq : (K2,K2)->Bool,
+    v:V
+  ) : Trie2D<K1, K2, V> {
+    let inner = find<K1,Trie<K2, V>>(t, k1, k1_eq);
     let (updated_inner, _) = switch inner {
-    case (null)   { put<K2,V>(#empty, k2, k2_eq, v) };
-    case (?inner) { put<K2,V>(inner, k2, k2_eq, v) };
+      case (null)   { put<K2, V>(#empty, k2, k2_eq, v) };
+      case (?inner) { put<K2, V>(inner, k2, k2_eq, v) };
     };
-    let (updated_outer, _) = put<K1,Trie<K2,V>>(t, k1, k1_eq, updated_inner);
+    let (updated_outer, _) = put<K1, Trie<K2, V>>(t, k1, k1_eq, updated_inner);
     updated_outer;
   };
 
   /// put the given key's value in the trie; return the new trie;
-  public func put3D<K1,K2,K3,V>
-    (t : Trie3D<K1,K2,K3,V>,
-     k1:Key<K1>, k1_eq:(K1,K1)->Bool,
-     k2:Key<K2>, k2_eq:(K2,K2)->Bool,
-     k3:Key<K3>, k3_eq:(K3,K3)->Bool,
-     v:V
-    )
-    : Trie3D<K1,K2,K3,V>
-  {
-    let inner1 = find<K1,Trie2D<K2,K3,V>>(t, k1, k1_eq);
+  public func put3D<K1, K2, K3, V> (
+    t : Trie3D<K1, K2, K3, V>,
+    k1 : Key<K1>,
+    k1_eq : (K1, K1) -> Bool,
+    k2 : Key<K2>,
+    k2_eq: (K2, K2) -> Bool,
+    k3 : Key<K3>,
+    k3_eq : (K3, K3)->Bool,
+    v : V
+  ) : Trie3D<K1,K2,K3,V> {
+    let inner1 = find<K1, Trie2D<K2, K3, V>>(t, k1, k1_eq);
     let (updated_inner1, _) = switch inner1 {
-    case (null)   {
-           put<K2,Trie<K3,V>>(
-             #empty, k2, k2_eq,
-             (put<K3,V>(#empty, k3, k3_eq, v)).0
-           )
-         };
-    case (?inner1) {
-           let inner2 = find<K2,Trie<K3,V>>(inner1, k2, k2_eq);
-           let (updated_inner2, _) = switch inner2 {
-           case (null) { put<K3,V>(#empty, k3, k3_eq, v) };
-           case (?inner2) { put<K3,V>(inner2, k3, k3_eq, v) };
-           };
-           put<K2,Trie<K3,V>>( inner1, k2, k2_eq, updated_inner2 )
-         };
+      case (null) {
+        put<K2, Trie<K3, V>>(
+          #empty, k2, k2_eq,
+           (put<K3,V>(#empty, k3, k3_eq, v)).0
+             )
+      };
+      case (?inner1) {
+        let inner2 = find<K2, Trie<K3, V>>(inner1, k2, k2_eq);
+        let (updated_inner2, _) = switch inner2 {
+          case (null) { put<K3, V>(#empty, k3, k3_eq, v) };
+          case (?inner2) { put<K3, V>(inner2, k3, k3_eq, v) };
+        };
+        put<K2,Trie<K3,V>>( inner1, k2, k2_eq, updated_inner2 )
+      };
     };
-    let (updated_outer, _) = put<K1,Trie2D<K2,K3,V>>(t, k1, k1_eq, updated_inner1);
+    let (updated_outer, _) = put<K1, Trie2D<K2, K3, V>>(t, k1, k1_eq, updated_inner1);
     updated_outer;
   };
 
   /// remove the given key's value in the trie; return the new trie
-  public func remove<K,V>(t : Trie<K,V>, k:Key<K>, k_eq:(K,K)->Bool) : (Trie<K,V>, ?V) {
+  public func remove<K,V>(t : Trie<K,V>, k : Key<K>, k_eq: (K, K) -> Bool) : (Trie<K, V>, ?V) {
     replace<K,V>(t, k, k_eq, null)
   };
 
   /// remove the given key's value in the trie,
   /// and only if successful, do the success continuation,
   /// otherwise, return the failure value
-  public func removeThen<K,V,X>(t : Trie<K,V>, k:Key<K>, k_eq:(K,K)->Bool,
-                         success: (Trie<K,V>, V) -> X,
-                         fail: () -> X)
-    : X
-  {
-    let (t2, ov) = replace<K,V>(t, k, k_eq, null);
+  public func removeThen<K, V, X>(
+    t : Trie<K, V>,
+    k : Key<K>,
+    k_eq: (K, K) -> Bool,
+    success: (Trie<K,V>, V) -> X,
+    fail: () -> X
+  ) : X {
+    let (t2, ov) = replace<K, V>(t, k, k_eq, null);
     switch ov {
       case (null) { /* no prior value; failure to remove */ fail() };
       case (?v) { success(t2, v) };
@@ -1184,58 +1185,61 @@ public func disj<K,V,W,X>(
 
   /// remove the given key-key pair's value in the 2D trie; return the
   /// new trie, and the prior value, if any.
-  public func remove2D<K1,K2,V>(t : Trie2D<K1,K2,V>,
-                         k1:Key<K1>, k1_eq:(K1,K1)->Bool,
-                         k2:Key<K2>, k2_eq:(K2,K2)->Bool)
-    : (Trie2D<K1,K2,V>, ?V)
-  {
+  public func remove2D<K1, K2, V>(
+    t : Trie2D<K1, K2, V>,
+    k1 : Key<K1>,
+    k1_eq : (K1, K1) -> Bool,
+    k2 : Key<K2>,
+    k2_eq: (K2, K2) -> Bool
+  ) : (Trie2D<K1, K2, V>, ?V)  {
     switch (find<K1,Trie<K2,V>>(t, k1, k1_eq)) {
-    case (null)   {
-           (t, null)
-         };
-    case (?inner) {
-           let (updated_inner, ov) = remove<K2,V>(inner, k2, k2_eq);
-           let (updated_outer, _) = put<K1,Trie<K2,V>>(t, k1, k1_eq, updated_inner);
-           (updated_outer, ov)
-         };
+      case (null)   {
+         (t, null)
+      };
+      case (?inner) {
+        let (updated_inner, ov) = remove<K2,V>(inner, k2, k2_eq);
+        let (updated_outer, _) = put<K1,Trie<K2,V>>(t, k1, k1_eq, updated_inner);
+        (updated_outer, ov)
+      };
     }
   };
 
   /// remove the given key-key pair's value in the 3D trie; return the
   /// new trie, and the prior value, if any.
-  public func remove3D<K1,K2,K3,V>
-    (t : Trie3D<K1,K2,K3,V>,
-     k1:Key<K1>, k1_eq:(K1,K1)->Bool,
-     k2:Key<K2>, k2_eq:(K2,K2)->Bool,
-     k3:Key<K3>, k3_eq:(K3,K3)->Bool,
-    )
-    : (Trie3D<K1,K2,K3,V>, ?V)
-  {
-    switch (find<K1,Trie2D<K2,K3,V>>(t, k1, k1_eq)) {
-    case (null)   {
-           (t, null)
-         };
-    case (?inner) {
-           let (updated_inner, ov) = remove2D<K2,K3,V>(inner, k2, k2_eq, k3, k3_eq);
-           let (updated_outer, _) = put<K1,Trie2D<K2,K3,V>>(t, k1, k1_eq, updated_inner);
-           (updated_outer, ov)
-         };
+  public func remove3D<K1, K2, K3, V>(
+    t : Trie3D<K1, K2, K3, V>,
+    k1 : Key<K1>,
+    k1_eq : (K1, K1) -> Bool,
+    k2 : Key<K2>,
+    k2_eq: (K2, K2) -> Bool,
+    k3:Key<K3>, k3_eq : (K3, K3)->Bool,
+   ) : (Trie3D<K1, K2, K3, V>, ?V) {
+    switch (find<K1, Trie2D<K2, K3, V>>(t, k1, k1_eq)) {
+      case (null)   {
+        (t, null)
+      };
+      case (?inner) {
+        let (updated_inner, ov) = remove2D<K2, K3, V>(inner, k2, k2_eq, k3, k3_eq);
+        let (updated_outer, _) = put<K1, Trie2D<K2, K3, V>>(t, k1, k1_eq, updated_inner);
+        (updated_outer, ov)
+      };
     }
   };
 
-
-
-   /// Like [`mergeDisjoint`](#mergedisjoint), except instead of merging a
-   /// pair, it merges the collection of dimension-2 sub-trees of a 2D
-   /// trie.
-  public func mergeDisjoint2D<K1,K2,V>(t : Trie2D<K1,K2,V>, k1_eq:(K1,K1)->Bool, k2_eq:(K2,K2)->Bool)
-    : Trie<K2,V>
-  {
-    foldUp<K1,Trie<K2,V>, Trie<K2,V>>
-    ( t,
-      func (t1:Trie<K2,V>, t2:Trie<K2,V>):Trie<K2,V> {  mergeDisjoint<K2,V>(t1, t2, k2_eq) },
-      func (_:K1, t:Trie<K2,V>): Trie<K2,V> { t },
-      #empty )
+  /// Like [`mergeDisjoint`](#mergedisjoint), except instead of merging a
+  /// pair, it merges the collection of dimension-2 sub-trees of a 2D
+  /// trie.
+  public func mergeDisjoint2D<K1, K2, V>(
+    t : Trie2D<K1, K2, V>,
+    k1_eq : (K1, K1) -> Bool,
+    k2_eq : (K2, K2) -> Bool
+  ) : Trie<K2,V> {
+    foldUp<K1, Trie<K2, V>, Trie<K2, V>>(
+      t,
+      func (t1 : Trie<K2, V>, t2 : Trie<K2, V>) : Trie<K2, V> { mergeDisjoint<K2, V>(t1, t2, k2_eq) },
+      func (_ : K1, t : Trie<K2, V>): Trie<K2, V> { t },
+      #empty
+    )
   };
 
 }

--- a/src/Trie.mo
+++ b/src/Trie.mo
@@ -880,7 +880,7 @@ module {
   /// Fold over the key-value pairs of the trie, using an accumulator.
   /// The key-value pairs have no reliable or meaningful ordering.
   public func fold<K, V, X>(t : Trie<K, V>, f : (K, V, X) -> X, x : X) : X {
-    func rec(t:Trie<K, V>, x:X) : X {
+    func rec(t : Trie<K, V>, x : X) : X {
       switch t {
         case (#empty) { x };
         case (#leaf(l)) {

--- a/src/TrieMap.mo
+++ b/src/TrieMap.mo
@@ -34,7 +34,7 @@ module {
 
     /// Put the key and value, _and_ return the (optional) prior value for the key.
     public func replace(k : K, v : V) : ?V {
-      let keyObj = {key = k; hash = hashOf(k);};
+      let keyObj = { key = k; hash = hashOf(k) };
       let (map2, ov) =
         T.put<K,V>(map, keyObj, isEq, v);
       map := map2;
@@ -48,7 +48,7 @@ module {
     /// Get the (optional) value associated with the given key.
     public func get(k : K) : ?V {
       let keyObj = {key = k; hash = hashOf(k);};
-      T.find<K,V>(map, keyObj, isEq)
+      T.find<K, V>(map, keyObj, isEq)
     };
 
     /// Delete the (optional) value associated with the given key.
@@ -57,7 +57,7 @@ module {
 
     /// Delete and return the (optional) value associated with the given key.
     public func remove(k : K) : ?V {
-      let keyObj = {key = k; hash = hashOf(k);};
+      let keyObj = { key = k; hash = hashOf(k) };
       let (t, ov) = T.remove<K, V>(map, keyObj, isEq);
       map := t;
       switch (ov) {
@@ -110,8 +110,8 @@ module {
     keyHash : K -> Hash.Hash
   ) : TrieMap<K, V> {
     let h2 = TrieMap<K, V>(keyEq, keyHash);
-    for ((k,v) in h.entries()) {
-      h2.put(k,v);
+    for ((k, v) in h.entries()) {
+      h2.put(k, v);
     };
     h2
   };
@@ -123,8 +123,8 @@ module {
     keyHash : K -> Hash.Hash
   ) : TrieMap<K, V> {
     let h = TrieMap<K, V>(keyEq, keyHash);
-    for ((k,v) in entries) {
-      h.put(k,v);
+    for ((k, v) in entries) {
+      h.put(k, v);
     };
     h
   };
@@ -139,7 +139,7 @@ module {
     let h2 = TrieMap<K, V2>(keyEq, keyHash);
     for ((k, v1) in h.entries()) {
       let v2 = mapFn(k, v1);
-      h2.put(k,v2);
+      h2.put(k, v2);
     };
     h2
   };
@@ -156,7 +156,7 @@ module {
       switch (mapFn(k, v1)) {
         case null { };
         case (?v2) {
-          h2.put(k,v2);
+          h2.put(k, v2);
         };
       }
     };

--- a/src/TrieMap.mo
+++ b/src/TrieMap.mo
@@ -1,6 +1,6 @@
 /// Functional map
 ///
-/// This module defines an imperative hash map, with a general key and value type.  It matches the interface and semantics of HashMap.  Unlike HashMap, its internal representation uses a functional hash trie (see `trie.mo`).
+/// This module defines an imperative hash map, with a general key and value type.  It matches the interface and semantics of HashMap.  Unlike HashMap, its internal representation uses a functional hash trie (see library `Trie`).
 ///
 /// This class permits us to compare the performance of two representations of hash-based maps, where tries (as binary trees) permit more efficient, constant-time, cloning compared with ordinary tables.  This property is nice for supporting transactional workflows where map mutations may be provisional, and where we may expect some mutations to be uncommitted, or to "roll back".
 ///

--- a/src/TrieMap.mo
+++ b/src/TrieMap.mo
@@ -17,144 +17,150 @@ import List "List";
 ///
 /// See also the `HashMap` module, with a matching interface.
 /// Unlike HashMap, the iterators are persistent (pure), clones are cheap and the maps have an efficient persistent representation.
+
 module {
-public class TrieMap<K,V> (isEq:(K, K) -> Bool, hashOf: K -> Hash.Hash) {
 
-  var map = T.empty<K, V>();
-  var _size : Nat = 0;
+  public class TrieMap<K, V> (isEq : (K, K) -> Bool, hashOf :  K -> Hash.Hash) {
 
-  /// Returns the number of entries in the map.
-  public func size() : Nat = _size;
+    var map = T.empty<K, V>();
+    var _size : Nat = 0;
 
-  /// Associate a key and value, overwriting any prior association for the key.
-  public func put(k:K, v:V) =
-    ignore replace(k, v);
+    /// Returns the number of entries in the map.
+    public func size() : Nat { _size };
 
-  /// Put the key and value, _and_ return the (optional) prior value for the key.
-  public func replace(k:K, v:V) : ?V {
-    let keyObj = {key=k; hash=hashOf(k);};
-    let (map2, ov) =
-      T.put<K,V>(map, keyObj, isEq, v);
-    map := map2;
-    switch(ov){
-    case null { _size += 1 };
-    case _ {}
+    /// Associate a key and value, overwriting any prior association for the key.
+    public func put(k : K, v : V) =
+      ignore replace(k, v);
+
+    /// Put the key and value, _and_ return the (optional) prior value for the key.
+    public func replace(k : K, v : V) : ?V {
+      let keyObj = {key = k; hash = hashOf(k);};
+      let (map2, ov) =
+        T.put<K,V>(map, keyObj, isEq, v);
+      map := map2;
+      switch (ov) {
+        case null { _size += 1 };
+        case _ {}
+      };
+      ov
     };
-    ov
-  };
 
-  /// Get the (optional) value associated with the given key.
-  public func get(k:K) : ?V {
-    let keyObj = {key=k; hash=hashOf(k);};
-    T.find<K,V>(map, keyObj, isEq)
-  };
-
-  /// Delete the (optional) value associated with the given key.
-  public func delete(k:K) =
-    ignore remove(k);
-
-  /// Delete and return the (optional) value associated with the given key.
-  public func remove(k:K) : ?V {
-    let keyObj = {key=k; hash=hashOf(k);};
-    let (t, ov) = T.remove<K, V>(map, keyObj, isEq);
-    map := t;
-    switch(ov){
-    case null { _size -= 1 };
-    case _ {}
+    /// Get the (optional) value associated with the given key.
+    public func get(k : K) : ?V {
+      let keyObj = {key = k; hash = hashOf(k);};
+      T.find<K,V>(map, keyObj, isEq)
     };
-    ov
-  };
 
-  /// Returns an `Iter` over the entries.
-  ///
-  /// Each iterator gets a _persistent view_ of the mapping, independent of concurrent updates to the iterated map.
-  public func entries() : I.Iter<(K,V)> = object {
-    var stack = ?(map, null) : List.List<T.Trie<K,V>>;
-    public func next() : ?(K,V) {
-      switch stack {
-      case null { null };
-      case (?(trie, stack2)) {
-        switch trie {
-        case (#empty) {
-               stack := stack2;
-               next()
-             };
-        case (#leaf({keyvals=null})) {
-               stack := stack2;
-               next()
-             };
-        case (#leaf({size=c; keyvals=?((k,v),kvs)})) {
-               stack := ?(#leaf({size=c-1; keyvals=kvs}), stack2);
-               ?(k.key, v)
-             };
-        case (#branch(br)) {
-               stack := ?(br.left, ?(br.right, stack2));
-               next()
-             };
+    /// Delete the (optional) value associated with the given key.
+    public func delete(k : K) =
+      ignore remove(k);
+
+    /// Delete and return the (optional) value associated with the given key.
+    public func remove(k : K) : ?V {
+      let keyObj = {key = k; hash = hashOf(k);};
+      let (t, ov) = T.remove<K, V>(map, keyObj, isEq);
+      map := t;
+      switch (ov) {
+        case null { _size -= 1 };
+        case _ {}
+      };
+      ov
+    };
+
+    /// Returns an `Iter` over the entries.
+    ///
+    /// Each iterator gets a _persistent view_ of the mapping, independent of concurrent updates to the iterated map.
+    public func entries() : I.Iter<(K, V)> {
+      object {
+        var stack = ?(map, null) : List.List<T.Trie<K, V>>;
+        public func next() : ?(K, V) {
+          switch stack {
+            case null { null };
+            case (?(trie, stack2)) {
+              switch trie {
+                case (#empty) {
+                  stack := stack2;
+                  next()
+                };
+                case (#leaf({keyvals = null})) {
+                  stack := stack2;
+                  next()
+                };
+                case (#leaf({size = c; keyvals = ?((k, v), kvs)})) {
+                  stack := ?(#leaf({size=c-1; keyvals=kvs}), stack2);
+                  ?(k.key, v)
+                };
+                case (#branch(br)) {
+                  stack := ?(br.left, ?(br.right, stack2));
+                  next()
+                };
+              }
+            }
           }
-         }
         }
       }
-    };
-
-  };
-
-
-/// Clone the map, given its key operations.
-public func clone<K,V>
-  (h:TrieMap<K,V>,
-   keyEq: (K,K) -> Bool,
-   keyHash: K -> Hash.Hash) : TrieMap<K,V> {
-  let h2 = TrieMap<K,V>(keyEq, keyHash);
-  for ((k,v) in h.entries()) {
-    h2.put(k,v);
-  };
-  h2
-};
-
-/// Clone an iterator of key-value pairs.
-public func fromEntries<K, V>(entries:I.Iter<(K, V)>,
-                              keyEq: (K,K) -> Bool,
-                              keyHash: K -> Hash.Hash) : TrieMap<K,V> {
-  let h = TrieMap<K,V>(keyEq, keyHash);
-  for ((k,v) in entries) {
-    h.put(k,v);
-  };
-  h
-};
-
-/// Transform (map) the values of a map, retaining its keys.
-public func map<K, V1, V2>
-  (h:TrieMap<K,V1>,
-   keyEq: (K,K) -> Bool,
-   keyHash: K -> Hash.Hash,
-   mapFn: (K, V1) -> V2,
-  ) : TrieMap<K,V2> {
-  let h2 = TrieMap<K,V2>(keyEq, keyHash);
-  for ((k, v1) in h.entries()) {
-    let v2 = mapFn(k, v1);
-    h2.put(k,v2);
-  };
-  h2
-};
-
-/// Transform and filter the values of a map, retaining its keys.
-public func mapFilter<K, V1, V2>
-  (h:TrieMap<K,V1>,
-   keyEq: (K,K) -> Bool,
-   keyHash: K -> Hash.Hash,
-   mapFn: (K, V1) -> ?V2,
-  ) : TrieMap<K,V2> {
-  let h2 = TrieMap<K,V2>(keyEq, keyHash);
-  for ((k, v1) in h.entries()) {
-    switch (mapFn(k, v1)) {
-      case null { };
-      case (?v2) {
-             h2.put(k,v2);
-           };
     }
   };
-  h2
-};
+
+
+  /// Clone the map, given its key operations.
+  public func clone<K, V>(
+    h : TrieMap<K, V>,
+    keyEq : (K,K) -> Bool,
+    keyHash : K -> Hash.Hash
+  ) : TrieMap<K, V> {
+    let h2 = TrieMap<K, V>(keyEq, keyHash);
+    for ((k,v) in h.entries()) {
+      h2.put(k,v);
+    };
+    h2
+  };
+
+  /// Clone an iterator of key-value pairs.
+  public func fromEntries<K, V>(
+    entries : I.Iter<(K, V)>,
+    keyEq : (K, K) -> Bool,
+    keyHash : K -> Hash.Hash
+  ) : TrieMap<K, V> {
+    let h = TrieMap<K, V>(keyEq, keyHash);
+    for ((k,v) in entries) {
+      h.put(k,v);
+    };
+    h
+  };
+
+  /// Transform (map) the values of a map, retaining its keys.
+  public func map<K, V1, V2> (
+    h : TrieMap<K, V1>,
+    keyEq : (K, K) -> Bool,
+    keyHash : K -> Hash.Hash,
+    mapFn : (K, V1) -> V2,
+  ) : TrieMap<K, V2> {
+    let h2 = TrieMap<K, V2>(keyEq, keyHash);
+    for ((k, v1) in h.entries()) {
+      let v2 = mapFn(k, v1);
+      h2.put(k,v2);
+    };
+    h2
+  };
+
+  /// Transform and filter the values of a map, retaining its keys.
+  public func mapFilter<K, V1, V2>(
+    h : TrieMap<K, V1>,
+    keyEq : (K, K) -> Bool,
+    keyHash : K -> Hash.Hash,
+    mapFn : (K, V1) -> ?V2,
+  ) : TrieMap<K, V2> {
+    let h2 = TrieMap<K, V2>(keyEq, keyHash);
+    for ((k, v1) in h.entries()) {
+      switch (mapFn(k, v1)) {
+        case null { };
+        case (?v2) {
+          h2.put(k,v2);
+        };
+      }
+    };
+    h2
+  };
 
 }

--- a/src/TrieSet.mo
+++ b/src/TrieSet.mo
@@ -17,62 +17,71 @@ import Hash "Hash";
 import List "List";
 
 module {
-public type Hash = Hash.Hash;
-public type Set<T> = Trie.Trie<T,()>;
+
+  public type Hash = Hash.Hash;
+  public type Set<T> = Trie.Trie<T,()>;
 
   /// Empty set.
-  public func empty<T>():Set<T> =
-    Trie.empty<T,()>();
+  public func empty<T>() : Set<T> { Trie.empty<T,()>(); };
+
   /// Put an element into the set.
-  public func put<T>(s:Set<T>, x:T, xh:Hash, eq:(T,T)->Bool) : Set<T> {
-    let (s2, _) = Trie.put<T,()>(s, {key=x; hash=xh}, eq, ());
+  public func put<T>(s : Set<T>, x : T, xh : Hash, eq : (T, T) -> Bool) : Set<T> {
+    let (s2, _) = Trie.put<T,()>(s, {key = x; hash = xh}, eq, ());
     s2
   };
+
   /// Delete an element from the set.
-  public func delete<T>(s:Set<T>, x:T, xh:Hash, eq:(T,T)->Bool) : Set<T> {
-    let (s2, _) = Trie.remove<T,()>(s, {key=x; hash=xh}, eq);
+  public func delete<T>(s : Set<T>, x : T, xh : Hash, eq : (T, T) -> Bool) : Set<T> {
+    let (s2, _) = Trie.remove<T, ()>(s, {key = x; hash = xh}, eq);
     s2
   };
+
   /// Test if two sets are equal.
-  public func equal<T>(s1:Set<T>, s2:Set<T>, eq:(T,T)->Bool):Bool {
+  public func equal<T>(s1 : Set<T>, s2 : Set<T>, eq : (T, T) -> Bool) : Bool {
     // XXX: Todo: use a smarter check
-    func unitEqual (_:(),_:()):Bool{ true };
-    Trie.equalStructure<T,()>(s1, s2, eq, unitEqual)
+    func unitEqual (_ : (),_ : ()) : Bool { true };
+    Trie.equalStructure<T, ()>(s1, s2, eq, unitEqual)
   };
+
   /// The number of set elements, set's cardinality.
-  public func size<T>(s:Set<T>) : Nat {
-    Trie.foldUp<T,(),Nat>
-    (s,
-     func(n:Nat,m:Nat):Nat{n+m},
-     func(_:T,_:()):Nat{1},
-     0)
+  public func size<T>(s : Set<T>) : Nat {
+    Trie.foldUp<T, (), Nat>(
+      s,
+      func(n : Nat, m : Nat) : Nat { n + m },
+      func(_ : T, _ : ()) : Nat { 1 },
+      0
+    )
   };
+
   /// Test if a set contains a given element.
-  public func mem<T>(s:Set<T>, x:T, xh:Hash, eq:(T,T)->Bool):Bool {
-    switch (Trie.find<T,()>(s, {key=x; hash=xh}, eq)) {
-    case null { false };
-    case (?_) { true };
+  public func mem<T>(s : Set<T>, x : T, xh : Hash, eq : (T, T) -> Bool) : Bool {
+    switch (Trie.find<T, ()>(s, {key = x; hash = xh}, eq)) {
+      case null { false };
+      case (?_) { true };
     }
   };
+
   /// [Set union](https://en.wikipedia.org/wiki/Union_(set_theory)).
-  public func union<T>(s1:Set<T>, s2:Set<T>, eq:(T,T)->Bool):Set<T> {
-    let s3 = Trie.merge<T,()>(s1, s2, eq);
+  public func union<T>(s1 : Set<T>, s2 : Set<T>, eq : (T, T) -> Bool) : Set<T> {
+    let s3 = Trie.merge<T, ()>(s1, s2, eq);
     s3
   };
+
   /// [Set difference](https://en.wikipedia.org/wiki/Difference_(set_theory)).
-  public func diff<T>(s1:Set<T>, s2:Set<T>, eq:(T,T)->Bool):Set<T> {
-    let s3 = Trie.diff<T,(),()>(s1, s2, eq);
+  public func diff<T>(s1 : Set<T>, s2 : Set<T>, eq : (T, T) -> Bool) : Set<T> {
+    let s3 = Trie.diff<T, (), ()>(s1, s2, eq);
     s3
   };
+
   /// [Set intersection](https://en.wikipedia.org/wiki/Intersection_(set_theory)).
-  public func intersect<T>(s1:Set<T>, s2:Set<T>, eq:(T,T)->Bool):Set<T> {
-    let noop : ((),())->(()) = func (_:(),_:()):(())=();
-    let s3 = Trie.join<T,(),(),()>(s1, s2, eq, noop);
+  public func intersect<T>(s1 : Set<T>, s2 : Set<T>, eq : (T, T) -> Bool) : Set<T> {
+    let noop : ((), ()) -> (()) = func (_ : (), _ : ()) : (()) = ();
+    let s3 = Trie.join<T, (), (), ()>(s1, s2, eq, noop);
     s3
   };
 
   //// Construct a set from an array.
-  public func fromArray<T>(arr: [T], elemHash: T -> Hash, eq: (T, T) -> Bool): Set<T> {
+  public func fromArray<T>(arr : [T], elemHash : T -> Hash, eq : (T, T) -> Bool) : Set<T> {
     var s = empty<T>();
     for (elem in arr.vals()) {
       s := put<T>(s, elem, elemHash(elem), eq);
@@ -81,8 +90,8 @@ public type Set<T> = Trie.Trie<T,()>;
   };
 
   //// Returns the set as an array.
-  public func toArray<T>(s: Set<T>): [T] {
-    Trie.toArray(s, func (t: T, _: ()): T { t })
+  public func toArray<T>(s : Set<T>): [T] {
+    Trie.toArray(s, func (t : T, _ : ()) : T { t })
   }
 
 }

--- a/src/TrieSet.mo
+++ b/src/TrieSet.mo
@@ -26,13 +26,13 @@ module {
 
   /// Put an element into the set.
   public func put<T>(s : Set<T>, x : T, xh : Hash, eq : (T, T) -> Bool) : Set<T> {
-    let (s2, _) = Trie.put<T,()>(s, {key = x; hash = xh}, eq, ());
+    let (s2, _) = Trie.put<T,()>(s, { key = x; hash = xh }, eq, ());
     s2
   };
 
   /// Delete an element from the set.
   public func delete<T>(s : Set<T>, x : T, xh : Hash, eq : (T, T) -> Bool) : Set<T> {
-    let (s2, _) = Trie.remove<T, ()>(s, {key = x; hash = xh}, eq);
+    let (s2, _) = Trie.remove<T, ()>(s, { key = x; hash = xh }, eq);
     s2
   };
 
@@ -55,7 +55,7 @@ module {
 
   /// Test if a set contains a given element.
   public func mem<T>(s : Set<T>, x : T, xh : Hash, eq : (T, T) -> Bool) : Bool {
-    switch (Trie.find<T, ()>(s, {key = x; hash = xh}, eq)) {
+    switch (Trie.find<T, ()>(s, { key = x; hash = xh }, eq)) {
       case null { false };
       case (?_) { true };
     }


### PR DESCRIPTION
- add eponymous type binding to primitive modules, eg. Nat8.Nat8 (commented out for now)
- apply style guidelines throughout (might have missed a few still, but was pretty thorough)

unresolved issues collected in #258 

Once in master and auto-merged to next-moc, I'll do a next-moc PR to expose the type components that rely on a new version of moc with extended mo:prim)

