### PR TITLE
Change version label from master to latest

### DIFF
--- a/doc/antora.yml
+++ b/doc/antora.yml
@@ -1,5 +1,5 @@
 name: docs
-version: 'master'
+version: 'latest'
 asciidoc:
   attributes:
     page-repl: true@


### PR DESCRIPTION
To be more PC and "accurate" changing the label for the docs bucket from "master" to "latest"