### PR TITLE
Fix unwraps

### DIFF
--- a/src/List.mo
+++ b/src/List.mo
@@ -406,7 +406,10 @@ module {
     Array.tabulate<A>(length, func (i) {
       let popped = pop<A>(list);
       list := popped.1;
-      Option.unwrap<A>(popped.0);
+      switch (popped.0) {
+        case null { loop { assert false } };
+        case (?x) x;
+      }
     });
   };
 

--- a/src/Option.mo
+++ b/src/Option.mo
@@ -12,13 +12,13 @@
 ///   case null 0;
 ///   case (?int) int;
 /// };
-/// assert (int1orZero == 42);
+/// assert int1orZero == 42;
 ///
 /// let int2orZero : Int = switch optionalInt2 {
 ///   case null 0;
 ///   case (?int) int;
 /// };
-/// assert (int2orZero == 0);
+/// assert int2orZero == 0;
 /// ```
 ///
 /// The functions in this module capture some common operations when working
@@ -47,8 +47,8 @@ module {
   /// Applies a function to the wrapped value. `null`'s are left untouched.
   /// ```motoko
   /// import Option "mo:base/Option";
-  /// assert (Option.map<Nat, Nat>(?(42), func x = x + 1) == ?(43));
-  /// assert (Option.map<Nat, Nat>(null, func x = x + 1) == null);
+  /// assert Option.map<Nat, Nat>(?42, func x = x + 1) == ?43;
+  /// assert Option.map<Nat, Nat>(null, func x = x + 1) == null;
   /// ```
   public func map<A, B>(x : ?A, f : A -> B) : ?B =
     switch x {
@@ -62,10 +62,10 @@ module {
   /// ```motoko
   /// import Option "mo:base/Option";
   /// var counter : Nat = 0;
-  /// Option.iterate(?(5), func (x : Nat) { counter += x });
-  /// assert (counter == 5);
+  /// Option.iterate(?5, func (x : Nat) { counter += x });
+  /// assert counter == 5;
   /// Option.iterate(null, func (x : Nat) { counter += x });
-  /// assert (counter == 5);
+  /// assert counter == 5;
   /// ```
   public func iterate<A>(x : ?A, f : A -> ()) =
     switch x {
@@ -102,9 +102,9 @@ module {
   /// Given an optional optional value, removes one layer of optionality.
   /// ```motoko
   /// import Option "mo:base/Option";
-  /// assert (Option.flatten(?(?(42))) == ?(42));
-  /// assert (Option.flatten(?(null)) == null);
-  /// assert (Option.flatten(null) == null);
+  /// assert Option.flatten(?(?(42))) == ?42;
+  /// assert Option.flatten(?(null)) == null;
+  /// assert Option.flatten(null) == null;
   /// ```
   public func flatten<A>(x : ??A) : ?A {
     chain<?A, A>(x, func (x_ : ?A) : ?A {
@@ -115,7 +115,7 @@ module {
   /// Creates an optional value from a definite value.
   /// ```motoko
   /// import Option "mo:base/Option";
-  /// assert (Option.make(42) == ?(42));
+  /// assert Option.make(42) == ?42;
   /// ```
   public func make<A>(x: A) : ?A = ?x;
 

--- a/src/Option.mo
+++ b/src/Option.mo
@@ -8,17 +8,17 @@
 /// let optionalInt1 : ?Int = ?42;
 /// let optionalInt2 : ?Int = null;
 ///
-/// let int1orZero : Int = switch(optionalInt1) {
+/// let int1orZero : Int = switch optionalInt1 {
 ///   case null 0;
 ///   case (?int) int;
 /// };
-/// assert(int1orZero == 42);
+/// assert (int1orZero == 42);
 ///
-/// let int2orZero : Int = switch(optionalInt2) {
+/// let int2orZero : Int = switch optionalInt2 {
 ///   case null 0;
 ///   case (?int) int;
 /// };
-/// assert(int2orZero == 0);
+/// assert (int2orZero == 0);
 /// ```
 ///
 /// The functions in this module capture some common operations when working
@@ -47,8 +47,8 @@ module {
   /// Applies a function to the wrapped value. `null`'s are left untouched.
   /// ```motoko
   /// import Option "mo:base/Option";
-  /// assert(Option.map<Nat, Nat>(?(42), func x = x + 1) == ?(43));
-  /// assert(Option.map<Nat, Nat>(null, func x = x + 1) == null);
+  /// assert (Option.map<Nat, Nat>(?(42), func x = x + 1) == ?(43));
+  /// assert (Option.map<Nat, Nat>(null, func x = x + 1) == null);
   /// ```
   public func map<A, B>(x : ?A, f : A -> B) : ?B =
     switch x {
@@ -63,9 +63,9 @@ module {
   /// import Option "mo:base/Option";
   /// var counter : Nat = 0;
   /// Option.iterate(?(5), func (x : Nat) { counter += x });
-  /// assert(counter == 5);
+  /// assert (counter == 5);
   /// Option.iterate(null, func (x : Nat) { counter += x });
-  /// assert(counter == 5);
+  /// assert (counter == 5);
   /// ```
   public func iterate<A>(x : ?A, f : A -> ()) =
     switch x {
@@ -102,9 +102,9 @@ module {
   /// Given an optional optional value, removes one layer of optionality.
   /// ```motoko
   /// import Option "mo:base/Option";
-  /// assert(Option.flatten(?(?(42))) == ?(42));
-  /// assert(Option.flatten(?(null)) == null);
-  /// assert(Option.flatten(null) == null);
+  /// assert (Option.flatten(?(?(42))) == ?(42));
+  /// assert (Option.flatten(?(null)) == null);
+  /// assert (Option.flatten(null) == null);
   /// ```
   public func flatten<A>(x : ??A) : ?A {
     chain<?A, A>(x, func (x_ : ?A) : ?A {
@@ -115,7 +115,7 @@ module {
   /// Creates an optional value from a definite value.
   /// ```motoko
   /// import Option "mo:base/Option";
-  /// assert(Option.make(42) == ?(42));
+  /// assert (Option.make(42) == ?(42));
   /// ```
   public func make<A>(x: A) : ?A = ?x;
 
@@ -134,7 +134,7 @@ module {
     };
 
   /// Asserts that the value is not `null`; fails otherwise.
-  /// Deprecated.
+  /// @deprecated Option.assertSome will be removed soon; use an assert expression instead
   public func assertSome(x : ?Any) =
     switch x {
       case null { P.unreachable() };
@@ -142,7 +142,7 @@ module {
     };
 
   /// Asserts that the value _is_ `null`; fails otherwise.
-  /// Deprecated.
+  /// @deprecated Option.assertNull will be removed soon; use an assert expression instead
   public func assertNull(x : ?Any) =
     switch x {
       case null { };
@@ -151,7 +151,7 @@ module {
 
   /// Unwraps an optional value, i.e. `unwrap(?x) = x`.
   ///
-  /// WARNING: `unwrap(x)` will fail if the argument is `null`, and is generally considered bad style. Use `switch x` instead.
+  /// @deprecated Option.unwrap is unsafe and fails if the argument is null; it will be removed soon; use a `switch` or `do?` expression instead
   public func unwrap<T>(x : ?T) : T =
     switch x {
       case null { P.unreachable() };

--- a/src/Trie.mo
+++ b/src/Trie.mo
@@ -569,7 +569,7 @@ module {
        case (#leaf(l)) {
          leaf(AssocList.disj<Key<K>, V, W, X>(null, l.keyvals, key_eq, vbin), bitpos)
        };
-       case (#branch(b)) { 
+       case (#branch(b)) {
          branch(recR(b.left, bitpos + 1),
                 recR(b.right, bitpos + 1)) };
      }
@@ -876,7 +876,11 @@ module {
         }
       };
       rec(tb);
-      A.tabulate<W>(c, func(i : Nat) : W = Option.unwrap<W>(a[i]))
+      A.tabulate<W>(c, func(i : Nat) : W {
+        switch (a[i]) {
+          case null { loop { assert false } };
+          case (?x) { x }
+        }})
     };
 
   };
@@ -959,7 +963,10 @@ module {
       let a = A.tabulate<W> (
         size<K, V>(t),
         func (i : Nat) : W {
-          let (k, v) = Option.unwrap<(Key<K>, V)>(nth<K, V>(t, i));
+          let (k, v) = switch (nth<K, V>(t, i)) {
+            case null { loop { assert false } };
+            case (?x) { x };
+          };
           f(k.key, v)
         }
       );

--- a/src/Trie.mo
+++ b/src/Trie.mo
@@ -964,7 +964,7 @@ module {
         size<K, V>(t),
         func (i : Nat) : W {
           let (k, v) = switch (nth<K, V>(t, i)) {
-            case null { loop { assert false } };
+            case null { P.unreachable() };
             case (?x) { x };
           };
           f(k.key, v)

--- a/src/Trie.mo
+++ b/src/Trie.mo
@@ -878,7 +878,7 @@ module {
       rec(tb);
       A.tabulate<W>(c, func(i : Nat) : W {
         switch (a[i]) {
-          case null { loop { assert false } };
+          case null { P.unreachable() };
           case (?x) { x }
         }})
     };


### PR DESCRIPTION
Updates `base` to not use deprecated `unwrap`, linked to #274 