### PR TITLE
Fix: AssocList diff bug fix; fixes Trie modules

### DIFF
--- a/src/AssocList.mo
+++ b/src/AssocList.mo
@@ -73,7 +73,7 @@ module {
 
   /// The entries of the final list consist of those pairs of
   /// the left list whose keys are not present in the right list; the
-  /// values of the right list are irrelevant.
+  /// "extra" values of the right list are irrelevant.
   public func diff<K, V, W>(
     al1 : AssocList<K, V>,
     al2 : AssocList<K, W>,
@@ -84,8 +84,8 @@ module {
         case (null) { null };
         case (?((k, v1), tl)) {
           switch (find<K, W>(al2, k, keq)) {
-            case (null) { rec(tl)};
-            case (?v2) { ?((k, v1), rec(tl)) };
+            case (null) { ?((k, v1), rec(tl)) };
+            case (?v2) { rec(tl)};
           }
         };
       }

--- a/test/trieSetTest.mo
+++ b/test/trieSetTest.mo
@@ -1,28 +1,52 @@
 import Nat "mo:base/Nat";
 import TrieSet "mo:base/TrieSet";
 import Nat32 "mo:base/Nat32";
+import Hash "mo:base/Hash";
 import Suite "mo:matchers/Suite";
 import M "mo:matchers/Matchers";
 import T "mo:matchers/Testable";
 
-let set1 = TrieSet.fromArray<Nat>([ 1, 2, 3, 1, 2, 3, 1 ], Nat32.fromNat, Nat.equal);
+let simpleTests = do {
+  let set1 = TrieSet.fromArray<Nat>([ 1, 2, 3, 1, 2, 3, 1 ], Nat32.fromNat, Nat.equal);
 
-let suite = Suite.suite("TrieSet fromArray", [
-  Suite.test(
-    "mem",
-    TrieSet.mem<Nat>(set1, 1, 1, Nat.equal),
-    M.equals(T.bool true)
-  ),
-  Suite.test(
-    "size",
-    TrieSet.size(set1),
-    M.equals(T.nat 3)
-  ),
-  Suite.test(
-    "toArray",
-    TrieSet.toArray<Nat>(set1),
-    M.equals(T.array<Nat>(T.natTestable, [ 1, 2, 3 ]))
-  )
-]);
+  let suite = Suite.suite("TrieSet fromArray", [
+    Suite.test(
+      "mem",
+      TrieSet.mem<Nat>(set1, 1, 1, Nat.equal),
+      M.equals(T.bool true)
+    ),
+    Suite.test(
+      "size",
+      TrieSet.size(set1),
+      M.equals(T.nat 3)
+    ),
+    Suite.test(
+      "toArray",
+      TrieSet.toArray<Nat>(set1),
+      M.equals(T.array<Nat>(T.natTestable, [ 1, 2, 3 ]))
+    )
+  ]);
+  Suite.run(suite);
+};
 
-Suite.run(suite);
+let binopTests = do {
+  let a = TrieSet.fromArray<Nat>([1, 3], Hash.hash, Nat.equal);
+  let b = TrieSet.fromArray<Nat>([2, 3], Hash.hash, Nat.equal);
+
+  let suite = Suite.suite("TrieSet -- binary operations", [
+    Suite.test("union",
+      TrieSet.toArray(TrieSet.union(a, b, Nat.equal)),
+      M.equals(T.array<Nat>(T.natTestable, [1, 2, 3]))
+    ),
+    Suite.test("intersect",
+      TrieSet.toArray(TrieSet.intersect(a, b, Nat.equal)),
+      M.equals(T.array<Nat>(T.natTestable, [3]))
+    ),
+    Suite.test("diff",
+      TrieSet.toArray(TrieSet.diff(a, b, Nat.equal)),
+      M.equals(T.array<Nat>(T.natTestable, [1]))
+    ),
+  ]);
+  Suite.run(suite);
+};
+


### PR DESCRIPTION
This PR fixes a logic bug in `AssocList.diff` (swapped cases).
This PR also adds a regression test that demonstrates the bug (thanks to @FloorLamp for the initial test and report; apologies for the extremely long delay in filing this officially and fixing it!).