### PR TITLE
Fix arithmetic overflow in TrieMap.

### DIFF
--- a/src/TrieMap.mo
+++ b/src/TrieMap.mo
@@ -63,8 +63,8 @@ module {
       let (t, ov) = T.remove<K, V>(map, keyObj, isEq);
       map := t;
       switch (ov) {
-        case null { _size -= 1 };
-        case _ {}
+        case null {};
+        case (?_) { _size -= 1 }
       };
       ov
     };

--- a/test/trieMapTest.mo
+++ b/test/trieMapTest.mo
@@ -6,7 +6,14 @@ import Text "mo:base/Text";
 debug {
   let a = H.TrieMap<Text, Nat>(Text.equal, Text.hash);
 
+  assert a.size() == 0;
   ignore a.remove("apple");
+  assert a.size() == 0;
+
+  a.put("apple", 1);
+  assert a.size() == 1;
+  ignore a.remove("apple");
+  assert a.size() == 0;
 
   a.put("apple", 1);
   a.put("banana", 2);

--- a/test/trieMapTest.mo
+++ b/test/trieMapTest.mo
@@ -6,6 +6,8 @@ import Text "mo:base/Text";
 debug {
   let a = H.TrieMap<Text, Nat>(Text.equal, Text.hash);
 
+  ignore a.remove("apple");
+
   a.put("apple", 1);
   a.put("banana", 2);
   a.put("pear", 3);
@@ -126,5 +128,4 @@ debug {
     case (?w) { assert v == w };
     };
   };
-
 };


### PR DESCRIPTION
In the current implementation the `size` gets reduced if the previous (removed) value is `null`.

https://github.com/dfinity/motoko-base/blob/2ac0707502bf7ffd816a37d480861f7a60e65628/src/TrieMap.mo#L63-L68

This results in an `arithmetic overflow`, since you'll be lowering `size` for every unknown key you try to remove.
I.e. if the map is empty and you remove an (unknown) key.

---

### How to replicate:

```
let a = H.TrieMap<Text, Nat>(Text.equal, Text.hash);
ignore a.remove("apple");
```