### PR TITLE
Use primitives provided by compiler for `Float` ⇔ `Int` conversions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ on:
 # Remember to update me in package-set.yml as well
 env:
   vessel_version: "v0.6.2"
-  moc_version: "0.6.7"
+  moc_version: "0.6.8"
 
 jobs:
   tests:

--- a/.github/workflows/package-set.yml
+++ b/.github/workflows/package-set.yml
@@ -8,7 +8,7 @@ on:
 
 env:
   vessel_version: "v0.6.2"
-  moc_version: "0.6.7"
+  moc_version: "0.6.8"
 
 jobs:
   verify:

--- a/src/Float.mo
+++ b/src/Float.mo
@@ -95,13 +95,13 @@ module {
   /// Conversion from Int64.
   public let fromInt64 : Int64 -> Float = Prim.int64ToFloat;
 
-  /// Conversion to Int via Int64, equivalent to `Int64.toInt(toInt64(trunc(f)))`
+  /// Conversion to Int.
   public let toInt : Float -> Int =
-    func (x : Float) : Int = Prim.int64ToInt(toInt64(x));
+    func (x : Float) : Int = Prim.floatToInt;
 
-  /// Conversion from Int via Int64. May trap.
+  /// Conversion from Int. May result in `Inf`.
   public let fromInt : Int -> Float =
-    func (x : Int) : Float = fromInt64(Prim.intToInt64(x));
+    func (x : Int) : Float = Prim.intToFloat;
 
   /// Returns `x == y`.
   public func equal(x : Float, y : Float) : Bool { x == y };

--- a/src/Float.mo
+++ b/src/Float.mo
@@ -96,12 +96,10 @@ module {
   public let fromInt64 : Int64 -> Float = Prim.int64ToFloat;
 
   /// Conversion to Int.
-  public let toInt : Float -> Int =
-    func (x : Float) : Int = Prim.floatToInt;
+  public let toInt : Float -> Int = Prim.floatToInt;
 
   /// Conversion from Int. May result in `Inf`.
-  public let fromInt : Int -> Float =
-    func (x : Int) : Float = Prim.intToFloat;
+  public let fromInt : Int -> Float = Prim.intToFloat;
 
   /// Returns `x == y`.
   public func equal(x : Float, y : Float) : Bool { x == y };


### PR DESCRIPTION
Fixes #272.