### PR TITLE
ExperimentalStableMemory 

### DIFF
--- a/src/ExperimentalStableMemory.mo
+++ b/src/ExperimentalStableMemory.mo
@@ -1,6 +1,6 @@
 /// Byte-level access to (virtual) _stable memory_.
 ///
-/// **WARNING**: The `StableMemory` library is **experimental**, subject to change
+/// **WARNING**: The `ExperimentalStableMemory` library is **experimental**, subject to change
 /// and may be replaced by safer alternatives in later versions of Motoko.
 /// Use at your own risk and discretion.
 ///

--- a/src/ExperimentalStableMemory.mo
+++ b/src/ExperimentalStableMemory.mo
@@ -1,6 +1,6 @@
 /// Byte-level access to (virtual) _stable memory_.
 ///
-/// **WARNING**: The `ExperimentalStableMemory` library is **experimental**, subject to change
+/// **WARNING**: As its name suggests, this library is **experimental**, subject to change
 /// and may be replaced by safer alternatives in later versions of Motoko.
 /// Use at your own risk and discretion.
 ///

--- a/src/ExperimentalStableMemory.mo
+++ b/src/ExperimentalStableMemory.mo
@@ -1,9 +1,16 @@
 /// Byte-level access to (virtual) _stable memory_.
 ///
+/// **WARNING**: The `StableMemory` library is **experimental**, subject to change
+/// and may be replaced by safer alternatives in later versions of Motoko.
+/// Use at your own risk and discretion.
+///
 /// This is a lightweight abstraction over IC _stable memory_ and supports persisting
 /// raw binary data across Motoko upgrades.
 /// Use of this module is fully compatible with Motoko's use of
 /// _stable variables_, whose persistence mechanism also uses (real) IC stable memory internally, but does not interfere with this API.
+///
+/// Memory is allocated, using 'grow(pages)`, sequentially and on demand, in units of 64KiB pages, starting with 0 allocated pages.
+/// New pages are zero initialized.
 ///
 /// Each `load` operation loads from byte address `offset` in little-endian
 /// format using the natural bit-width of the type in question.
@@ -13,6 +20,9 @@
 /// The operation traps if attempting to write beyond the current stable memory size.
 ///
 /// Text values can be handled by using `Text.decodeUtf8` and `Text.encodeUtf8`, in conjunction with `loadBlob` and `storeBlob`.
+///
+/// The current page allocation and page contents is preserved across upgrades.
+///
 ///
 /// NB: The IC's actual stable memory size (`ic0.stable_size`) may exceed the
 /// page size reported by Motoko function `size()`.
@@ -25,6 +35,8 @@ module {
   /// Current size of the stable memory, in pages.
   /// Each page is 64KiB (65536 bytes).
   /// Initially `0`.
+  /// Preserved across upgrades, together with contents of allocated
+  /// StableMemory.
   public let size : () -> (pages : Nat32) =
     Prim.stableMemorySize;
 
@@ -32,6 +44,7 @@ module {
   /// Each page is 64KiB (65536 bytes).
   /// Returns previous `size` when able to grow.
   /// Returns `0xFFFF` if remaining pages insufficient.
+  /// Every new page is zero-initialized, containing byte 0 at every offset.
   public let grow : (new_pages : Nat32) -> (oldpages : Nat32) =
     Prim.stableMemoryGrow;
 


### PR DESCRIPTION
* Rename as Experimental
* Add warning to doc
* Extend doc

You can tell this project has too many Germans on it by the length of the library names.