### PR TITLE
Fix wasmtime run for error `'--disable-cache' which wasn't expected`

### DIFF
--- a/test/Makefile
+++ b/test/Makefile
@@ -1,6 +1,6 @@
 STDLIB ?= ../src
 MOC ?= moc
-WASMTIME_OPTIONS = --disable-cache --cranelift
+WASMTIME_OPTIONS = --disable-cache --enable-cranelift-debug-verifier
 
 OUTDIR=_out
 
@@ -30,7 +30,7 @@ $(OUTDIR)/%.wasm: $(OUTDIR)/%.mo | $(OUTDIR)
 	$(MOC) -c --package base $(STDLIB) $(VESSEL_PKGS) -wasi-system-api -o $@ $<
 
 $(OUTDIR)/%.checked: $(OUTDIR)/%.wasm
-	wasmtime $(WASMTIME_OPTIONS) $<
+	wasmtime run $(WASMTIME_OPTIONS) $<
 	touch $@
 
 clean:

--- a/test/Makefile
+++ b/test/Makefile
@@ -1,6 +1,6 @@
 STDLIB ?= ../src
 MOC ?= moc
-WASMTIME_OPTIONS = --disable-cache --enable-cranelift-debug-verifier
+WASMTIME_OPTIONS = --disable-cache
 
 OUTDIR=_out
 


### PR DESCRIPTION
As per https://github.com/bytecodealliance/wasmtime/blob/main/RELEASES.md#0310, the `light beam` backend has been removed from `Wasmtime`, thus the backend isn't switchable any more. The `--cranelift` option is gone now, accordingly.