### PR TITLE
Use static literal `Blob` in `isAnonymous`

### DIFF
--- a/src/Principal.mo
+++ b/src/Principal.mo
@@ -18,9 +18,10 @@ module {
   /// Conversion.
   public func toText(p : Principal) : Text = debug_show(p);
 
-  private let anonymousPrincipal : Principal = fromText "2vxsx-fae";
+  private let anonymousPrincipal : Blob = "\04";
+
   public func isAnonymous(p : Principal) : Bool =
-    p == anonymousPrincipal;
+    Prim.blobOfPrincipal p == anonymousPrincipal;
 
   public func hash(principal : Principal) : Hash.Hash =
     Blob.hash (Prim.blobOfPrincipal(principal));

--- a/src/Principal.mo
+++ b/src/Principal.mo
@@ -18,8 +18,8 @@ module {
   /// Conversion.
   public func toText(p : Principal) : Text = debug_show(p);
 
-  public func isAnonymous(p: Principal): Bool =
-    equal(p, fromText("2vxsx-fae"));
+  public func isAnonymous(p : Principal) : Bool =
+    equal(p, "2vxsx-fae" : Principal);
 
   public func hash(principal : Principal) : Hash.Hash =
     Blob.hash (Prim.blobOfPrincipal(principal));

--- a/src/Principal.mo
+++ b/src/Principal.mo
@@ -18,8 +18,9 @@ module {
   /// Conversion.
   public func toText(p : Principal) : Text = debug_show(p);
 
+  let anonymousPrincipal = fromText "2vxsx-fae";
   public func isAnonymous(p : Principal) : Bool =
-    equal(p, "2vxsx-fae" : Principal);
+    p == anonymousPrincipal;
 
   public func hash(principal : Principal) : Hash.Hash =
     Blob.hash (Prim.blobOfPrincipal(principal));

--- a/src/Principal.mo
+++ b/src/Principal.mo
@@ -18,7 +18,7 @@ module {
   /// Conversion.
   public func toText(p : Principal) : Text = debug_show(p);
 
-  let anonymousPrincipal = fromText "2vxsx-fae";
+  private let anonymousPrincipal : Principal = fromText "2vxsx-fae";
   public func isAnonymous(p : Principal) : Bool =
     p == anonymousPrincipal;
 


### PR DESCRIPTION
This will hopefully be much cheaper in cycles and allocation.