### PR TITLE
Correctly compute RBTree size

### DIFF
--- a/src/RBTree.mo
+++ b/src/RBTree.mo
@@ -209,8 +209,11 @@ module {
   public func size<X, Y>(t : Tree<X, Y>) : Nat {
     switch t {
       case (#leaf) { 0 };
-      case (#node(_, l, _, r)) {
-        size(l) + size(r) + 1
+      case (#node(_, l, xy, r)) {
+        switch (xy.1) {
+          case null { size(l) + size(r) };
+          case (_) { size(l) + size(r) + 1 };
+        }
       };
     }
   };

--- a/src/RBTree.mo
+++ b/src/RBTree.mo
@@ -210,10 +210,7 @@ module {
     switch t {
       case (#leaf) { 0 };
       case (#node(_, l, xy, r)) {
-        switch (xy.1) {
-          case null { size(l) + size(r) };
-          case (_) { size(l) + size(r) + 1 };
-        }
+        size(l) + size(r) + (switch (xy.1) { case null 0; case _ 1 });
       };
     }
   };

--- a/test/RBTreeTest.mo
+++ b/test/RBTreeTest.mo
@@ -55,3 +55,7 @@ for ((num, lab) in t.entriesRev()) {
 }};
 
 assert RBT.size(t.share()) == 9;
+
+t.delete(5);
+
+assert RBT.size(t.share()) == 8;


### PR DESCRIPTION
Right now, it doesn't work when you `remove` or `delete` elements from the `RBTree`, since those methods just set the value of a `#node` to `null`. The fix is to treat the tree as empty in the latter case.