### PR TITLE
Add `toIter` method to `List`

### DIFF
--- a/src/Iter.mo
+++ b/src/Iter.mo
@@ -181,9 +181,7 @@ module {
   };
 
   /// Like `fromArray` but for Lists.
-  public func fromList<A>(xs : List.List<A>) : Iter<A> {
-    List.toArray<A>(xs).vals();
-  };
+  public let fromList = List.toIter;
 
   /// Consumes an iterator and collects its produced elements in an Array.
   /// ```motoko

--- a/src/List.mo
+++ b/src/List.mo
@@ -419,7 +419,7 @@ module {
     Array.thaw<A>(toArray<A>(xs));
 
   /// Create an iterator from a list.
-  public func toIter<A>(xs: List<A>) : Iter.Iter<A> {
+  public func toIter<A>(xs : List<A>) : Iter.Iter<A> {
     var state = xs;
     object {
       public func next() : ?A =

--- a/src/List.mo
+++ b/src/List.mo
@@ -1,6 +1,7 @@
 /// Purely-functional, singly-linked lists.
 
 import Array "Array";
+import Iter "IterType";
 import Option "Option";
 import Order "Order";
 import Result "Result";
@@ -416,5 +417,10 @@ module {
   /// Create a mutable array from a list.
   public func toVarArray<A>(xs : List<A>) : [var A] =
     Array.thaw<A>(toArray<A>(xs));
+
+  /// Create an iterator from a list.
+  public func toIter<A>(xs: List<A>) : Iter.Iter<A> {
+    toArray<A>(xs).vals();
+  };
 
 }

--- a/src/List.mo
+++ b/src/List.mo
@@ -420,21 +420,14 @@ module {
 
   /// Create an iterator from a list.
   public func toIter<A>(xs: List<A>) : Iter.Iter<A> {
-    var ix : Nat = 0;
-    let s = size<A>(xs);
-    var list = xs;
+    var state = xs;
     object {
-      public func next() : ?A {
-        if (ix >= s) {
-          return null
-        } else {
-          let popped = pop<A>(list);
-          list := popped.1;
-          ix += 1;
-          return popped.0
+      public func next() : ?A =
+        switch state {
+          case (?(hd, tl)) { state := tl; ?hd };
+          case _ null
         }
-      }
     }
-  };
+  }
 
 }

--- a/src/List.mo
+++ b/src/List.mo
@@ -420,7 +420,21 @@ module {
 
   /// Create an iterator from a list.
   public func toIter<A>(xs: List<A>) : Iter.Iter<A> {
-    toArray<A>(xs).vals();
+    var ix : Nat = 0;
+    let s = size<A>(xs);
+    var list = xs;
+    object {
+      public func next() : ?A {
+        if (ix >= s) {
+          return null
+        } else {
+          let popped = pop<A>(list);
+          list := popped.1;
+          ix += 1;
+          return popped.0
+        }
+      }
+    }
   };
 
 }

--- a/test/listTest.mo
+++ b/test/listTest.mo
@@ -1,6 +1,7 @@
 import List "mo:base/List";
 import Debug "mo:base/Debug";
 import Int "mo:base/Int";
+import Iter "mo:base/Iter";
 import Result "mo:base/Result";
 import Suite "mo:matchers/Suite";
 import M "mo:matchers/Matchers";
@@ -120,6 +121,21 @@ type X = Nat;
     let actual = List.toVarArray<Nat>(list);
 
     assert (actual.size() == expected.size());
+
+    for (i in actual.keys()) {
+      assert(actual[i] == expected[i]);
+    };
+  };
+
+  do {
+    Debug.print("  toIter");
+
+    let list : List.List<Nat> = ?(1, ?(2, ?(3, List.nil<Nat>())));
+    let _actual = List.toIter<Nat>(list);
+    let actual = [var 0, 0, 0];
+    let expected = [1, 2, 3];
+
+    Iter.iterate<Nat>(_actual, func (x, i) { actual[i] := x; });
 
     for (i in actual.keys()) {
       assert(actual[i] == expected[i]);


### PR DESCRIPTION
In this PR, I have added a method `toIter` to `List.mo` to convert `List` to `Iter`.
The first reason for this addition is that it is intuitive to have the conversion method defined in the class/module from which it is converted, in association with for example Rust's `array.into_iter()`.
The second reason is that the current library requires the conversion from `List` to `Iter` using `Iter.fromList()`, so there are situations where an extra `import Iter "mo:base/Iter";` is needed just for the conversion.
Thank you for your consideration.
