### PR TITLE
tidy: fix Hash.hash to avoid trapping; deprecate most Hash.hash functions; …

### DIFF
--- a/src/Array.mo
+++ b/src/Array.mo
@@ -24,8 +24,7 @@ module {
   };
 
   /// Append the values of two input arrays
-  /// @deprecated `Array.append` copies its arguments and has linear complexity;
-  /// when used in a loop, consider using a `Buffer`, and `Buffer.append`, instead.
+  /// @deprecated `Array.append` copies its arguments and has linear complexity; when used in a loop, consider using a `Buffer`, and `Buffer.append`, instead.
   public func append<A>(xs : [A], ys : [A]) : [A] {
     switch(xs.size(), ys.size()) {
       case (0, 0) { []; };

--- a/src/Array.mo
+++ b/src/Array.mo
@@ -22,8 +22,10 @@ module {
     };
     return true;
   };
+
   /// Append the values of two input arrays
-  /// @deprecated Array.append has critical performance flaws; use a Buffer, and Buffer.append, instead.
+  /// @deprecated `Array.append` copies its arguments and has linear complexity;
+  /// when used in a loop, consider using a `Buffer`, and `Buffer.append`, instead.
   public func append<A>(xs : [A], ys : [A]) : [A] {
     switch(xs.size(), ys.size()) {
       case (0, 0) { []; };

--- a/src/Hash.mo
+++ b/src/Hash.mo
@@ -22,8 +22,10 @@ module {
     ha == hb
   };
 
-  public func hash(i : Nat) : Hash {
-    let j = Prim.natToNat32(i);
+  /// Computes a hash from the least significant 32-bits of `n`, ignoring other bits.
+  /// @deprecated For large `Nat` values consider using a bespoke hash function that considers all of the argument's bits.
+  public func hash(n : Nat) : Hash {
+    let j = Prim.intToNat32Wrap(n);
     hashNat8(
       [j & (255 << 0),
        j & (255 << 8),
@@ -32,6 +34,7 @@ module {
       ]);
   };
 
+  /// @deprecated This function will be removed in future.
   public func debugPrintBits(bits : Hash) {
     for (j in Iter.range(0, length - 1)) {
       if (bit(bits, j)) {
@@ -42,6 +45,7 @@ module {
     }
   };
 
+  /// @deprecated This function will be removed in future.
   public func debugPrintBitsRev(bits : Hash) {
     for (j in Iter.revRange(length - 1, 0)) {
       if (bit(bits, Prim.abs(j))) {
@@ -60,6 +64,7 @@ module {
   /// Note: Be sure to explode each `Nat8` of a `Nat32` into its own `Nat32`, and to shift into lower 8 bits.
 
   // should this really be public?
+  /// @deprecated This function may be removed or changed in future.
   public func hashNat8(key : [Hash]) : Hash {
     var hash : Nat32 = 0;
     for (natOfKey in key.vals()) {


### PR DESCRIPTION
* Fixes #345 (Hash.hash(i) traps on large Nats)
* Deprecates adhoc functions in Hash
* Reword `Array.append` deprecation to explain the issue. There's nothing wrong with linear functions....
(I would like to get this in before releasing moc 0.6.26)

I think we might want to expose a proper hash function for Nat and Int derives from LibTomMath's hashing functions, if appropriate).