### PR TITLE
Add fromArray method to Buffer

### DIFF
--- a/src/Buffer.mo
+++ b/src/Buffer.mo
@@ -146,4 +146,19 @@ module {
     };
   };
 
+  /// Construct a buffer from an array.
+  public func fromArray<T>(arr: [T]): Buffer<T> {
+    let count = arr.size();
+    let buffer = Buffer<T>(count);
+
+    var i = 0;
+    label l loop {
+      if (i >= count) break l;
+      buffer.add(arr[i]);
+      i += 1;
+    };
+    
+    buffer
+  };
+
 }


### PR DESCRIPTION
Useful to use in postupgrade in combination with `buffer.toArray()` in preupgrade