### PR TITLE
Let type inference determine the type parameters if possible

### DIFF
--- a/src/Trie.mo
+++ b/src/Trie.mo
@@ -140,14 +140,14 @@ module {
           }
         };
         case (#leaf(l)) {
-          let len = List.size<(Key<K>, V)>(l.keyvals);
+          let len = List.size(l.keyvals);
           ((len <= MAX_LEAF_SIZE) or (not enforceNormal))
           and
           len == l.size
           and
-          ( List.all<(Key<K>, V)>(
+          ( List.all(
               l.keyvals,
-              func ((k : Key<K>, v  :V)) : Bool {
+              func ((k : Key<K>, v : V)) : Bool {
               // { Prim.debugPrint "testing hash..."; true }
               // and
                 ((k.hash & mask) == bits)
@@ -176,7 +176,7 @@ module {
             };
           let mask1 = mask | (Prim.natToNat32(1) << bitpos1);
           let bits1 = bits | (Prim.natToNat32(1) << bitpos1);
-          let sum = size<K, V>(b.left) + size<K, V>(b.right);
+          let sum = size(b.left) + size(b.right);
           (b.size == sum
        //  or (do { Prim.debugPrint("malformed size"); false })
            )
@@ -215,7 +215,7 @@ module {
 
   /// Construct a branch node, computing the size stored there.
   public func branch<K, V>(l : Trie<K, V>, r : Trie<K, V>) : Trie<K, V> {
-      let sum = size<K, V>(l) + size<K, V>(r);
+      let sum = size(l) + size(r);
       #branch {
         size = sum;
         left = l;
@@ -229,7 +229,7 @@ module {
   /// by constructing branches as necessary; to do so, it also needs the bitpos
   /// of the leaf.
   public func leaf<K, V>(kvs : AssocList<Key<K>, V>, bitpos : Nat) : Trie<K, V> {
-    fromList<K, V>(null, kvs, bitpos)
+    fromList(null, kvs, bitpos)
   };
 
   module ListUtil {
@@ -241,7 +241,7 @@ module {
         case null { true };
         case (?(_, t)) {
           if (i == 0) { false }
-          else { lenIsEqLessThan<T>(t, i - 1) }
+          else { lenIsEqLessThan(t, i - 1) }
         };
       };
     };
@@ -268,7 +268,7 @@ module {
     func rec(kvc : ?Nat, kvs : AssocList<Key<K>, V>, bitpos : Nat) : Trie<K, V> {
       switch kvc {
         case null {
-          switch (ListUtil.lenClamp<(Key<K>, V)>(kvs, MAX_LEAF_SIZE)) {
+          switch (ListUtil.lenClamp(kvs, MAX_LEAF_SIZE)) {
             case null {} /* fall through to branch case. */;
             case (?len) {
               return #leaf({ size = len; keyvals = kvs })
@@ -285,7 +285,7 @@ module {
           }
         };
       };
-      let (ls, l, rs, r) = splitList<K, V>(kvs, bitpos);
+      let (ls, l, rs, r) = splitList(kvs, bitpos);
       if ( ls == 0 and rs == 0 ) {
         #empty
       } else if (rs == 0 and ls <= MAX_LEAF_SIZE) {
@@ -306,12 +306,12 @@ module {
 
   /// Replace the given key's value option with the given one, returning the previous one
   public func replace<K, V>(t : Trie<K, V>, k : Key<K>, k_eq : (K, K) -> Bool, v : ?V) : (Trie<K, V>, ?V) {
-     let key_eq = equalKey<K>(k_eq);
+     let key_eq = equalKey(k_eq);
 
      func rec(t : Trie<K, V>, bitpos : Nat) : (Trie<K, V>, ?V) {
         switch t {
           case (#empty) {
-            let (kvs, _) = AssocList.replace<Key<K>, V>(null, k, key_eq, v);
+            let (kvs, _) = AssocList.replace(null, k, key_eq, v);
             (leaf(kvs, bitpos), null)
           };
           case (#branch(b)) {
@@ -328,7 +328,7 @@ module {
           };
        case (#leaf(l)) {
          let (kvs2, old_val) =
-           AssocList.replace<Key<K>, V>(l.keyvals, k, key_eq, v);
+           AssocList.replace(l.keyvals, k, key_eq, v);
          (leaf(kvs2, bitpos), old_val)
         };
       }
@@ -340,21 +340,21 @@ module {
 
   /// Put the given key's value in the trie; return the new trie, and the previous value associated with the key, if any
   public func put<K, V>(t : Trie<K, V>, k : Key<K>, k_eq : (K, K) -> Bool, v : V) : (Trie<K, V>, ?V) {
-      replace<K, V>(t, k, k_eq, ?v)
+      replace(t, k, k_eq, ?v)
     };
 
   /// Get the value of the given key in the trie, or return null if nonexistent
   public func get<K, V>(t : Trie<K, V>, k : Key<K>, k_eq : (K, K) -> Bool) : ?V =
-     find<K, V>(t, k, k_eq);
+     find(t, k, k_eq);
 
   /// Find the given key's value in the trie, or return null if nonexistent
   public func find<K, V>(t : Trie<K, V>, k : Key<K>, k_eq : (K, K) -> Bool) : ?V {
-      let key_eq = equalKey<K>(k_eq);
+      let key_eq = equalKey(k_eq);
       func rec(t : Trie<K, V>, bitpos : Nat) : ?V {
         switch t {
           case (#empty) { null };
           case (#leaf(l)) {
-            AssocList.find<Key<K>, V>(l.keyvals, k, key_eq)
+            AssocList.find(l.keyvals, k, key_eq)
           };
           case (#branch(b)) {
             let bit = Hash.bit(k.hash, bitpos);
@@ -375,7 +375,7 @@ module {
   func splitAssocList<K, V>(al : AssocList<Key<K>, V>, bitpos : Nat)
      : (AssocList<Key<K>, V>, AssocList<Key<K>, V>)
    {
-     List.partition<(Key<K>, V)>(
+     List.partition(
        al,
        func ((k : Key<K>, v : V)) : Bool {
          not Hash.bit(k.hash, bitpos)
@@ -409,7 +409,7 @@ module {
   /// operation in various ways, and does not (in general) lose
   /// information; this operation is a simpler, special case.
   public func merge<K, V>(tl:Trie<K, V>, tr:Trie<K, V>, k_eq : (K, K) -> Bool) : Trie<K, V> {
-      let key_eq = equalKey<K>(k_eq);
+      let key_eq = equalKey(k_eq);
       func rec(bitpos : Nat, tl : Trie<K, V>, tr:Trie<K, V>) : Trie<K, V> {
         func lf(kvs : AssocList<Key<K>, V>) : Trie<K, V> = leaf(kvs, bitpos);
         switch (tl, tr) {
@@ -417,7 +417,7 @@ module {
           case (_, #empty) { return tl };
           case (#leaf(l1), #leaf(l2)) {
             lf(
-              AssocList.disj<Key<K>, V, V, V>(
+              AssocList.disj(
                 l1.keyvals, l2.keyvals,
                 key_eq,
                 func (x : ?V, y : ?V):V {
@@ -431,11 +431,11 @@ module {
             )
           };
           case (#leaf(l), _) {
-            let (ll, lr) = splitAssocList<K, V>(l.keyvals, bitpos);
+            let (ll, lr) = splitAssocList(l.keyvals, bitpos);
             rec(bitpos, branch(lf(ll), lf(lr)), tr)
           };
           case (_, #leaf(l)) {
-            let (ll, lr) = splitAssocList<K, V>(l.keyvals, bitpos);
+            let (ll, lr) = splitAssocList(l.keyvals, bitpos);
             rec(bitpos, tl, branch(lf(ll), lf(lr)))
           };
           case (#branch(b1), #branch(b2)) {
@@ -451,7 +451,7 @@ module {
   /// dynamic error if there are collisions in common keys between the
   /// left and right inputs.
   public func mergeDisjoint<K, V>(tl : Trie<K, V>, tr : Trie<K, V>, k_eq : (K, K) -> Bool) : Trie<K, V> {
-      let key_eq = equalKey<K>(k_eq);
+      let key_eq = equalKey(k_eq);
 
       func rec(bitpos : Nat, tl : Trie<K, V>, tr : Trie<K, V>) : Trie<K, V> {
         func lf(kvs : AssocList<Key<K>, V>) : Trie<K, V> = leaf(kvs, bitpos);
@@ -460,7 +460,7 @@ module {
           case (_, #empty) { return tl };
           case (#leaf(l1), #leaf(l2)) {
             lf(
-              AssocList.disjDisjoint<Key<K>, V, V, V>(
+              AssocList.disjDisjoint(
                 l1.keyvals, l2.keyvals,
                 func (x : ?V, y : ?V) : V {
                   switch (x, y) {
@@ -473,11 +473,11 @@ module {
             )
           };
           case (#leaf(l), _) {
-            let (ll, lr) = splitAssocList<K, V>(l.keyvals, bitpos);
+            let (ll, lr) = splitAssocList(l.keyvals, bitpos);
             rec(bitpos, branch(lf(ll), lf(lr)), tr)
           };
           case (_, #leaf(l)) {
-            let (ll, lr) = splitAssocList<K, V>(l.keyvals, bitpos);
+            let (ll, lr) = splitAssocList(l.keyvals, bitpos);
             rec(bitpos, tl, branch(lf(ll), lf(lr)))
           };
           case (#branch(b1), #branch(b2)) {
@@ -495,7 +495,7 @@ module {
   /// the left trie whose keys are not present in the right trie; the
   /// values of the right trie are irrelevant.
   public func diff<K, V, W>(tl : Trie<K, V>, tr : Trie<K, W>, k_eq : ( K, K) -> Bool): Trie<K, V> {
-    let key_eq = equalKey<K>(k_eq);
+    let key_eq = equalKey(k_eq);
 
     func rec(bitpos : Nat, tl : Trie<K, V>, tr : Trie<K, W>) : Trie<K, V> {
       func lf<X>(kvs : AssocList<Key<K>, X>) : Trie<K, X> = leaf(kvs, bitpos);
@@ -504,18 +504,18 @@ module {
         case (_, #empty) { return tl };
         case (#leaf(l1), #leaf(l2)) {
           lf(
-             AssocList.diff<Key<K>, V, W>(
+             AssocList.diff(
                l1.keyvals, l2.keyvals,
                key_eq,
              )
            )
         };
         case (#leaf(l), _) {
-          let (ll, lr) = splitAssocList<K, V>(l.keyvals, bitpos);
+          let (ll, lr) = splitAssocList(l.keyvals, bitpos);
           rec(bitpos, branch(lf(ll), lf(lr)), tr)
         };
         case (_, #leaf(l)) {
-          let (ll, lr) = splitAssocList<K, W>(l.keyvals, bitpos);
+          let (ll, lr) = splitAssocList(l.keyvals, bitpos);
           rec(bitpos, tl, branch(lf(ll), lf(lr)))
         };
         case (#branch(b1), #branch(b2)) {
@@ -547,14 +547,14 @@ module {
     k_eq : (K, K) -> Bool,
     vbin : (?V, ?W) -> X
   ) : Trie<K, X> {
-    let key_eq = equalKey<K>(k_eq);
+    let key_eq = equalKey(k_eq);
 
     /* empty right case; build from left only: */
     func recL(t : Trie<K, V>, bitpos : Nat) : Trie<K, X> {
       switch t {
         case (#empty) { #empty };
         case (#leaf(l)) {
-          leaf(AssocList.disj<Key<K>, V, W, X>(l.keyvals, null, key_eq, vbin), bitpos)
+          leaf(AssocList.disj(l.keyvals, null, key_eq, vbin), bitpos)
         };
         case (#branch(b)) {
           branch(recL(b.left, bitpos + 1),
@@ -567,7 +567,7 @@ module {
      switch t {
        case (#empty) { #empty };
        case (#leaf(l)) {
-         leaf(AssocList.disj<Key<K>, V, W, X>(null, l.keyvals, key_eq, vbin), bitpos)
+         leaf(AssocList.disj(null, l.keyvals, key_eq, vbin), bitpos)
        };
        case (#branch(b)) {
          branch(recR(b.left, bitpos + 1),
@@ -583,14 +583,14 @@ module {
        case (#empty, _) { recR(tr, bitpos) };
        case (_, #empty) { recL(tl, bitpos) };
        case (#leaf(l1), #leaf(l2)) {
-         leaf(AssocList.disj<Key<K>, V, W, X>(l1.keyvals, l2.keyvals, key_eq, vbin), bitpos)
+         leaf(AssocList.disj(l1.keyvals, l2.keyvals, key_eq, vbin), bitpos)
        };
        case (#leaf(l), _) {
-         let (ll, lr) = splitAssocList<K, V>(l.keyvals, bitpos);
+         let (ll, lr) = splitAssocList(l.keyvals, bitpos);
          rec(bitpos, branch(lf(ll), lf(lr)), tr)
        };
        case (_, #leaf(l)) {
-         let (ll, lr) = splitAssocList<K, W>(l.keyvals, bitpos);
+         let (ll, lr) = splitAssocList(l.keyvals, bitpos);
          rec(bitpos, tl, branch(lf(ll), lf(lr)))
        };
        case (#branch(b1), #branch(b2)) {
@@ -617,7 +617,7 @@ module {
     k_eq : (K, K) -> Bool,
     vbin : (V, W) -> X
   ) : Trie<K, X> {
-    let key_eq = equalKey<K>(k_eq);
+    let key_eq = equalKey(k_eq);
 
     func rec(bitpos : Nat, tl : Trie<K, V>, tr : Trie<K, W>) : Trie<K, X> {
       func lf<X>(kvs : AssocList<Key<K>, X>) : Trie<K, X> = leaf(kvs, bitpos);
@@ -626,14 +626,14 @@ module {
         case (#empty, _) { #empty };
         case (_, #empty) { #empty };
         case (#leaf(l1), #leaf(l2)) {
-          lf(AssocList.join<Key<K>, V, W, X>(l1.keyvals, l2.keyvals, key_eq, vbin))
+          lf(AssocList.join(l1.keyvals, l2.keyvals, key_eq, vbin))
         };
         case (#leaf(l), _) {
-          let (ll, lr) = splitAssocList<K, V>(l.keyvals, bitpos);
+          let (ll, lr) = splitAssocList(l.keyvals, bitpos);
           rec(bitpos, branch(lf(ll), lf(lr)), tr)
         };
         case (_, #leaf(l)) {
-          let (ll, lr) = splitAssocList<K, W>(l.keyvals, bitpos);
+          let (ll, lr) = splitAssocList(l.keyvals, bitpos);
           rec(bitpos, tl, branch(lf(ll), lf(lr)))
         };
         case (#branch(b1), #branch(b2)) {
@@ -655,7 +655,7 @@ module {
       switch t {
         case (#empty) { empty };
         case (#leaf(l)) {
-          AssocList.fold<Key<K>, V, X>(
+          AssocList.fold(
             l.keyvals, empty,
             func (k : Key<K>, v : V, x : X) : X { bin(leaf(k.key, v), x) }
           )
@@ -687,18 +687,18 @@ module {
 
     /*- binary case: merge disjoint results: */
     func merge (a:Trie<K3, V3>, b:Trie<K3, V3>) : Trie<K3, V3> =
-      mergeDisjoint<K3, V3>(a, b, k3_eq);
+      mergeDisjoint(a, b, k3_eq);
 
     /*- "`foldUp` squared" (imagine two nested loops): */
-    foldUp<K1, V1, Trie<K3, V3>>(
+    foldUp(
       tl, merge,
       func (k1 : K1, v1 : V1) : Trie<K3, V3> {
-        foldUp<K2, V2, Trie<K3, V3>>(
+        foldUp(
           tr, merge,
           func (k2 : K2, v2 : V2) : Trie<K3, V3> {
             switch (op(k1, v1, k2, v2)) {
               case null { #empty };
-              case (?(k3, v3)) { (put<K3, V3>(#empty, k3, k3_eq, v3)).0 };
+              case (?(k3, v3)) { (put(#empty, k3, k3_eq, v3)).0 };
             }
           },
           #empty
@@ -782,7 +782,7 @@ module {
 
     /// Build sequence of two sub-builds
     public func seq<K, V>(l : Build<K, V>, r : Build<K, V>) : Build<K, V> {
-        let sum = size<K, V>(l) + size<K, V>(r);
+        let sum = size(l) + size(r);
         #seq({ size = sum; left = l; right = r })
       };
 
@@ -798,19 +798,19 @@ module {
 
       func outer_bin (a : Build<K3, V3>, b : Build<K3, V3>)
         : Build<K3, V3> {
-          seq<K3, V3>(a, b)
+          seq(a, b)
         };
 
       func inner_bin (a : Build<K3, V3>, b : Build<K3, V3>)
         : Build<K3, V3> {
-          seq<K3, V3>(a, b)
+          seq(a, b)
         };
 
       /// double-nested folds
-      foldUp<K1, V1, Build<K3, V3>>(
+      foldUp(
         tl, outer_bin,
         func (k1 : K1, v1 : V1) : Build<K3, V3> {
-          foldUp<K2, V2, Build<K3, V3>>(
+          foldUp(
             tr, inner_bin,
             func (k2 : K2, v2 : V2) : Build<K3, V3> {
               switch (op(k1, v1, k2, v2)) {
@@ -837,14 +837,14 @@ module {
               ?(k, h, v)
              };
              case (#seq(s)) {
-               let size_left = size<K, V>(s.left);
+               let size_left = size(s.left);
                if (i < size_left) { rec(s.left,  i) }
                else { rec(s.right, i - size_left) }
              };
           }
         };
 
-        if (i >= size<K, V>(tb)) {
+        if (i >= size(tb)) {
           return null
         };
         rec(tb, i)
@@ -855,9 +855,9 @@ module {
     /// latter (if ever).
     public func projectInner<K1, K2, V>(t : Trie<K1, Build<K2, V>>)
       : Build<K2, V> {
-      foldUp<K1, Build<K2, V>, Build<K2, V>>(
+      foldUp(
         t,
-        func (t1 : Build<K2, V>, t2 : Build<K2, V>) : Build<K2, V> { seq<K2, V>(t1, t2) },
+        func (t1 : Build<K2, V>, t2 : Build<K2, V>) : Build<K2, V> { seq(t1, t2) },
         func (_ : K1, t : Build<K2, V>): Build<K2, V> { t },
         #skip
       )
@@ -865,10 +865,10 @@ module {
 
     /// Gather the collection of key-value pairs into an array of a (possibly-distinct) type.
     public func toArray<K, V, W>(tb : Build<K, V>, f: (K, V) -> W) : [W] {
-      let c = size<K, V>(tb);
+      let c = size(tb);
       let a = A.init<?W>(c, null);
       var i = 0;
-      func rec(tb:Build<K, V>) {
+      func rec(tb : Build<K, V>) {
         switch tb {
           case (#skip) {};
           case (#put(k, _, v)) { a[i] := ?f(k, v); i := i + 1 };
@@ -876,7 +876,7 @@ module {
         }
       };
       rec(tb);
-      A.tabulate<W>(c, func(i : Nat) : W {
+      A.tabulate(c, func(i : Nat) : W {
         switch (a[i]) {
           case null { P.unreachable() };
           case (?x) { x }
@@ -892,7 +892,7 @@ module {
       switch t {
         case (#empty) { x };
         case (#leaf(l)) {
-          AssocList.fold<Key<K>, V, X>(
+          AssocList.fold(
            l.keyvals, x,
            func (k : Key<K>, v : V, x : X) : X = f(k.key, v, x)
           )
@@ -909,7 +909,7 @@ module {
       switch t {
         case (#empty) { false };
         case (#leaf(l)) {
-          List.some<(Key<K>, V)>(
+          List.some(
             l.keyvals, func ((k:Key<K>, v:V)):Bool=f(k.key, v)
           )
         };
@@ -925,7 +925,7 @@ module {
       switch t {
         case (#empty) { true };
         case (#leaf(l)) {
-          List.all<(Key<K>, V)>(
+          List.all(
             l.keyvals, func ((k : Key<K>, v : V)) : Bool=f(k.key, v)
           )
         };
@@ -943,15 +943,15 @@ module {
       func rec(t : Trie<K, V>, i : Nat) : ?(Key<K>, V) {
         switch t {
           case (#empty) { P.unreachable() };
-          case (#leaf(l)) { List.get<(Key<K>, V)>(l.keyvals, i) };
+          case (#leaf(l)) { List.get(l.keyvals, i) };
           case (#branch(b)) {
-            let size_left = size<K, V>(b.left);
+            let size_left = size(b.left);
             if (i < size_left) { rec(b.left,  i) }
             else { rec(b.right, i - size_left) }
           }
         }
       };
-      if (i >= size<K, V>(t)) {
+      if (i >= size(t)) {
         return null
       };
       rec(t, i)
@@ -961,9 +961,9 @@ module {
   /// Gather the collection of key-value pairs into an array of a (possibly-distinct) type.
   public func toArray<K, V, W>(t : Trie<K, V>, f : (K, V)-> W):[W] {
       let a = A.tabulate<W> (
-        size<K, V>(t),
+        size(t),
         func (i : Nat) : W {
-          let (k, v) = switch (nth<K, V>(t, i)) {
+          let (k, v) = switch (nth(t, i)) {
             case null { P.unreachable() };
             case (?x) { x };
           };
@@ -977,7 +977,7 @@ module {
   /// but no leaves.  These can result from naive filtering operations;
   /// filter uses this function to avoid creating such subtrees.
   public func isEmpty<K, V>(t : Trie<K, V>) : Bool {
-    size<K, V>(t) == 0
+    size(t) == 0
   };
 
   /// Filter the key-value pairs by a given predicate.
@@ -987,7 +987,7 @@ module {
         case (#empty) { #empty };
         case (#leaf(l)) {
           leaf(
-            List.filter<(Key<K>, V)>(
+            List.filter(
               l.keyvals,
               func ((k : Key<K>, v : V)) : Bool = f(k.key, v)
             ),
@@ -997,7 +997,7 @@ module {
         case (#branch(b)) {
           let fl = rec(b.left, bitpos + 1);
           let fr = rec(b.right, bitpos + 1);
-          switch (isEmpty<K, V>(fl), isEmpty<K, V>(fr)) {
+          switch (isEmpty(fl), isEmpty(fr)) {
             case (true, true) { #empty };
             case (false, true) { fr };
             case (true, false) { fl };
@@ -1016,7 +1016,7 @@ module {
         case (#empty) { #empty };
         case (#leaf(l)) {
           leaf(
-            List.mapFilter<(Key<K>, V),(Key<K>, W)>(
+            List.mapFilter(
               l.keyvals,
               // retain key and hash, but update key's value using f:
               func ((k : Key<K>, v : V)) : ?(Key<K>, W) {
@@ -1032,7 +1032,7 @@ module {
         case (#branch(b)) {
           let fl = rec(b.left, bitpos + 1);
           let fr = rec(b.right, bitpos + 1);
-          switch (isEmpty<K, W>(fl), isEmpty<K, W>(fr)) {
+          switch (isEmpty(fl), isEmpty(fr)) {
             case (true, true) { #empty };
             case (false, true) { fr };
             case (true, false) { fl };
@@ -1062,7 +1062,7 @@ module {
       switch (tl, tr) {
         case (#empty, #empty) { true };
         case (#leaf(l1), #leaf(l2)) {
-          List.equal<(Key<K>, V)>(l1.keyvals, l2.keyvals,
+          List.equal(l1.keyvals, l2.keyvals,
             func ((k1 : Key<K>, v1 : V), (k2 : Key<K>, v2 : V)) : Bool =
               keq(k1.key, k2.key) and veq(v1, v2)
           )
@@ -1084,7 +1084,7 @@ module {
     success: (Trie<K, V>, V) -> X,
     fail: () -> X
   ) : X {
-    let (t2, ov) = replace<K, V>(t, k, k_eq, ?v2);
+    let (t2, ov) = replace(t, k, k_eq, ?v2);
     switch ov {
       case (null) { /* no prior value; failure to remove */ fail() };
       case (?v1) { success(t2, v1) };
@@ -1093,7 +1093,7 @@ module {
 
   /// Put the given key's value in the trie; return the new trie; assert that no prior value is associated with the key
   public func putFresh<K, V>(t : Trie<K, V>,  k : Key<K>, k_eq : (K, K) -> Bool, v : V) : Trie<K, V> {
-    let (t2, none) = replace<K, V>(t, k, k_eq, ?v);
+    let (t2, none) = replace(t, k, k_eq, ?v);
     switch none {
       case (null) {};
       case (?_) assert false;
@@ -1110,12 +1110,12 @@ module {
     k2_eq : (K2, K2)->Bool,
     v:V
   ) : Trie2D<K1, K2, V> {
-    let inner = find<K1, Trie<K2, V>>(t, k1, k1_eq);
+    let inner = find(t, k1, k1_eq);
     let (updated_inner, _) = switch inner {
-      case (null) { put<K2, V>(#empty, k2, k2_eq, v) };
-      case (?inner) { put<K2, V>(inner, k2, k2_eq, v) };
+      case (null) { put(#empty, k2, k2_eq, v) };
+      case (?inner) { put(inner, k2, k2_eq, v) };
     };
-    let (updated_outer, _) = put<K1, Trie<K2, V>>(t, k1, k1_eq, updated_inner);
+    let (updated_outer, _) = put(t, k1, k1_eq, updated_inner);
     updated_outer;
   };
 
@@ -1130,30 +1130,30 @@ module {
     k3_eq : (K3, K3)->Bool,
     v : V
   ) : Trie3D<K1, K2, K3, V> {
-    let inner1 = find<K1, Trie2D<K2, K3, V>>(t, k1, k1_eq);
+    let inner1 = find(t, k1, k1_eq);
     let (updated_inner1, _) = switch inner1 {
       case (null) {
-        put<K2, Trie<K3, V>>(
+        put(
           #empty, k2, k2_eq,
-           (put<K3, V>(#empty, k3, k3_eq, v)).0
+           (put(#empty, k3, k3_eq, v)).0
         )
       };
       case (?inner1) {
-        let inner2 = find<K2, Trie<K3, V>>(inner1, k2, k2_eq);
+        let inner2 = find(inner1, k2, k2_eq);
         let (updated_inner2, _) = switch inner2 {
-          case (null) { put<K3, V>(#empty, k3, k3_eq, v) };
-          case (?inner2) { put<K3, V>(inner2, k3, k3_eq, v) };
+          case (null) { put(#empty, k3, k3_eq, v) };
+          case (?inner2) { put(inner2, k3, k3_eq, v) };
         };
-        put<K2, Trie<K3, V>>(inner1, k2, k2_eq, updated_inner2 )
+        put(inner1, k2, k2_eq, updated_inner2 )
       };
     };
-    let (updated_outer, _) = put<K1, Trie2D<K2, K3, V>>(t, k1, k1_eq, updated_inner1);
+    let (updated_outer, _) = put(t, k1, k1_eq, updated_inner1);
     updated_outer;
   };
 
   /// Remove the given key's value in the trie; return the new trie
   public func remove<K, V>(t : Trie<K, V>, k : Key<K>, k_eq: (K, K) -> Bool) : (Trie<K, V>, ?V) {
-    replace<K, V>(t, k, k_eq, null)
+    replace(t, k, k_eq, null)
   };
 
   /// Remove the given key's value in the trie,
@@ -1166,7 +1166,7 @@ module {
     success: (Trie<K, V>, V) -> X,
     fail: () -> X
   ) : X {
-    let (t2, ov) = replace<K, V>(t, k, k_eq, null);
+    let (t2, ov) = replace(t, k, k_eq, null);
     switch ov {
       case (null) { /* no prior value; failure to remove */ fail() };
       case (?v) { success(t2, v) };
@@ -1183,13 +1183,13 @@ module {
     k2 : Key<K2>,
     k2_eq: (K2, K2) -> Bool
   ) : (Trie2D<K1, K2, V>, ?V)  {
-    switch (find<K1, Trie<K2, V>>(t, k1, k1_eq)) {
+    switch (find(t, k1, k1_eq)) {
       case (null) {
         (t, null)
       };
       case (?inner) {
-        let (updated_inner, ov) = remove<K2, V>(inner, k2, k2_eq);
-        let (updated_outer, _) = put<K1, Trie<K2, V>>(t, k1, k1_eq, updated_inner);
+        let (updated_inner, ov) = remove(inner, k2, k2_eq);
+        let (updated_outer, _) = put(t, k1, k1_eq, updated_inner);
         (updated_outer, ov)
       };
     }
@@ -1205,13 +1205,13 @@ module {
     k2_eq: (K2, K2) -> Bool,
     k3:Key<K3>, k3_eq : (K3, K3) -> Bool,
   ) : (Trie3D<K1, K2, K3, V>, ?V) {
-    switch (find<K1, Trie2D<K2, K3, V>>(t, k1, k1_eq)) {
+    switch (find(t, k1, k1_eq)) {
       case (null) {
         (t, null)
       };
       case (?inner) {
-        let (updated_inner, ov) = remove2D<K2, K3, V>(inner, k2, k2_eq, k3, k3_eq);
-        let (updated_outer, _) = put<K1, Trie2D<K2, K3, V>>(t, k1, k1_eq, updated_inner);
+        let (updated_inner, ov) = remove2D(inner, k2, k2_eq, k3, k3_eq);
+        let (updated_outer, _) = put(t, k1, k1_eq, updated_inner);
         (updated_outer, ov)
       };
     }
@@ -1225,10 +1225,10 @@ module {
     k1_eq : (K1, K1) -> Bool,
     k2_eq : (K2, K2) -> Bool
   ) : Trie<K2, V> {
-    foldUp<K1, Trie<K2, V>, Trie<K2, V>>(
+    foldUp(
       t,
       func (t1 : Trie<K2, V>, t2 : Trie<K2, V>) : Trie<K2, V> {
-        mergeDisjoint<K2, V>(t1, t2, k2_eq)
+        mergeDisjoint(t1, t2, k2_eq)
       },
       func (_ : K1, t : Trie<K2, V>) : Trie<K2, V> { t },
       #empty

--- a/src/Trie.mo
+++ b/src/Trie.mo
@@ -426,8 +426,8 @@ module {
                     case (?v, _) { v };
                   }
                 }
-              )
-              , bitpos)
+              ),
+              bitpos)
           };
           case (#leaf(l), _) {
             let (ll, lr) = splitAssocList(l.keyvals, bitpos);
@@ -467,8 +467,8 @@ module {
                     case (_, _) { P.unreachable() };
                   }
                 }
-              )
-              , bitpos
+              ),
+              bitpos
             )
           };
           case (#leaf(l), _) {
@@ -505,8 +505,8 @@ module {
              AssocList.diff(
                l1.keyvals, l2.keyvals,
                key_eq,
-             )
-             , bitpos
+             ),
+             bitpos
            )
         };
         case (#leaf(l), _) {

--- a/src/Trie.mo
+++ b/src/Trie.mo
@@ -411,12 +411,11 @@ module {
   public func merge<K, V>(tl:Trie<K, V>, tr:Trie<K, V>, k_eq : (K, K) -> Bool) : Trie<K, V> {
       let key_eq = equalKey(k_eq);
       func rec(bitpos : Nat, tl : Trie<K, V>, tr:Trie<K, V>) : Trie<K, V> {
-        func lf(kvs : AssocList<Key<K>, V>) : Trie<K, V> = leaf(kvs, bitpos);
         switch (tl, tr) {
           case (#empty, _) { return tr };
           case (_, #empty) { return tl };
           case (#leaf(l1), #leaf(l2)) {
-            lf(
+            leaf(
               AssocList.disj(
                 l1.keyvals, l2.keyvals,
                 key_eq,
@@ -428,15 +427,15 @@ module {
                   }
                 }
               )
-            )
+              , bitpos)
           };
           case (#leaf(l), _) {
             let (ll, lr) = splitAssocList(l.keyvals, bitpos);
-            rec(bitpos, branch(lf(ll), lf(lr)), tr)
+            rec(bitpos, branch(leaf(ll, bitpos), leaf(lr, bitpos)), tr)
           };
           case (_, #leaf(l)) {
             let (ll, lr) = splitAssocList(l.keyvals, bitpos);
-            rec(bitpos, tl, branch(lf(ll), lf(lr)))
+            rec(bitpos, tl, branch(leaf(ll, bitpos), leaf(lr, bitpos)))
           };
           case (#branch(b1), #branch(b2)) {
             branch(rec(bitpos + 1, b1.left, b2.left),
@@ -454,12 +453,11 @@ module {
       let key_eq = equalKey(k_eq);
 
       func rec(bitpos : Nat, tl : Trie<K, V>, tr : Trie<K, V>) : Trie<K, V> {
-        func lf(kvs : AssocList<Key<K>, V>) : Trie<K, V> = leaf(kvs, bitpos);
         switch (tl, tr) {
           case (#empty, _) { return tr };
           case (_, #empty) { return tl };
           case (#leaf(l1), #leaf(l2)) {
-            lf(
+            leaf(
               AssocList.disjDisjoint(
                 l1.keyvals, l2.keyvals,
                 func (x : ?V, y : ?V) : V {
@@ -470,15 +468,16 @@ module {
                   }
                 }
               )
+              , bitpos
             )
           };
           case (#leaf(l), _) {
             let (ll, lr) = splitAssocList(l.keyvals, bitpos);
-            rec(bitpos, branch(lf(ll), lf(lr)), tr)
+            rec(bitpos, branch(leaf(ll, bitpos), leaf(lr, bitpos)), tr)
           };
           case (_, #leaf(l)) {
             let (ll, lr) = splitAssocList(l.keyvals, bitpos);
-            rec(bitpos, tl, branch(lf(ll), lf(lr)))
+            rec(bitpos, tl, branch(leaf(ll, bitpos), leaf(lr, bitpos)))
           };
           case (#branch(b1), #branch(b2)) {
             branch(
@@ -498,25 +497,25 @@ module {
     let key_eq = equalKey(k_eq);
 
     func rec(bitpos : Nat, tl : Trie<K, V>, tr : Trie<K, W>) : Trie<K, V> {
-      func lf<X>(kvs : AssocList<Key<K>, X>) : Trie<K, X> = leaf(kvs, bitpos);
       switch (tl, tr) {
         case (#empty, _) { return #empty };
         case (_, #empty) { return tl };
         case (#leaf(l1), #leaf(l2)) {
-          lf(
+          leaf(
              AssocList.diff(
                l1.keyvals, l2.keyvals,
                key_eq,
              )
+             , bitpos
            )
         };
         case (#leaf(l), _) {
           let (ll, lr) = splitAssocList(l.keyvals, bitpos);
-          rec(bitpos, branch(lf(ll), lf(lr)), tr)
+          rec(bitpos, branch(leaf(ll, bitpos), leaf(lr, bitpos)), tr)
         };
         case (_, #leaf(l)) {
           let (ll, lr) = splitAssocList(l.keyvals, bitpos);
-          rec(bitpos, tl, branch(lf(ll), lf(lr)))
+          rec(bitpos, tl, branch(leaf(ll, bitpos), leaf(lr, bitpos)))
         };
         case (#branch(b1), #branch(b2)) {
           branch(rec(bitpos + 1, b1.left, b2.left),
@@ -577,7 +576,6 @@ module {
 
    /* main recursion */
    func rec(bitpos : Nat, tl : Trie<K, V>, tr : Trie<K, W>) : Trie<K, X> {
-     func lf<X>(kvs : AssocList<Key<K>, X>) : Trie<K, X> = leaf(kvs, bitpos);
      switch (tl, tr) {
        case (#empty, #empty) { #empty };
        case (#empty, _) { recR(tr, bitpos) };
@@ -587,11 +585,11 @@ module {
        };
        case (#leaf(l), _) {
          let (ll, lr) = splitAssocList(l.keyvals, bitpos);
-         rec(bitpos, branch(lf(ll), lf(lr)), tr)
+         rec(bitpos, branch(leaf(ll, bitpos), leaf(lr, bitpos)), tr)
        };
        case (_, #leaf(l)) {
          let (ll, lr) = splitAssocList(l.keyvals, bitpos);
-         rec(bitpos, tl, branch(lf(ll), lf(lr)))
+         rec(bitpos, tl, branch(leaf(ll, bitpos), leaf(lr, bitpos)))
        };
        case (#branch(b1), #branch(b2)) {
          branch(rec(bitpos + 1, b1.left, b2.left),
@@ -620,21 +618,19 @@ module {
     let key_eq = equalKey(k_eq);
 
     func rec(bitpos : Nat, tl : Trie<K, V>, tr : Trie<K, W>) : Trie<K, X> {
-      func lf<X>(kvs : AssocList<Key<K>, X>) : Trie<K, X> = leaf(kvs, bitpos);
-
       switch (tl, tr) {
         case (#empty, _) { #empty };
         case (_, #empty) { #empty };
         case (#leaf(l1), #leaf(l2)) {
-          lf(AssocList.join(l1.keyvals, l2.keyvals, key_eq, vbin))
+          leaf(AssocList.join(l1.keyvals, l2.keyvals, key_eq, vbin), bitpos)
         };
         case (#leaf(l), _) {
           let (ll, lr) = splitAssocList(l.keyvals, bitpos);
-          rec(bitpos, branch(lf(ll), lf(lr)), tr)
+          rec(bitpos, branch(leaf(ll, bitpos), leaf(lr, bitpos)), tr)
         };
         case (_, #leaf(l)) {
           let (ll, lr) = splitAssocList(l.keyvals, bitpos);
-          rec(bitpos, tl, branch(lf(ll), lf(lr)))
+          rec(bitpos, tl, branch(leaf(ll, bitpos), leaf(lr, bitpos)))
         };
         case (#branch(b1), #branch(b2)) {
           branch(rec(bitpos + 1, b1.left, b2.left),

--- a/src/Trie.mo
+++ b/src/Trie.mo
@@ -1017,7 +1017,7 @@ module {
               // retain key and hash, but update key's value using f:
               func ((k : Key<K>, v : V)) : ?(Key<K>, W) {
                 switch (f(k.key, v)) {
-                  case (null) { null };
+                  case null { null };
                   case (?w) { ?({key = k.key; hash = k.hash}, w) };
                 }
               }
@@ -1082,7 +1082,7 @@ module {
   ) : X {
     let (t2, ov) = replace(t, k, k_eq, ?v2);
     switch ov {
-      case (null) { /* no prior value; failure to remove */ fail() };
+      case null { /* no prior value; failure to remove */ fail() };
       case (?v1) { success(t2, v1) };
     }
   };
@@ -1091,7 +1091,7 @@ module {
   public func putFresh<K, V>(t : Trie<K, V>,  k : Key<K>, k_eq : (K, K) -> Bool, v : V) : Trie<K, V> {
     let (t2, none) = replace(t, k, k_eq, ?v);
     switch none {
-      case (null) {};
+      case null {};
       case (?_) assert false;
     };
     t2
@@ -1108,7 +1108,7 @@ module {
   ) : Trie2D<K1, K2, V> {
     let inner = find(t, k1, k1_eq);
     let (updated_inner, _) = switch inner {
-      case (null) { put(#empty, k2, k2_eq, v) };
+      case null { put(#empty, k2, k2_eq, v) };
       case (?inner) { put(inner, k2, k2_eq, v) };
     };
     let (updated_outer, _) = put(t, k1, k1_eq, updated_inner);
@@ -1128,7 +1128,7 @@ module {
   ) : Trie3D<K1, K2, K3, V> {
     let inner1 = find(t, k1, k1_eq);
     let (updated_inner1, _) = switch inner1 {
-      case (null) {
+      case null {
         put(
           #empty, k2, k2_eq,
            (put(#empty, k3, k3_eq, v)).0
@@ -1137,7 +1137,7 @@ module {
       case (?inner1) {
         let inner2 = find(inner1, k2, k2_eq);
         let (updated_inner2, _) = switch inner2 {
-          case (null) { put(#empty, k3, k3_eq, v) };
+          case null { put(#empty, k3, k3_eq, v) };
           case (?inner2) { put(inner2, k3, k3_eq, v) };
         };
         put(inner1, k2, k2_eq, updated_inner2 )
@@ -1164,7 +1164,7 @@ module {
   ) : X {
     let (t2, ov) = replace(t, k, k_eq, null);
     switch ov {
-      case (null) { /* no prior value; failure to remove */ fail() };
+      case null { /* no prior value; failure to remove */ fail() };
       case (?v) { success(t2, v) };
     }
   };
@@ -1180,7 +1180,7 @@ module {
     k2_eq: (K2, K2) -> Bool
   ) : (Trie2D<K1, K2, V>, ?V)  {
     switch (find(t, k1, k1_eq)) {
-      case (null) {
+      case null {
         (t, null)
       };
       case (?inner) {
@@ -1202,7 +1202,7 @@ module {
     k3:Key<K3>, k3_eq : (K3, K3) -> Bool,
   ) : (Trie3D<K1, K2, K3, V>, ?V) {
     switch (find(t, k1, k1_eq)) {
-      case (null) {
+      case null {
         (t, null)
       };
       case (?inner) {

--- a/src/Trie.mo
+++ b/src/Trie.mo
@@ -955,7 +955,7 @@ module {
 
 
   /// Gather the collection of key-value pairs into an array of a (possibly-distinct) type.
-  public func toArray<K, V, W>(t : Trie<K, V>, f : (K, V)-> W):[W] {
+  public func toArray<K, V, W>(t : Trie<K, V>, f : (K, V) -> W):[W] {
       let a = A.tabulate<W> (
         size(t),
         func (i : Nat) : W {
@@ -1103,7 +1103,7 @@ module {
     k1 : Key<K1>,
     k1_eq : (K1, K1)->Bool,
     k2 : Key<K2>,
-    k2_eq : (K2, K2)->Bool,
+    k2_eq : (K2, K2) -> Bool,
     v:V
   ) : Trie2D<K1, K2, V> {
     let inner = find(t, k1, k1_eq);
@@ -1123,7 +1123,7 @@ module {
     k2 : Key<K2>,
     k2_eq: (K2, K2) -> Bool,
     k3 : Key<K3>,
-    k3_eq : (K3, K3)->Bool,
+    k3_eq : (K3, K3) -> Bool,
     v : V
   ) : Trie3D<K1, K2, K3, V> {
     let inner1 = find(t, k1, k1_eq);

--- a/src/Trie.mo
+++ b/src/Trie.mo
@@ -955,7 +955,7 @@ module {
 
 
   /// Gather the collection of key-value pairs into an array of a (possibly-distinct) type.
-  public func toArray<K, V, W>(t : Trie<K, V>, f : (K, V) -> W):[W] {
+  public func toArray<K, V, W>(t : Trie<K, V>, f : (K, V) -> W) : [W] {
       let a = A.tabulate<W> (
         size(t),
         func (i : Nat) : W {
@@ -1101,7 +1101,7 @@ module {
   public func put2D<K1, K2, V>(
     t : Trie2D<K1, K2, V>,
     k1 : Key<K1>,
-    k1_eq : (K1, K1)->Bool,
+    k1_eq : (K1, K1) -> Bool,
     k2 : Key<K2>,
     k2_eq : (K2, K2) -> Bool,
     v:V

--- a/src/Trie.mo
+++ b/src/Trie.mo
@@ -419,7 +419,7 @@ module {
               AssocList.disj(
                 l1.keyvals, l2.keyvals,
                 key_eq,
-                func (x : ?V, y : ?V):V {
+                func (x : ?V, y : ?V) : V {
                   switch (x, y) {
                     case (null, null) { P.unreachable() };
                     case (null, ?v) { v };
@@ -493,7 +493,7 @@ module {
   /// Difference of tries. The output consists are pairs of
   /// the left trie whose keys are not present in the right trie; the
   /// values of the right trie are irrelevant.
-  public func diff<K, V, W>(tl : Trie<K, V>, tr : Trie<K, W>, k_eq : ( K, K) -> Bool): Trie<K, V> {
+  public func diff<K, V, W>(tl : Trie<K, V>, tr : Trie<K, W>, k_eq : ( K, K) -> Bool) : Trie<K, V> {
     let key_eq = equalKey(k_eq);
 
     func rec(bitpos : Nat, tl : Trie<K, V>, tr : Trie<K, W>) : Trie<K, V> {
@@ -854,7 +854,7 @@ module {
       foldUp(
         t,
         func (t1 : Build<K2, V>, t2 : Build<K2, V>) : Build<K2, V> { seq(t1, t2) },
-        func (_ : K1, t : Build<K2, V>): Build<K2, V> { t },
+        func (_ : K1, t : Build<K2, V>) : Build<K2, V> { t },
         #skip
       )
     };
@@ -906,7 +906,7 @@ module {
         case (#empty) { false };
         case (#leaf(l)) {
           List.some(
-            l.keyvals, func ((k:Key<K>, v:V)):Bool=f(k.key, v)
+            l.keyvals, func ((k:Key<K>, v:V)) : Bool=f(k.key, v)
           )
         };
         case (#branch(b)) { rec(b.left) or rec(b.right) };


### PR DESCRIPTION
Arguably this makes the code more readable. The type inference for call-site type parameters has been strengthened considerably, so almost all type parameter passing can be eliminated from `Trie.mo`.