### PR TITLE
bugfix: avoid Hash.hashNat8 deprecation when importing Int.mo

### DIFF
--- a/src/Hash.mo
+++ b/src/Hash.mo
@@ -56,6 +56,7 @@ module {
     }
   };
 
+
   /// Jenkin's one at a time:
   ///
   /// https://en.wikipedia.org/wiki/Jenkins_hash_function#one_at_a_time
@@ -64,6 +65,7 @@ module {
   /// Note: Be sure to explode each `Nat8` of a `Nat32` into its own `Nat32`, and to shift into lower 8 bits.
 
   // should this really be public?
+  // NB: Int.mo contains a local copy of hashNat8 (redefined to suppress the deprecation warning).
   /// @deprecated This function may be removed or changed in future.
   public func hashNat8(key : [Hash]) : Hash {
     var hash : Nat32 = 0;

--- a/src/Int.mo
+++ b/src/Int.mo
@@ -58,11 +58,26 @@ module {
     if (x < y) { y } else { x };
   };
 
-  // TODO: (re)move me?
+  // this is a local copy of deprecated Hash.hashNat8 (redefined to suppress the warning)
+  private func hashNat8(key : [Nat32]) : Hash.Hash {
+    var hash : Nat32 = 0;
+    for (natOfKey in key.vals()) {
+      hash := hash +% natOfKey;
+      hash := hash +% hash << 10;
+      hash := hash ^ (hash >> 6);
+    };
+    hash := hash +% hash << 3;
+    hash := hash ^ (hash >> 11);
+    hash := hash +% hash << 15;
+    return hash;
+  };
+
+  /// Computes a hash from the least significant 32-bits of `i`, ignoring other bits.
+  /// @deprecated For large `Int` values consider using a bespoke hash function that considers all of the argument's bits.
   public func hash(i : Int) : Hash.Hash {
     // CAUTION: This removes the high bits!
     let j = Prim.int32ToNat32(Prim.intToInt32Wrap(i));
-    Hash.hashNat8(
+    hashNat8(
       [j & (255 << 0),
        j & (255 << 8),
        j & (255 << 16),
@@ -70,12 +85,11 @@ module {
       ]);
   };
 
-  // TODO: (re)move me?
-  /// WARNING: May go away (?)
+  /// @deprecated This function will be removed in future.
   public func hashAcc(h1 : Hash.Hash, i : Int) : Hash.Hash {
     // CAUTION: This removes the high bits!
     let j = Prim.int32ToNat32(Prim.intToInt32Wrap(i));
-    Hash.hashNat8(
+    hashNat8(
       [h1,
        j & (255 << 0),
        j & (255 << 8),


### PR DESCRIPTION
Fixes #376 
- copies now deprecated Hash.hashNat8 into Int.mo (to suppress deprecation of Hash.hashNat8)
- deprecates dodgy hashing functions Int.mo.

Just a band-aid to prevent users getting deprecation warnings they cannot fix themselves.