### PR TITLE
Efficient addArray method

### DIFF
--- a/src/Buffer.mo
+++ b/src/Buffer.mo
@@ -13,6 +13,8 @@
 /// determined at construction and cannot be changed).
 
 import Prim "mo:⛔";
+import Nat "Nat";
+import Iter "Iter";
 
 module {
 
@@ -45,6 +47,37 @@ module {
       };
       elems[count] := elem;
       count += 1;
+    };
+
+    /// Adds all elements in the given array to this buffer.
+    public func addArray(arr : [X]) {
+      if (count + arr.size() >= elems.size()){
+        let size = if (count == 0) {
+          Nat.max(initCapacity, arr.size())
+        } else {
+          Nat.max(2 * elems.size(), count + arr.size())
+        };
+        
+        let rng = Iter.range(0, size - 1);
+        let elemIter = Iter.map<Nat, X>(rng, func(i: Nat){
+          if (i < count) {
+            elems[i]
+          } else if (i < arr.size() + count) {
+            arr[i - count]
+          }else{
+            arr[0]
+          }
+        });
+
+        elems:= Iter.toArrayMut<X>(elemIter);
+        count += arr.size();
+      }else{
+        for (item in arr.vals()){
+          elems[count] := item;
+          count+=1;
+        };
+      };
+      
     };
 
     /// Removes the item that was inserted last and returns it or `null` if no
@@ -146,4 +179,10 @@ module {
     };
   };
 
+  /// Creates a new buffer instance from an array.
+  public func fromArray<X>(arr : [X]) : Buffer<X> {
+    let buf = Buffer<X>(arr.size());
+    buf.addArray(arr);
+    buf
+  };
 }

--- a/test/bufTest.mo
+++ b/test/bufTest.mo
@@ -92,3 +92,28 @@ do {
   assert (c.toArray().size() == 2);
   assert (c.toVarArray().size() == 2);
 };
+
+// regression test: initially-empty buffer grows to add elements in an array
+do {
+  let buf = B.Buffer<Nat>(0);
+  assert (buf.size() == 0);
+
+  buf.addArray([1,2,3,4]);
+  assert (buf.toArray().size() == 4);
+  assert (buf.toArray() == [1,2,3,4]);
+
+  buf.addArray([5,6,7,8]);
+  assert (buf.toArray().size() == 8);
+  assert (buf.toArray() == [1,2,3,4,5,6,7,8]);
+
+};
+
+
+// regression test: buffer instantiated from an array
+do {
+  let arr = [1,2,3,4];
+  let buf = B.fromArray<Nat>(arr);
+
+  assert (buf.size() == arr.size());
+  assert (buf.toArray() == arr);
+};


### PR DESCRIPTION
An efficient solution for the `addArray()` method addressed in this comment
https://github.com/dfinity/motoko-base/pull/368#discussion_r858858661

The previous solution used the `add()` method, which could resize the array more than once.
This PR solves this problem by only resizing the buffer once.