### PR TITLE
bugfix: `Trie.mo`: fix off-by-one error in `lenClamp`; restore original invariant

### DIFF
--- a/src/Trie.mo
+++ b/src/Trie.mo
@@ -219,10 +219,7 @@ module {
     public func lenClamp<T>(l : List<T>, max : Nat) : ?Nat {
       func rec(l : List<T>, max : Nat, i : Nat) : ?Nat {
         switch l {
-          case null {
-            if (i >= max) { null }
-            else { ?i }
-          };
+          case null { ?i };
           case (?(_, t)) {
             if ( i >= max ) { null }
             else { rec(t, max, i + 1) }

--- a/src/Trie.mo
+++ b/src/Trie.mo
@@ -219,7 +219,10 @@ module {
     public func lenClamp<T>(l : List<T>, max : Nat) : ?Nat {
       func rec(l : List<T>, max : Nat, i : Nat) : ?Nat {
         switch l {
-          case null { ?i };
+          case null {
+            if (i >= max) { null }
+            else { ?i }
+          };
           case (?(_, t)) {
             if ( i >= max ) { null }
             else { rec(t, max, i + 1) }

--- a/src/Trie.mo
+++ b/src/Trie.mo
@@ -140,7 +140,7 @@ module {
         };
         case (#leaf(l)) {
           let len = List.size(l.keyvals);
-            len <= MAX_LEAF_SIZE + 1
+            len <= MAX_LEAF_SIZE
           and
             len == l.size
           and
@@ -221,7 +221,7 @@ module {
         switch l {
           case null { ?i };
           case (?(_, t)) {
-            if ( i > max ) { null }
+            if ( i >= max ) { null }
             else { rec(t, max, i + 1) }
           };
         }

--- a/test/testLenClamp.mo
+++ b/test/testLenClamp.mo
@@ -4,6 +4,7 @@ import Debug "mo:base/Debug";
 
 type List<T> = List.List<T>;
 
+/* copied because private to Trie.mo */
 func lenClamp<T>(l : List<T>, max : Nat) : ?Nat {
   func rec(l : List<T>, max : Nat, i : Nat) : ?Nat {
     switch l {

--- a/test/testLenClamp.mo
+++ b/test/testLenClamp.mo
@@ -1,0 +1,35 @@
+import List "mo:base/List";
+import Trie "mo:base/Trie";
+import Debug "mo:base/Debug";
+
+type List<T> = List.List<T>;
+
+func lenClamp<T>(l : List<T>, max : Nat) : ?Nat {
+  func rec(l : List<T>, max : Nat, i : Nat) : ?Nat {
+    switch l {
+      case null { ?i };
+      case (?(_, t)) {
+        if ( i >= max ) { null }
+        else { rec(t, max, i + 1) }
+      };
+    }
+  };
+  rec(l, max, 0)
+};
+
+var s = 0;
+var l = List.nil<Nat>();
+
+while (s < 10) {
+  var m = 0;
+  while (m <= s + 3) {
+    let o = lenClamp(l, m);
+    Debug.print(debug_show ({l = List.toArray(l); m; o}));
+    assert (s == List.size(l));
+    assert (if (s <= m) { o == ?s} else { o == null } );
+    m += 1;
+  };
+  l := List.push(s+1, l);
+  s += 1;
+}
+


### PR DESCRIPTION
@nomeata suggests:

> I wonder if one shouldn't simply change the code to allow arbitrary sized association lists in the 32th level of the tree. The bitpos is readily available, so it should be easy to not split the list at that level. Then the tree would not have the problem of at most 8 collisions at all

That would also let us remove the trap in `Hash.mo` (when we run out of bits).