### PR TITLE
chore: update matrix strategy in formatter CI

### DIFF
--- a/.github/workflows/prettier.yml
+++ b/.github/workflows/prettier.yml
@@ -13,12 +13,8 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        os: [ubuntu-18.04]
-        ghc: ["8.8.4"]
-        spec:
-          - release-0.16 # https://github.com/dfinity-lab/ic-ref/tree/release-0.16
-        node:
-          - 14
+        os: [ubuntu-22.04]
+        node: [14]
     steps:
       - uses: actions/checkout@v2
       - name: Use Node.js ${{ matrix.node }}

--- a/.github/workflows/prettier.yml
+++ b/.github/workflows/prettier.yml
@@ -14,7 +14,7 @@ jobs:
       fail-fast: true
       matrix:
         os: [ubuntu-22.04]
-        node: [14]
+        node: [16]
     steps:
       - uses: actions/checkout@v2
       - name: Use Node.js ${{ matrix.node }}


### PR DESCRIPTION
Fixes what appears to be a GHA brownout which started breaking the new CI on Thursday:

<img width="1355" alt="Screenshot 2022-12-15 at 7 41 37 PM" src="https://user-images.githubusercontent.com/522097/208009763-73dbe829-aa50-4986-9b46-45672076a791.png">
