### PR TITLE
chore: add examples for CertifiedData

### DIFF
--- a/src/CertifiedData.mo
+++ b/src/CertifiedData.mo
@@ -26,8 +26,9 @@ module {
   /// let a: [Nat8] = [1, 2, 3];
   /// let b = Blob.fromArray(a);
   /// CertifiedData.set(b);
-  ///
   /// ```
+  ///
+  /// See a full example on how to use certified variables here: https://github.com/dfinity/examples/tree/master/motoko/cert-var
   ///
   public let set : (data : Blob) -> () = Prim.setCertifiedData;
 
@@ -43,6 +44,7 @@ module {
   /// 
   /// CertifiedData.getCertificate();
   /// ```
+  /// See a full example on how to use certified variables here: https://github.com/dfinity/examples/tree/master/motoko/cert-var
   ///
   public let getCertificate : () -> ?Blob = Prim.getCertificate;
 }

--- a/src/CertifiedData.mo
+++ b/src/CertifiedData.mo
@@ -19,13 +19,15 @@ module {
   /// Must be passed a blob of at most 32 bytes, else traps.
   ///
   /// Example:
-  /// ```motoko
+  /// ```motoko no-repl
   /// import CertifiedData "mo:base/CertifiedData";
   /// import Blob "mo:base/Blob";
   ///
-  /// let a: [Nat8] = [1, 2, 3];
-  /// let b = Blob.fromArray(a);
-  /// CertifiedData.set(b);
+  /// // Must be in an update call
+  ///
+  /// let array : [Nat8] = [1, 2, 3];
+  /// let blob = Blob.fromArray(a);
+  /// CertifiedData.set(blob);
   /// ```
   ///
   /// See a full example on how to use certified variables here: https://github.com/dfinity/examples/tree/master/motoko/cert-var
@@ -39,9 +41,10 @@ module {
   /// when processing a query call.
   ///
   /// Example:
-  /// ```motoko
+  /// ```motoko no-repl
   /// import CertifiedData "mo:base/CertifiedData";
-  /// 
+  /// // Must be in a query call
+  ///
   /// CertifiedData.getCertificate();
   /// ```
   /// See a full example on how to use certified variables here: https://github.com/dfinity/examples/tree/master/motoko/cert-var

--- a/src/CertifiedData.mo
+++ b/src/CertifiedData.mo
@@ -17,6 +17,18 @@ module {
   ///
   /// Must be called from an update method, else traps.
   /// Must be passed a blob of at most 32 bytes, else traps.
+  ///
+  /// Example:
+  /// ```motoko
+  /// import CertifiedData "mo:base/CertifiedData";
+  /// import Blob "mo:base/Blob";
+  ///
+  /// let a: [Nat8] = [1, 2, 3];
+  /// let b = Blob.fromArray(a);
+  /// CertifiedData.set(b);
+  ///
+  /// ```
+  ///
   public let set : (data : Blob) -> () = Prim.setCertifiedData;
 
   /// Gets a certificate
@@ -24,6 +36,13 @@ module {
   /// Returns `null` if no certificate is available, e.g. when processing an
   /// update call or inter-canister call. This returns a non-`null` value only
   /// when processing a query call.
+  ///
+  /// Example:
+  /// ```motoko
+  /// import CertifiedData "mo:base/CertifiedData";
+  /// 
+  /// CertifiedData.getCertificate();
+  /// ```
+  ///
   public let getCertificate : () -> ?Blob = Prim.getCertificate;
-
 }


### PR DESCRIPTION
Adds examples for CertifiedData. The examples aren't interactive since they require a canister environment, but they seem useful to use as copy/paste examples.