### PR TITLE
feat: user-facing API for timers

### DIFF
--- a/src/Timer.mo
+++ b/src/Timer.mo
@@ -27,7 +27,7 @@ module {
   /// func alarmUser() : async () {
   ///   // ...
   /// };
-  /// appt.reminder = setTimer(#nanoseconds (appt.when - now - thirtyMinutes), alarmUser);
+  /// appt.reminder = setTimer(#nanoseconds (Int.abs(appt.when - now - thirtyMinutes)), alarmUser);
   /// ```
   public func setTimer(d : Duration, job : () -> async ()) : TimerId {
     setTimerNano(toNanos d, false, job)

--- a/src/Timer.mo
+++ b/src/Timer.mo
@@ -1,5 +1,6 @@
 /// Timers for one-off or periodic tasks.
 ///
+/// Note: if `moc` is invoked with `-no-timer`, the importing will fail
 
 import { setTimer = setTimerNano; cancelTimer = cancel } = "mo:⛔";
 import { fromIntWrap } = "Nat64";
@@ -9,26 +10,25 @@ module {
   public type Duration = { #seconds : Nat; #nanoseconds : Nat };
   public type TimerId = Nat;
 
+  func toNanos(d : Duration) : Nat64 =
+    fromIntWrap (switch d {
+      case (#seconds s) 1000_000_000 * s;
+      case (#nanoseconds ns) ns });
+
   /// installs a one-off timer that upon expiration after given duration `d`
   /// executes the future `job()`
   ///
   public func setTimer(d : Duration, job : () -> async ()) : TimerId {
-    let nanos = switch d {
-      case (#seconds s) 1000_000_000 * s;
-      case (#nanoseconds ns) ns
-    };
-    setTimerNano(fromIntWrap nanos, false, job)
+    setTimerNano(toNanos d, false, job)
   };
 
   /// installs a recurring timer that upon expiration after given duration `d`
   /// executes the future `job()` and reinserts itself for expiration
   ///
+  /// Note: a duration of 0 will only expire once
+  ///
   public func recurringTimer(d : Duration, job : () -> async ()) : TimerId {
-    let nanos = switch d {
-      case (#seconds s) 1000_000_000 * s;
-      case (#nanoseconds ns) ns
-    };
-    setTimerNano(fromIntWrap nanos, true, job)
+    setTimerNano(toNanos d, true, job)
   };
 
   /// cancels a still active timer with `(id : TimerId)`. For expired timers

--- a/src/Timer.mo
+++ b/src/Timer.mo
@@ -1,0 +1,38 @@
+/// Timers for one-off or periodic tasks.
+///
+
+import { setTimer = setTimerNano; cancelTimer = cancel } = "mo:⛔";
+import { fromIntWrap } = "Nat64";
+
+module {
+
+  public type Duration = { #seconds : Nat; #nanoseconds : Nat };
+  public type TimerId = Nat;
+
+  /// installs a one-off timer that upon expiration after given duration `d`
+  /// executes the future `job()`
+  ///
+  public func setTimer(d : Duration, job : () -> async ()) : TimerId {
+    let nanos = switch d {
+      case (#seconds s) 1000_000_000 * s;
+      case (#nanoseconds ns) ns
+    };
+    setTimerNano(fromIntWrap nanos, false, job)
+  };
+
+  /// installs a recurring timer that upon expiration after given duration `d`
+  /// executes the future `job()` and reinserts itself for expiration
+  ///
+  public func recurringTimer(d : Duration, job : () -> async ()) : TimerId {
+    let nanos = switch d {
+      case (#seconds s) 1000_000_000 * s;
+      case (#nanoseconds ns) ns
+    };
+    setTimerNano(fromIntWrap nanos, true, job)
+  };
+
+  /// cancels a still active timer with `(id : TimerId)`. For expired timers
+  /// and not recognised `id`s nothing happens
+  public let cancelTimer = cancel;
+
+}

--- a/src/Timer.mo
+++ b/src/Timer.mo
@@ -12,27 +12,27 @@ module {
 
   func toNanos(d : Duration) : Nat64 =
     fromIntWrap (switch d {
-      case (#seconds s) 1000_000_000 * s;
+      case (#seconds s) s * 1000_000_000;
       case (#nanoseconds ns) ns });
 
-  /// installs a one-off timer that upon expiration after given duration `d`
-  /// executes the future `job()`
+  /// Installs a one-off timer that upon expiration after given duration `d`
+  /// executes the future `job()`.
   ///
   public func setTimer(d : Duration, job : () -> async ()) : TimerId {
     setTimerNano(toNanos d, false, job)
   };
 
-  /// installs a recurring timer that upon expiration after given duration `d`
-  /// executes the future `job()` and reinserts itself for expiration
+  /// Installs a recurring timer that upon expiration after given duration `d`
+  /// executes the future `job()` and reinserts itself for another expiration.
   ///
-  /// Note: a duration of 0 will only expire once
+  /// Note: A duration of 0 will only expire once.
   ///
   public func recurringTimer(d : Duration, job : () -> async ()) : TimerId {
     setTimerNano(toNanos d, true, job)
   };
 
-  /// cancels a still active timer with `(id : TimerId)`. For expired timers
-  /// and not recognised `id`s nothing happens
+  /// Cancels a still active timer with `(id : TimerId)`. For expired timers
+  /// and not recognised `id`s nothing happens.
   public let cancelTimer : TimerId -> () = cancel;
 
 }

--- a/src/Timer.mo
+++ b/src/Timer.mo
@@ -33,6 +33,6 @@ module {
 
   /// cancels a still active timer with `(id : TimerId)`. For expired timers
   /// and not recognised `id`s nothing happens
-  public let cancelTimer = cancel;
+  public let cancelTimer : TimerId -> () = cancel;
 
 }

--- a/src/Timer.mo
+++ b/src/Timer.mo
@@ -1,6 +1,9 @@
 /// Timers for one-off or periodic tasks.
 ///
-/// Note: if `moc` is invoked with `-no-timer`, the importing will fail
+/// Note: If `moc` is invoked with `-no-timer`, the importing will fail.
+/// Note: The resolution of the timers is in the order of the block rate,
+///       so durations should be chosen well above that. For frequent
+///       canister wake-ups the heatbeat mechanism should be considered.
 
 import { setTimer = setTimerNano; cancelTimer = cancel } = "mo:⛔";
 import { fromIntWrap } = "Nat64";
@@ -18,6 +21,14 @@ module {
   /// Installs a one-off timer that upon expiration after given duration `d`
   /// executes the future `job()`.
   ///
+  /// ```motoko no-repl
+  /// let now = Time.now();
+  /// let thirtyMinutes = 1_000_000_000 * 60 * 30;
+  /// func alarmUser() : async () {
+  ///   // ...
+  /// };
+  /// appt.reminder = setTimer(#nanoseconds (appt.when - now - thirtyMinutes), alarmUser);
+  /// ```
   public func setTimer(d : Duration, job : () -> async ()) : TimerId {
     setTimerNano(toNanos d, false, job)
   };
@@ -27,12 +38,25 @@ module {
   ///
   /// Note: A duration of 0 will only expire once.
   ///
+  /// ```motoko no-repl
+  /// func checkAndWaterPlants() : async () {
+  ///   // ...
+  /// };
+  /// let daily = recurringTimer(#seconds (24 * 60 * 60), checkAndWaterPlants);
+  /// ```
   public func recurringTimer(d : Duration, job : () -> async ()) : TimerId {
     setTimerNano(toNanos d, true, job)
   };
 
   /// Cancels a still active timer with `(id : TimerId)`. For expired timers
   /// and not recognised `id`s nothing happens.
+  ///
+  /// ```motoko no-repl
+  /// func deleteAppt(appt : Appointment) {
+  ///   cancelTimer (appt.reminder);
+  ///   // ...
+  /// };
+  /// ```
   public let cancelTimer : TimerId -> () = cancel;
 
 }


### PR DESCRIPTION
Adds the public API to support the default timer mechanism
- `setTimer : (Duration, () -> async ()) -> TimerId` to insert a one-off timer
- `recurringTimer : (Duration, () -> async ()) -> TimerId ` to insert a repeating timer
- `cancelTimer : TimerId -> ()` to remove timer

where `Duration` is a variant that can specify a timespan in seconds or nanoseconds.

Please refer to the PR https://github.com/dfinity/motoko/pull/3542 for the gory details.

Some caveats:
- importing `Timer.mo` will fail when invoked as `moc -no-timer`
- these functions have no effect (other than filling the heap) when the user chooses to implement `system func timer` herself (i.e. opting out of the Motoko default timer mechanism).
- `Duration` should be well above the round time to make this mechanism more efficient than `system func heartbeat`.