### PR TITLE
Fix: Base library issues in Int8/16/32/64

### DIFF
--- a/src/Int16.mo
+++ b/src/Int16.mo
@@ -10,6 +10,12 @@ module {
   /// 16-bit signed integers.
   public type Int16 = Prim.Types.Int16;
 
+  /// Minimum 16-bit integer value, `-2 ** 15`.
+  public let minimumValue = -32_768 : Int16;
+
+  /// Maximum 16-bit integer value, `+2 ** 15 - 1`.
+  public let maximumValue = 32_767 : Int16;
+
   /// Converts a 16-bit signed integer to a signed integer with infinite precision.
   ///
   /// Example:
@@ -279,16 +285,14 @@ module {
   public func pow(x : Int16, y : Int16) : Int16 { x ** y };
 
   /// Returns the bitwise negation of `x`, `^x`.
-  /// Issue: The argument `y` is not needed and will be removed in future.
   ///
   /// Example:
   /// ```motoko
   /// import Int16 "mo:base/Int16";
   ///
-  /// let unused = 0 : Int16; // will be fixed in future
-  /// Int16.bitnot(-256 /* 0xff00 */, unused) // => +255 // 0xff
+  /// Int16.bitnot(-256 /* 0xff00 */) // => +255 // 0xff
   /// ```
-  public func bitnot(x : Int16, y : Int16) : Int16 { ^x };
+  public func bitnot(x : Int16) : Int16 { ^x };
 
   /// Returns the bitwise "and" of `x` and `y`, `x & y`.
   ///

--- a/src/Int32.mo
+++ b/src/Int32.mo
@@ -10,6 +10,12 @@ module {
   /// 32-bit signed integers.
   public type Int32 = Prim.Types.Int32;
 
+  /// Minimum 32-bit integer value, `-2 ** 31`.
+  public let minimumValue = -2_147_483_648 : Int32;
+
+  /// Maximum 32-bit integer value, `+2 ** 31 - 1`.
+  public let maximumValue = 2_147_483_647 : Int32;
+
   /// Converts a 32-bit signed integer to a signed integer with infinite precision.
   ///
   /// Example:
@@ -279,16 +285,14 @@ module {
   public func pow(x : Int32, y : Int32) : Int32 { x ** y };
 
   /// Returns the bitwise negation of `x`, `^x`.
-  /// Issue: The argument `y` is not needed and will be removed in future.
   ///
   /// Example:
   /// ```motoko
   /// import Int32 "mo:base/Int32";
   ///
-  /// let unused = 0 : Int32; // will be fixed in future
-  /// Int32.bitnot(-256 /* 0xffff_ff00 */, unused) // => +255 // 0xff
+  /// Int32.bitnot(-256 /* 0xffff_ff00 */) // => +255 // 0xff
   /// ```
-  public func bitnot(x : Int32, y : Int32) : Int32 { ^x };
+  public func bitnot(x : Int32) : Int32 { ^x };
 
   /// Returns the bitwise "and" of `x` and `y`, `x & y`.
   ///

--- a/src/Int64.mo
+++ b/src/Int64.mo
@@ -10,6 +10,12 @@ module {
   /// 64-bit signed integers.
   public type Int64 = Prim.Types.Int64;
 
+  /// Minimum 64-bit integer value, `-2 ** 63`.
+  public let minimumValue = -9_223_372_036_854_775_808 : Int64;
+
+  /// Maximum 64-bit integer value, `+2 ** 63 - 1`.
+  public let maximumValue = 9_223_372_036_854_775_807 : Int64;
+
   /// Converts a 64-bit signed integer to a signed integer with infinite precision.
   ///
   /// Example:
@@ -279,16 +285,14 @@ module {
   public func pow(x : Int64, y : Int64) : Int64 { x ** y };
 
   /// Returns the bitwise negation of `x`, `^x`.
-  /// Issue: The argument `y` is not needed and will be removed in future.
   ///
   /// Example:
   /// ```motoko
   /// import Int64 "mo:base/Int64";
   ///
-  /// let unused = 0 : Int64; // will be fixed in future
-  /// Int64.bitnot(-256 /* 0xffff_ffff_ffff_ff00 */, unused) // => +255 // 0xff
+  /// Int64.bitnot(-256 /* 0xffff_ffff_ffff_ff00 */) // => +255 // 0xff
   /// ```
-  public func bitnot(x : Int64, y : Int64) : Int64 { ^x };
+  public func bitnot(x : Int64) : Int64 { ^x };
 
   /// Returns the bitwise "and" of `x` and `y`, `x & y`.
   ///

--- a/src/Int8.mo
+++ b/src/Int8.mo
@@ -10,6 +10,12 @@ module {
   /// 8-bit signed integers.
   public type Int8 = Prim.Types.Int8;
 
+  /// Minimum 8-bit integer value, `-2 ** 7`.
+  public let minimumValue = -128 : Int8;
+
+  /// Maximum 8-bit integer value, `+2 ** 7 - 1`.
+  public let maximumValue = 127 : Int8;
+
   /// Converts a 8-bit signed integer to a signed integer with infinite precision.
   ///
   /// Example:
@@ -279,16 +285,14 @@ module {
   public func pow(x : Int8, y : Int8) : Int8 { x ** y };
 
   /// Returns the bitwise negation of `x`, `^x`.
-  /// Issue: The argument `y` is not needed and will be removed in future.
   ///
   /// Example:
   /// ```motoko
   /// import Int8 "mo:base/Int8";
   ///
-  /// let unused = 0 : Int8; // will be fixed in future
-  /// Int8.bitnot(-16 /* 0xf0 */, unused) // => +15 // 0x0f
+  /// Int8.bitnot(-16 /* 0xf0 */) // => +15 // 0x0f
   /// ```
-  public func bitnot(x : Int8, y : Int8) : Int8 { ^x };
+  public func bitnot(x : Int8) : Int8 { ^x };
 
   /// Returns the bitwise "and" of `x` and `y`, `x & y`.
   ///

--- a/test/int16Test.mo
+++ b/test/int16Test.mo
@@ -8,12 +8,10 @@ import M "mo:matchers/Matchers";
 
 let { run; test; suite } = Suite;
 
-let maximumInt16 = 32_767 : Int16;
-let maximumInt16asInt = 32_767 : Int;
-let maximumInt16asNat16 = 32_767 : Nat16;
+let maximumInt16asInt = +2 ** 15 - 1 : Int;
+let maximumInt16asNat16 = 2 ** 15 - 1 : Nat16;
 
-let minimumInt16 = -32_768 : Int16;
-let minimumInt16asInt = -32_768 : Int;
+let minimumInt16asInt = -2 ** 15 : Int;
 
 let maximumNat16 = 65_535 : Nat16;
 
@@ -53,16 +51,36 @@ class OrderTestable(value : Order) : T.TestableItem<Order> {
 
 run(
     suite(
+        "constants",
+        [
+            test(
+                "minimum value",
+                Int16.minimumValue,
+                M.equals(Int16Testable(Int16.fromInt(-2 ** 15)))
+            ),
+            test(
+                "maximum value",
+                Int16.maximumValue,
+                M.equals(Int16Testable(Int16.fromInt(+2 ** 15 - 1)))
+            ),
+        ]
+    )
+);
+
+/* --------------------------------------- */
+
+run(
+    suite(
         "toInt",
         [
             test(
                 "maximum number",
-                Int16.toInt(maximumInt16),
+                Int16.toInt(Int16.maximumValue),
                 M.equals(T.int(maximumInt16asInt))
             ),
             test(
                 "minimum number",
-                Int16.toInt(minimumInt16),
+                Int16.toInt(Int16.minimumValue),
                 M.equals(T.int(minimumInt16asInt))
             ),
             test(
@@ -93,12 +111,12 @@ run(
             test(
                 "maximum number",
                 Int16.fromInt(maximumInt16asInt),
-                M.equals(Int16Testable(maximumInt16))
+                M.equals(Int16Testable(Int16.maximumValue))
             ),
             test(
                 "minimum number",
                 Int16.fromInt(minimumInt16asInt),
-                M.equals(Int16Testable(minimumInt16))
+                M.equals(Int16Testable(Int16.minimumValue))
             ),
             test(
                 "one",
@@ -128,12 +146,12 @@ run(
             test(
                 "maximum number",
                 Int16.fromIntWrap(maximumInt16asInt),
-                M.equals(Int16Testable(maximumInt16))
+                M.equals(Int16Testable(Int16.maximumValue))
             ),
             test(
                 "minimum number",
                 Int16.fromIntWrap(minimumInt16asInt),
-                M.equals(Int16Testable(minimumInt16))
+                M.equals(Int16Testable(Int16.minimumValue))
             ),
             test(
                 "one",
@@ -153,12 +171,12 @@ run(
             test(
                 "overflow",
                 Int16.fromIntWrap(maximumInt16asInt + 1),
-                M.equals(Int16Testable(minimumInt16))
+                M.equals(Int16Testable(Int16.minimumValue))
             ),
             test(
                 "underflow",
                 Int16.fromIntWrap(minimumInt16asInt - 1),
-                M.equals(Int16Testable(maximumInt16))
+                M.equals(Int16Testable(Int16.maximumValue))
             )
         ]
     )
@@ -173,7 +191,7 @@ run(
             test(
                 "maximum number",
                 Int16.fromNat16(maximumInt16asNat16),
-                M.equals(Int16Testable(maximumInt16))
+                M.equals(Int16Testable(Int16.maximumValue))
             ),
             test(
                 "one",
@@ -188,7 +206,7 @@ run(
             test(
                 "overflow",
                 Int16.fromNat16(maximumInt16asNat16 + 1),
-                M.equals(Int16Testable(minimumInt16))
+                M.equals(Int16Testable(Int16.minimumValue))
             )
         ]
     )
@@ -202,7 +220,7 @@ run(
         [
             test(
                 "maximum number",
-                Int16.toNat16(maximumInt16),
+                Int16.toNat16(Int16.maximumValue),
                 M.equals(Nat16Testable(maximumInt16asNat16))
             ),
             test(
@@ -247,12 +265,12 @@ run(
             ),
             test(
                 "maximum number",
-                Int16.toText(maximumInt16),
+                Int16.toText(Int16.maximumValue),
                 M.equals(T.text("32767"))
             ),
             test(
                 "minimum number",
-                Int16.toText(minimumInt16),
+                Int16.toText(Int16.minimumValue),
                 M.equals(T.text("-32768"))
             )
         ]
@@ -283,13 +301,13 @@ run(
             ),
             test(
                 "maximum number",
-                Int16.abs(maximumInt16),
-                M.equals(Int16Testable(maximumInt16))
+                Int16.abs(Int16.maximumValue),
+                M.equals(Int16Testable(Int16.maximumValue))
             ),
             test(
                 "smallest possible",
-                Int16.abs(-maximumInt16),
-                M.equals(Int16Testable(maximumInt16))
+                Int16.abs(-Int16.maximumValue),
+                M.equals(Int16Testable(Int16.maximumValue))
             )
         ]
     )
@@ -328,8 +346,8 @@ run(
             ),
             test(
                 "maximum and minimum number",
-                Int16.min(maximumInt16, minimumInt16),
-                M.equals(Int16Testable(minimumInt16))
+                Int16.min(Int16.maximumValue, Int16.minimumValue),
+                M.equals(Int16Testable(Int16.minimumValue))
             )
         ]
     )
@@ -368,8 +386,8 @@ run(
             ),
             test(
                 "maximum and minimum number",
-                Int16.max(maximumInt16, minimumInt16),
-                M.equals(Int16Testable(maximumInt16))
+                Int16.max(Int16.maximumValue, Int16.minimumValue),
+                M.equals(Int16Testable(Int16.maximumValue))
             )
         ]
     )
@@ -413,17 +431,17 @@ run(
             ),
             test(
                 "maxmimum equal",
-                Int16.equal(maximumInt16, maximumInt16),
+                Int16.equal(Int16.maximumValue, Int16.maximumValue),
                 M.equals(T.bool(true))
             ),
             test(
                 "minimum equal",
-                Int16.equal(minimumInt16, minimumInt16),
+                Int16.equal(Int16.minimumValue, Int16.minimumValue),
                 M.equals(T.bool(true))
             ),
             test(
                 "minimum and maximum",
-                Int16.equal(minimumInt16, maximumInt16),
+                Int16.equal(Int16.minimumValue, Int16.maximumValue),
                 M.equals(T.bool(false))
             )
         ]
@@ -468,17 +486,17 @@ run(
             ),
             test(
                 "maxmimum equal",
-                Int16.notEqual(maximumInt16, maximumInt16),
+                Int16.notEqual(Int16.maximumValue, Int16.maximumValue),
                 M.equals(T.bool(false))
             ),
             test(
                 "minimum equal",
-                Int16.notEqual(minimumInt16, minimumInt16),
+                Int16.notEqual(Int16.minimumValue, Int16.minimumValue),
                 M.equals(T.bool(false))
             ),
             test(
                 "minimum and maximum",
-                Int16.notEqual(minimumInt16, maximumInt16),
+                Int16.notEqual(Int16.minimumValue, Int16.maximumValue),
                 M.equals(T.bool(true))
             )
         ]
@@ -538,22 +556,22 @@ run(
             ),
             test(
                 "minimum and maximum",
-                Int16.less(minimumInt16, maximumInt16),
+                Int16.less(Int16.minimumValue, Int16.maximumValue),
                 M.equals(T.bool(true))
             ),
             test(
                 "maximum and minimum",
-                Int16.less(maximumInt16, minimumInt16),
+                Int16.less(Int16.maximumValue, Int16.minimumValue),
                 M.equals(T.bool(false))
             ),
             test(
                 "maximum and maximum",
-                Int16.less(maximumInt16, maximumInt16),
+                Int16.less(Int16.maximumValue, Int16.maximumValue),
                 M.equals(T.bool(false))
             ),
             test(
                 "minimum and minimum",
-                Int16.less(minimumInt16, minimumInt16),
+                Int16.less(Int16.minimumValue, Int16.minimumValue),
                 M.equals(T.bool(false))
             )
         ]
@@ -613,22 +631,22 @@ run(
             ),
             test(
                 "minimum and maximum",
-                Int16.lessOrEqual(minimumInt16, maximumInt16),
+                Int16.lessOrEqual(Int16.minimumValue, Int16.maximumValue),
                 M.equals(T.bool(true))
             ),
             test(
                 "maximum and minimum",
-                Int16.lessOrEqual(maximumInt16, minimumInt16),
+                Int16.lessOrEqual(Int16.maximumValue, Int16.minimumValue),
                 M.equals(T.bool(false))
             ),
             test(
                 "maximum and maximum",
-                Int16.lessOrEqual(maximumInt16, maximumInt16),
+                Int16.lessOrEqual(Int16.maximumValue, Int16.maximumValue),
                 M.equals(T.bool(true))
             ),
             test(
                 "minimum and minimum",
-                Int16.lessOrEqual(minimumInt16, minimumInt16),
+                Int16.lessOrEqual(Int16.minimumValue, Int16.minimumValue),
                 M.equals(T.bool(true))
             )
         ]
@@ -688,22 +706,22 @@ run(
             ),
             test(
                 "minimum and maximum",
-                Int16.greater(minimumInt16, maximumInt16),
+                Int16.greater(Int16.minimumValue, Int16.maximumValue),
                 M.equals(T.bool(false))
             ),
             test(
                 "maximum and minimum",
-                Int16.greater(maximumInt16, minimumInt16),
+                Int16.greater(Int16.maximumValue, Int16.minimumValue),
                 M.equals(T.bool(true))
             ),
             test(
                 "maximum and maximum",
-                Int16.greater(maximumInt16, maximumInt16),
+                Int16.greater(Int16.maximumValue, Int16.maximumValue),
                 M.equals(T.bool(false))
             ),
             test(
                 "minimum and minimum",
-                Int16.greater(minimumInt16, minimumInt16),
+                Int16.greater(Int16.minimumValue, Int16.minimumValue),
                 M.equals(T.bool(false))
             )
         ]
@@ -763,22 +781,22 @@ run(
             ),
             test(
                 "minimum and maximum",
-                Int16.greaterOrEqual(minimumInt16, maximumInt16),
+                Int16.greaterOrEqual(Int16.minimumValue, Int16.maximumValue),
                 M.equals(T.bool(false))
             ),
             test(
                 "maximum and minimum",
-                Int16.greaterOrEqual(maximumInt16, minimumInt16),
+                Int16.greaterOrEqual(Int16.maximumValue, Int16.minimumValue),
                 M.equals(T.bool(true))
             ),
             test(
                 "maximum and maximum",
-                Int16.greaterOrEqual(maximumInt16, maximumInt16),
+                Int16.greaterOrEqual(Int16.maximumValue, Int16.maximumValue),
                 M.equals(T.bool(true))
             ),
             test(
                 "minimum and minimum",
-                Int16.greaterOrEqual(minimumInt16, minimumInt16),
+                Int16.greaterOrEqual(Int16.minimumValue, Int16.minimumValue),
                 M.equals(T.bool(true))
             )
         ]
@@ -838,22 +856,22 @@ run(
             ),
             test(
                 "minimum and maximum",
-                Int16.compare(minimumInt16, maximumInt16),
+                Int16.compare(Int16.minimumValue, Int16.maximumValue),
                 M.equals(OrderTestable(#less))
             ),
             test(
                 "maximum and minimum",
-                Int16.compare(maximumInt16, minimumInt16),
+                Int16.compare(Int16.maximumValue, Int16.minimumValue),
                 M.equals(OrderTestable(#greater))
             ),
             test(
                 "maximum and maximum",
-                Int16.compare(maximumInt16, maximumInt16),
+                Int16.compare(Int16.maximumValue, Int16.maximumValue),
                 M.equals(OrderTestable(#equal))
             ),
             test(
                 "minimum and minimum",
-                Int16.compare(minimumInt16, minimumInt16),
+                Int16.compare(Int16.minimumValue, Int16.minimumValue),
                 M.equals(OrderTestable(#equal))
             )
         ]
@@ -883,13 +901,13 @@ run(
             ),
             test(
                 "maximum number",
-                Int16.neg(maximumInt16),
-                M.equals(Int16Testable(-maximumInt16))
+                Int16.neg(Int16.maximumValue),
+                M.equals(Int16Testable(-Int16.maximumValue))
             ),
             test(
                 "smallest possible",
-                Int16.neg(-maximumInt16),
-                M.equals(Int16Testable(maximumInt16))
+                Int16.neg(-Int16.maximumValue),
+                M.equals(Int16Testable(Int16.maximumValue))
             )
         ]
     )
@@ -923,7 +941,7 @@ run(
             ),
             test(
                 "minimum and maximum",
-                Int16.add(minimumInt16, maximumInt16),
+                Int16.add(Int16.minimumValue, Int16.maximumValue),
                 M.equals(Int16Testable(-1))
             )
         ]
@@ -958,7 +976,7 @@ run(
             ),
             test(
                 "maximum and maximum",
-                Int16.sub(maximumInt16, maximumInt16),
+                Int16.sub(Int16.maximumValue, Int16.maximumValue),
                 M.equals(Int16Testable(0))
             )
         ]
@@ -993,23 +1011,23 @@ run(
             ),
             test(
                 "zero and maximum",
-                Int16.mul(0, maximumInt16),
+                Int16.mul(0, Int16.maximumValue),
                 M.equals(Int16Testable(0))
             ),
             test(
                 "minimum and zero",
-                Int16.mul(minimumInt16, 0),
+                Int16.mul(Int16.minimumValue, 0),
                 M.equals(Int16Testable(0))
             ),
             test(
                 "one and maximum",
-                Int16.mul(1, maximumInt16),
-                M.equals(Int16Testable(maximumInt16))
+                Int16.mul(1, Int16.maximumValue),
+                M.equals(Int16Testable(Int16.maximumValue))
             ),
             test(
                 "minimum and one",
-                Int16.mul(minimumInt16, 1),
-                M.equals(Int16Testable(minimumInt16))
+                Int16.mul(Int16.minimumValue, 1),
+                M.equals(Int16Testable(Int16.minimumValue))
             )
         ]
     )
@@ -1053,22 +1071,22 @@ run(
             ),
             test(
                 "zero and maximum",
-                Int16.div(0, maximumInt16),
+                Int16.div(0, Int16.maximumValue),
                 M.equals(Int16Testable(0))
             ),
             test(
                 "zero and minimum",
-                Int16.div(0, minimumInt16),
+                Int16.div(0, Int16.minimumValue),
                 M.equals(Int16Testable(0))
             ),
             test(
                 "maximum and maximum",
-                Int16.div(maximumInt16, maximumInt16),
+                Int16.div(Int16.maximumValue, Int16.maximumValue),
                 M.equals(Int16Testable(1))
             ),
             test(
                 "minimum and minimum",
-                Int16.div(minimumInt16, minimumInt16),
+                Int16.div(Int16.minimumValue, Int16.minimumValue),
                 M.equals(Int16Testable(1))
             )
         ]
@@ -1113,22 +1131,22 @@ run(
             ),
             test(
                 "zero and maximum",
-                Int16.rem(0, maximumInt16),
+                Int16.rem(0, Int16.maximumValue),
                 M.equals(Int16Testable(0))
             ),
             test(
                 "zero and minimum",
-                Int16.rem(0, minimumInt16),
+                Int16.rem(0, Int16.minimumValue),
                 M.equals(Int16Testable(0))
             ),
             test(
                 "maximum and maximum",
-                Int16.rem(maximumInt16, maximumInt16),
+                Int16.rem(Int16.maximumValue, Int16.maximumValue),
                 M.equals(Int16Testable(0))
             ),
             test(
                 "minimum and minimum",
-                Int16.rem(minimumInt16, minimumInt16),
+                Int16.rem(Int16.minimumValue, Int16.minimumValue),
                 M.equals(Int16Testable(0))
             )
         ]
@@ -1168,22 +1186,22 @@ run(
             ),
             test(
                 "maximum and zero",
-                Int16.pow(maximumInt16, 0),
+                Int16.pow(Int16.maximumValue, 0),
                 M.equals(Int16Testable(1))
             ),
             test(
                 "minimum and zero",
-                Int16.pow(minimumInt16, 0),
+                Int16.pow(Int16.minimumValue, 0),
                 M.equals(Int16Testable(1))
             ),
             test(
                 "plus one and maximum",
-                Int16.pow(1, maximumInt16),
+                Int16.pow(1, Int16.maximumValue),
                 M.equals(Int16Testable(1))
             ),
             test(
                 "minus one and maximum",
-                Int16.pow(-1, maximumInt16),
+                Int16.pow(-1, Int16.maximumValue),
                 M.equals(Int16Testable(-1))
             )
         ]
@@ -1192,35 +1210,33 @@ run(
 
 /* --------------------------------------- */
 
-let unused = 0 : Int16; // Issue: bitnot has superfluous second argument.
-
 run(
     suite(
         "bitnot",
         [
             test(
                 "zero",
-                Int16.bitnot(0, unused),
+                Int16.bitnot(0),
                 M.equals(Int16Testable(-1))
             ),
             test(
                 "minus 1",
-                Int16.bitnot(-1, unused),
+                Int16.bitnot(-1),
                 M.equals(Int16Testable(0))
             ),
             test(
                 "maximum",
-                Int16.bitnot(maximumInt16, unused),
-                M.equals(Int16Testable(minimumInt16))
+                Int16.bitnot(Int16.maximumValue),
+                M.equals(Int16Testable(Int16.minimumValue))
             ),
             test(
                 "minimum",
-                Int16.bitnot(minimumInt16, unused),
-                M.equals(Int16Testable(maximumInt16))
+                Int16.bitnot(Int16.minimumValue),
+                M.equals(Int16Testable(Int16.maximumValue))
             ),
             test(
                 "arbitrary",
-                Int16.bitnot(1234, 0),
+                Int16.bitnot(1234),
                 M.equals(Int16Testable(-1235))
             )
         ]
@@ -1265,17 +1281,17 @@ run(
             ),
             test(
                 "zero and maximum",
-                Int16.bitand(0, maximumInt16),
+                Int16.bitand(0, Int16.maximumValue),
                 M.equals(Int16Testable(0))
             ),
             test(
                 "minimum and zero",
-                Int16.bitand(minimumInt16, 0),
+                Int16.bitand(Int16.minimumValue, 0),
                 M.equals(Int16Testable(0))
             ),
             test(
                 "minimum and maximum",
-                Int16.bitand(minimumInt16, maximumInt16),
+                Int16.bitand(Int16.minimumValue, Int16.maximumValue),
                 M.equals(Int16Testable(0))
             )
         ]
@@ -1320,17 +1336,17 @@ run(
             ),
             test(
                 "zero and maximum",
-                Int16.bitor(0, maximumInt16),
-                M.equals(Int16Testable(maximumInt16))
+                Int16.bitor(0, Int16.maximumValue),
+                M.equals(Int16Testable(Int16.maximumValue))
             ),
             test(
                 "minimum and zero",
-                Int16.bitor(minimumInt16, 0),
-                M.equals(Int16Testable(minimumInt16))
+                Int16.bitor(Int16.minimumValue, 0),
+                M.equals(Int16Testable(Int16.minimumValue))
             ),
             test(
                 "minimum and maximum",
-                Int16.bitor(minimumInt16, maximumInt16),
+                Int16.bitor(Int16.minimumValue, Int16.maximumValue),
                 M.equals(Int16Testable(-1))
             )
         ]
@@ -1375,17 +1391,17 @@ run(
             ),
             test(
                 "zero and maximum",
-                Int16.bitxor(0, maximumInt16),
-                M.equals(Int16Testable(maximumInt16))
+                Int16.bitxor(0, Int16.maximumValue),
+                M.equals(Int16Testable(Int16.maximumValue))
             ),
             test(
                 "minimum and zero",
-                Int16.bitxor(minimumInt16, 0),
-                M.equals(Int16Testable(minimumInt16))
+                Int16.bitxor(Int16.minimumValue, 0),
+                M.equals(Int16Testable(Int16.minimumValue))
             ),
             test(
                 "minimum and maximum",
-                Int16.bitxor(minimumInt16, maximumInt16),
+                Int16.bitxor(Int16.minimumValue, Int16.maximumValue),
                 M.equals(Int16Testable(-1))
             )
         ]
@@ -1421,12 +1437,12 @@ run(
             test(
                 "one maximum shift",
                 Int16.bitshiftLeft(1, 15),
-                M.equals(Int16Testable(minimumInt16))
+                M.equals(Int16Testable(Int16.minimumValue))
             ),
             test(
                 "minimum number",
                 Int16.bitshiftLeft(-1, 15),
-                M.equals(Int16Testable(minimumInt16))
+                M.equals(Int16Testable(Int16.minimumValue))
             ),
             test(
                 "discard overflow",
@@ -1485,7 +1501,7 @@ run(
             ),
             test(
                 "minimum number",
-                Int16.bitshiftRight(minimumInt16, 15),
+                Int16.bitshiftRight(Int16.minimumValue, 15),
                 M.equals(Int16Testable(-1))
             ),
             test(
@@ -1550,13 +1566,13 @@ run(
             ),
             test(
                 "maximum number",
-                Int16.bitrotLeft(maximumInt16, 1),
+                Int16.bitrotLeft(Int16.maximumValue, 1),
                 M.equals(Int16Testable(-2))
             ),
             test(
                 "minimum number",
                 Int16.bitrotLeft(1, 15),
-                M.equals(Int16Testable(minimumInt16))
+                M.equals(Int16Testable(Int16.minimumValue))
             ),
             test(
                 "opposite rotation",
@@ -1611,11 +1627,11 @@ run(
             test(
                 "maximum number",
                 Int16.bitrotRight(-2, 1),
-                M.equals(Int16Testable(maximumInt16))
+                M.equals(Int16Testable(Int16.maximumValue))
             ),
             test(
                 "minimum number",
-                Int16.bitrotRight(minimumInt16, 15),
+                Int16.bitrotRight(Int16.minimumValue, 15),
                 M.equals(Int16Testable(1))
             ),
             test(
@@ -1889,12 +1905,12 @@ run(
             ),
             test(
                 "minimum value",
-                Int16.bitcountNonZero(minimumInt16),
+                Int16.bitcountNonZero(Int16.minimumValue),
                 M.equals(Int16Testable(1))
             ),
             test(
                 "maximum value",
-                Int16.bitcountNonZero(maximumInt16),
+                Int16.bitcountNonZero(Int16.maximumValue),
                 M.equals(Int16Testable(15))
             ),
             test(
@@ -1949,12 +1965,12 @@ run(
             ),
             test(
                 "minimum value",
-                Int16.bitcountLeadingZero(minimumInt16),
+                Int16.bitcountLeadingZero(Int16.minimumValue),
                 M.equals(Int16Testable(0))
             ),
             test(
                 "maximum value",
-                Int16.bitcountLeadingZero(maximumInt16),
+                Int16.bitcountLeadingZero(Int16.maximumValue),
                 M.equals(Int16Testable(1))
             ),
             test(
@@ -2009,12 +2025,12 @@ run(
             ),
             test(
                 "minimum value",
-                Int16.bitcountTrailingZero(minimumInt16),
+                Int16.bitcountTrailingZero(Int16.minimumValue),
                 M.equals(Int16Testable(15))
             ),
             test(
                 "maximum value",
-                Int16.bitcountTrailingZero(maximumInt16),
+                Int16.bitcountTrailingZero(Int16.maximumValue),
                 M.equals(Int16Testable(0))
             ),
             test(
@@ -2059,27 +2075,27 @@ run(
             ),
             test(
                 "minimum and maximum",
-                Int16.addWrap(minimumInt16, maximumInt16),
+                Int16.addWrap(Int16.minimumValue, Int16.maximumValue),
                 M.equals(Int16Testable(-1))
             ),
             test(
                 "small overflow",
-                Int16.addWrap(maximumInt16, 1),
-                M.equals(Int16Testable(minimumInt16))
+                Int16.addWrap(Int16.maximumValue, 1),
+                M.equals(Int16Testable(Int16.minimumValue))
             ),
             test(
                 "large overflow",
-                Int16.addWrap(maximumInt16, maximumInt16),
+                Int16.addWrap(Int16.maximumValue, Int16.maximumValue),
                 M.equals(Int16Testable(-2))
             ),
             test(
                 "small underflow",
-                Int16.addWrap(minimumInt16, -1),
-                M.equals(Int16Testable(maximumInt16))
+                Int16.addWrap(Int16.minimumValue, -1),
+                M.equals(Int16Testable(Int16.maximumValue))
             ),
             test(
                 "large underflow",
-                Int16.addWrap(minimumInt16, minimumInt16),
+                Int16.addWrap(Int16.minimumValue, Int16.minimumValue),
                 M.equals(Int16Testable(0))
             ),
         ]
@@ -2114,27 +2130,27 @@ run(
             ),
             test(
                 "maximum and maximum",
-                Int16.subWrap(maximumInt16, maximumInt16),
+                Int16.subWrap(Int16.maximumValue, Int16.maximumValue),
                 M.equals(Int16Testable(0))
             ),
             test(
                 "small overflow",
-                Int16.subWrap(maximumInt16, -1),
-                M.equals(Int16Testable(minimumInt16))
+                Int16.subWrap(Int16.maximumValue, -1),
+                M.equals(Int16Testable(Int16.minimumValue))
             ),
             test(
                 "large overflow",
-                Int16.subWrap(maximumInt16, minimumInt16),
+                Int16.subWrap(Int16.maximumValue, Int16.minimumValue),
                 M.equals(Int16Testable(-1))
             ),
             test(
                 "small underflow",
-                Int16.subWrap(minimumInt16, 1),
-                M.equals(Int16Testable(maximumInt16))
+                Int16.subWrap(Int16.minimumValue, 1),
+                M.equals(Int16Testable(Int16.maximumValue))
             ),
             test(
                 "large underflow",
-                Int16.subWrap(minimumInt16, maximumInt16),
+                Int16.subWrap(Int16.minimumValue, Int16.maximumValue),
                 M.equals(Int16Testable(1))
             ),
         ]
@@ -2169,42 +2185,42 @@ run(
             ),
             test(
                 "zero and maximum",
-                Int16.mulWrap(0, maximumInt16),
+                Int16.mulWrap(0, Int16.maximumValue),
                 M.equals(Int16Testable(0))
             ),
             test(
                 "minimum and zero",
-                Int16.mulWrap(minimumInt16, 0),
+                Int16.mulWrap(Int16.minimumValue, 0),
                 M.equals(Int16Testable(0))
             ),
             test(
                 "one and maximum",
-                Int16.mulWrap(1, maximumInt16),
-                M.equals(Int16Testable(maximumInt16))
+                Int16.mulWrap(1, Int16.maximumValue),
+                M.equals(Int16Testable(Int16.maximumValue))
             ),
             test(
                 "minimum and one",
-                Int16.mulWrap(minimumInt16, 1),
-                M.equals(Int16Testable(minimumInt16))
+                Int16.mulWrap(Int16.minimumValue, 1),
+                M.equals(Int16Testable(Int16.minimumValue))
             ),
             test(
                 "small overflow",
-                Int16.mulWrap(2, maximumInt16),
+                Int16.mulWrap(2, Int16.maximumValue),
                 M.equals(Int16Testable(-2))
             ),
             test(
                 "large overflow",
-                Int16.mulWrap(maximumInt16, maximumInt16),
+                Int16.mulWrap(Int16.maximumValue, Int16.maximumValue),
                 M.equals(Int16Testable(1))
             ),
             test(
                 "small underflow",
-                Int16.mulWrap(minimumInt16, 2),
+                Int16.mulWrap(Int16.minimumValue, 2),
                 M.equals(Int16Testable(0))
             ),
             test(
                 "large underflow",
-                Int16.mulWrap(minimumInt16, minimumInt16),
+                Int16.mulWrap(Int16.minimumValue, Int16.minimumValue),
                 M.equals(Int16Testable(0))
             ),
         ]
@@ -2239,37 +2255,37 @@ run(
             ),
             test(
                 "maximum and zero",
-                Int16.powWrap(maximumInt16, 0),
+                Int16.powWrap(Int16.maximumValue, 0),
                 M.equals(Int16Testable(1))
             ),
             test(
                 "minimum and zero",
-                Int16.powWrap(minimumInt16, 0),
+                Int16.powWrap(Int16.minimumValue, 0),
                 M.equals(Int16Testable(1))
             ),
             test(
                 "plus one and maximum",
-                Int16.powWrap(1, maximumInt16),
+                Int16.powWrap(1, Int16.maximumValue),
                 M.equals(Int16Testable(1))
             ),
             test(
                 "minus one and maximum",
-                Int16.powWrap(-1, maximumInt16),
+                Int16.powWrap(-1, Int16.maximumValue),
                 M.equals(Int16Testable(-1))
             ),
             test(
                 "minimum value",
                 Int16.powWrap(-2, 15),
-                M.equals(Int16Testable(minimumInt16))
+                M.equals(Int16Testable(Int16.minimumValue))
             ),
             test(
                 "small overflow",
                 Int16.powWrap(2, 15),
-                M.equals(Int16Testable(minimumInt16))
+                M.equals(Int16Testable(Int16.minimumValue))
             ),
             test(
                 "large overflow",
-                Int16.powWrap(maximumInt16, 10),
+                Int16.powWrap(Int16.maximumValue, 10),
                 M.equals(Int16Testable(1))
             ),
             test(
@@ -2279,7 +2295,7 @@ run(
             ),
             test(
                 "large underflow",
-                Int16.powWrap(minimumInt16, 10),
+                Int16.powWrap(Int16.minimumValue, 10),
                 M.equals(Int16Testable(0))
             ),
         ]

--- a/test/int32Test.mo
+++ b/test/int32Test.mo
@@ -8,12 +8,10 @@ import M "mo:matchers/Matchers";
 
 let { run; test; suite } = Suite;
 
-let maximumInt32 = 2_147_483_647 : Int32;
-let maximumInt32asInt = 2_147_483_647 : Int;
-let maximumInt32asNat32 = 2_147_483_647 : Nat32;
+let maximumInt32asInt = +2 ** 31 - 1 : Int;
+let maximumInt32asNat32 = 2 ** 31 - 1 : Nat32;
 
-let minimumInt32 = -2_147_483_648 : Int32;
-let minimumInt32asInt = -2_147_483_648 : Int;
+let minimumInt32asInt = -2 ** 31 : Int;
 
 let maximumNat32 = 4_294_967_295 : Nat32;
 
@@ -53,16 +51,36 @@ class OrderTestable(value : Order) : T.TestableItem<Order> {
 
 run(
     suite(
+        "constants",
+        [
+            test(
+                "minimum value",
+                Int32.minimumValue,
+                M.equals(Int32Testable(Int32.fromInt(-2 ** 31)))
+            ),
+            test(
+                "maximum value",
+                Int32.maximumValue,
+                M.equals(Int32Testable(Int32.fromInt(+2 ** 31 - 1)))
+            ),
+        ]
+    )
+);
+
+/* --------------------------------------- */
+
+run(
+    suite(
         "toInt",
         [
             test(
                 "maximum number",
-                Int32.toInt(maximumInt32),
+                Int32.toInt(Int32.maximumValue),
                 M.equals(T.int(maximumInt32asInt))
             ),
             test(
                 "minimum number",
-                Int32.toInt(minimumInt32),
+                Int32.toInt(Int32.minimumValue),
                 M.equals(T.int(minimumInt32asInt))
             ),
             test(
@@ -93,12 +111,12 @@ run(
             test(
                 "maximum number",
                 Int32.fromInt(maximumInt32asInt),
-                M.equals(Int32Testable(maximumInt32))
+                M.equals(Int32Testable(Int32.maximumValue))
             ),
             test(
                 "minimum number",
                 Int32.fromInt(minimumInt32asInt),
-                M.equals(Int32Testable(minimumInt32))
+                M.equals(Int32Testable(Int32.minimumValue))
             ),
             test(
                 "one",
@@ -128,12 +146,12 @@ run(
             test(
                 "maximum number",
                 Int32.fromIntWrap(maximumInt32asInt),
-                M.equals(Int32Testable(maximumInt32))
+                M.equals(Int32Testable(Int32.maximumValue))
             ),
             test(
                 "minimum number",
                 Int32.fromIntWrap(minimumInt32asInt),
-                M.equals(Int32Testable(minimumInt32))
+                M.equals(Int32Testable(Int32.minimumValue))
             ),
             test(
                 "one",
@@ -153,12 +171,12 @@ run(
             test(
                 "overflow",
                 Int32.fromIntWrap(maximumInt32asInt + 1),
-                M.equals(Int32Testable(minimumInt32))
+                M.equals(Int32Testable(Int32.minimumValue))
             ),
             test(
                 "underflow",
                 Int32.fromIntWrap(minimumInt32asInt - 1),
-                M.equals(Int32Testable(maximumInt32))
+                M.equals(Int32Testable(Int32.maximumValue))
             )
         ]
     )
@@ -173,7 +191,7 @@ run(
             test(
                 "maximum number",
                 Int32.fromNat32(maximumInt32asNat32),
-                M.equals(Int32Testable(maximumInt32))
+                M.equals(Int32Testable(Int32.maximumValue))
             ),
             test(
                 "one",
@@ -188,7 +206,7 @@ run(
             test(
                 "overflow",
                 Int32.fromNat32(maximumInt32asNat32 + 1),
-                M.equals(Int32Testable(minimumInt32))
+                M.equals(Int32Testable(Int32.minimumValue))
             )
         ]
     )
@@ -202,7 +220,7 @@ run(
         [
             test(
                 "maximum number",
-                Int32.toNat32(maximumInt32),
+                Int32.toNat32(Int32.maximumValue),
                 M.equals(Nat32Testable(maximumInt32asNat32))
             ),
             test(
@@ -247,12 +265,12 @@ run(
             ),
             test(
                 "maximum number",
-                Int32.toText(maximumInt32),
+                Int32.toText(Int32.maximumValue),
                 M.equals(T.text("2147483647"))
             ),
             test(
                 "minimum number",
-                Int32.toText(minimumInt32),
+                Int32.toText(Int32.minimumValue),
                 M.equals(T.text("-2147483648"))
             )
         ]
@@ -283,13 +301,13 @@ run(
             ),
             test(
                 "maximum number",
-                Int32.abs(maximumInt32),
-                M.equals(Int32Testable(maximumInt32))
+                Int32.abs(Int32.maximumValue),
+                M.equals(Int32Testable(Int32.maximumValue))
             ),
             test(
                 "smallest possible",
-                Int32.abs(-maximumInt32),
-                M.equals(Int32Testable(maximumInt32))
+                Int32.abs(-Int32.maximumValue),
+                M.equals(Int32Testable(Int32.maximumValue))
             )
         ]
     )
@@ -328,8 +346,8 @@ run(
             ),
             test(
                 "maximum and minimum number",
-                Int32.min(maximumInt32, minimumInt32),
-                M.equals(Int32Testable(minimumInt32))
+                Int32.min(Int32.maximumValue, Int32.minimumValue),
+                M.equals(Int32Testable(Int32.minimumValue))
             )
         ]
     )
@@ -368,8 +386,8 @@ run(
             ),
             test(
                 "maximum and minimum number",
-                Int32.max(maximumInt32, minimumInt32),
-                M.equals(Int32Testable(maximumInt32))
+                Int32.max(Int32.maximumValue, Int32.minimumValue),
+                M.equals(Int32Testable(Int32.maximumValue))
             )
         ]
     )
@@ -413,17 +431,17 @@ run(
             ),
             test(
                 "maxmimum equal",
-                Int32.equal(maximumInt32, maximumInt32),
+                Int32.equal(Int32.maximumValue, Int32.maximumValue),
                 M.equals(T.bool(true))
             ),
             test(
                 "minimum equal",
-                Int32.equal(minimumInt32, minimumInt32),
+                Int32.equal(Int32.minimumValue, Int32.minimumValue),
                 M.equals(T.bool(true))
             ),
             test(
                 "minimum and maximum",
-                Int32.equal(minimumInt32, maximumInt32),
+                Int32.equal(Int32.minimumValue, Int32.maximumValue),
                 M.equals(T.bool(false))
             )
         ]
@@ -468,17 +486,17 @@ run(
             ),
             test(
                 "maxmimum equal",
-                Int32.notEqual(maximumInt32, maximumInt32),
+                Int32.notEqual(Int32.maximumValue, Int32.maximumValue),
                 M.equals(T.bool(false))
             ),
             test(
                 "minimum equal",
-                Int32.notEqual(minimumInt32, minimumInt32),
+                Int32.notEqual(Int32.minimumValue, Int32.minimumValue),
                 M.equals(T.bool(false))
             ),
             test(
                 "minimum and maximum",
-                Int32.notEqual(minimumInt32, maximumInt32),
+                Int32.notEqual(Int32.minimumValue, Int32.maximumValue),
                 M.equals(T.bool(true))
             )
         ]
@@ -538,22 +556,22 @@ run(
             ),
             test(
                 "minimum and maximum",
-                Int32.less(minimumInt32, maximumInt32),
+                Int32.less(Int32.minimumValue, Int32.maximumValue),
                 M.equals(T.bool(true))
             ),
             test(
                 "maximum and minimum",
-                Int32.less(maximumInt32, minimumInt32),
+                Int32.less(Int32.maximumValue, Int32.minimumValue),
                 M.equals(T.bool(false))
             ),
             test(
                 "maximum and maximum",
-                Int32.less(maximumInt32, maximumInt32),
+                Int32.less(Int32.maximumValue, Int32.maximumValue),
                 M.equals(T.bool(false))
             ),
             test(
                 "minimum and minimum",
-                Int32.less(minimumInt32, minimumInt32),
+                Int32.less(Int32.minimumValue, Int32.minimumValue),
                 M.equals(T.bool(false))
             )
         ]
@@ -613,22 +631,22 @@ run(
             ),
             test(
                 "minimum and maximum",
-                Int32.lessOrEqual(minimumInt32, maximumInt32),
+                Int32.lessOrEqual(Int32.minimumValue, Int32.maximumValue),
                 M.equals(T.bool(true))
             ),
             test(
                 "maximum and minimum",
-                Int32.lessOrEqual(maximumInt32, minimumInt32),
+                Int32.lessOrEqual(Int32.maximumValue, Int32.minimumValue),
                 M.equals(T.bool(false))
             ),
             test(
                 "maximum and maximum",
-                Int32.lessOrEqual(maximumInt32, maximumInt32),
+                Int32.lessOrEqual(Int32.maximumValue, Int32.maximumValue),
                 M.equals(T.bool(true))
             ),
             test(
                 "minimum and minimum",
-                Int32.lessOrEqual(minimumInt32, minimumInt32),
+                Int32.lessOrEqual(Int32.minimumValue, Int32.minimumValue),
                 M.equals(T.bool(true))
             )
         ]
@@ -688,22 +706,22 @@ run(
             ),
             test(
                 "minimum and maximum",
-                Int32.greater(minimumInt32, maximumInt32),
+                Int32.greater(Int32.minimumValue, Int32.maximumValue),
                 M.equals(T.bool(false))
             ),
             test(
                 "maximum and minimum",
-                Int32.greater(maximumInt32, minimumInt32),
+                Int32.greater(Int32.maximumValue, Int32.minimumValue),
                 M.equals(T.bool(true))
             ),
             test(
                 "maximum and maximum",
-                Int32.greater(maximumInt32, maximumInt32),
+                Int32.greater(Int32.maximumValue, Int32.maximumValue),
                 M.equals(T.bool(false))
             ),
             test(
                 "minimum and minimum",
-                Int32.greater(minimumInt32, minimumInt32),
+                Int32.greater(Int32.minimumValue, Int32.minimumValue),
                 M.equals(T.bool(false))
             )
         ]
@@ -763,22 +781,22 @@ run(
             ),
             test(
                 "minimum and maximum",
-                Int32.greaterOrEqual(minimumInt32, maximumInt32),
+                Int32.greaterOrEqual(Int32.minimumValue, Int32.maximumValue),
                 M.equals(T.bool(false))
             ),
             test(
                 "maximum and minimum",
-                Int32.greaterOrEqual(maximumInt32, minimumInt32),
+                Int32.greaterOrEqual(Int32.maximumValue, Int32.minimumValue),
                 M.equals(T.bool(true))
             ),
             test(
                 "maximum and maximum",
-                Int32.greaterOrEqual(maximumInt32, maximumInt32),
+                Int32.greaterOrEqual(Int32.maximumValue, Int32.maximumValue),
                 M.equals(T.bool(true))
             ),
             test(
                 "minimum and minimum",
-                Int32.greaterOrEqual(minimumInt32, minimumInt32),
+                Int32.greaterOrEqual(Int32.minimumValue, Int32.minimumValue),
                 M.equals(T.bool(true))
             )
         ]
@@ -838,22 +856,22 @@ run(
             ),
             test(
                 "minimum and maximum",
-                Int32.compare(minimumInt32, maximumInt32),
+                Int32.compare(Int32.minimumValue, Int32.maximumValue),
                 M.equals(OrderTestable(#less))
             ),
             test(
                 "maximum and minimum",
-                Int32.compare(maximumInt32, minimumInt32),
+                Int32.compare(Int32.maximumValue, Int32.minimumValue),
                 M.equals(OrderTestable(#greater))
             ),
             test(
                 "maximum and maximum",
-                Int32.compare(maximumInt32, maximumInt32),
+                Int32.compare(Int32.maximumValue, Int32.maximumValue),
                 M.equals(OrderTestable(#equal))
             ),
             test(
                 "minimum and minimum",
-                Int32.compare(minimumInt32, minimumInt32),
+                Int32.compare(Int32.minimumValue, Int32.minimumValue),
                 M.equals(OrderTestable(#equal))
             )
         ]
@@ -883,13 +901,13 @@ run(
             ),
             test(
                 "maximum number",
-                Int32.neg(maximumInt32),
-                M.equals(Int32Testable(-maximumInt32))
+                Int32.neg(Int32.maximumValue),
+                M.equals(Int32Testable(-Int32.maximumValue))
             ),
             test(
                 "smallest possible",
-                Int32.neg(-maximumInt32),
-                M.equals(Int32Testable(maximumInt32))
+                Int32.neg(-Int32.maximumValue),
+                M.equals(Int32Testable(Int32.maximumValue))
             )
         ]
     )
@@ -923,7 +941,7 @@ run(
             ),
             test(
                 "minimum and maximum",
-                Int32.add(minimumInt32, maximumInt32),
+                Int32.add(Int32.minimumValue, Int32.maximumValue),
                 M.equals(Int32Testable(-1))
             )
         ]
@@ -958,7 +976,7 @@ run(
             ),
             test(
                 "maximum and maximum",
-                Int32.sub(maximumInt32, maximumInt32),
+                Int32.sub(Int32.maximumValue, Int32.maximumValue),
                 M.equals(Int32Testable(0))
             )
         ]
@@ -993,23 +1011,23 @@ run(
             ),
             test(
                 "zero and maximum",
-                Int32.mul(0, maximumInt32),
+                Int32.mul(0, Int32.maximumValue),
                 M.equals(Int32Testable(0))
             ),
             test(
                 "minimum and zero",
-                Int32.mul(minimumInt32, 0),
+                Int32.mul(Int32.minimumValue, 0),
                 M.equals(Int32Testable(0))
             ),
             test(
                 "one and maximum",
-                Int32.mul(1, maximumInt32),
-                M.equals(Int32Testable(maximumInt32))
+                Int32.mul(1, Int32.maximumValue),
+                M.equals(Int32Testable(Int32.maximumValue))
             ),
             test(
                 "minimum and one",
-                Int32.mul(minimumInt32, 1),
-                M.equals(Int32Testable(minimumInt32))
+                Int32.mul(Int32.minimumValue, 1),
+                M.equals(Int32Testable(Int32.minimumValue))
             )
         ]
     )
@@ -1053,22 +1071,22 @@ run(
             ),
             test(
                 "zero and maximum",
-                Int32.div(0, maximumInt32),
+                Int32.div(0, Int32.maximumValue),
                 M.equals(Int32Testable(0))
             ),
             test(
                 "zero and minimum",
-                Int32.div(0, minimumInt32),
+                Int32.div(0, Int32.minimumValue),
                 M.equals(Int32Testable(0))
             ),
             test(
                 "maximum and maximum",
-                Int32.div(maximumInt32, maximumInt32),
+                Int32.div(Int32.maximumValue, Int32.maximumValue),
                 M.equals(Int32Testable(1))
             ),
             test(
                 "minimum and minimum",
-                Int32.div(minimumInt32, minimumInt32),
+                Int32.div(Int32.minimumValue, Int32.minimumValue),
                 M.equals(Int32Testable(1))
             )
         ]
@@ -1113,22 +1131,22 @@ run(
             ),
             test(
                 "zero and maximum",
-                Int32.rem(0, maximumInt32),
+                Int32.rem(0, Int32.maximumValue),
                 M.equals(Int32Testable(0))
             ),
             test(
                 "zero and minimum",
-                Int32.rem(0, minimumInt32),
+                Int32.rem(0, Int32.minimumValue),
                 M.equals(Int32Testable(0))
             ),
             test(
                 "maximum and maximum",
-                Int32.rem(maximumInt32, maximumInt32),
+                Int32.rem(Int32.maximumValue, Int32.maximumValue),
                 M.equals(Int32Testable(0))
             ),
             test(
                 "minimum and minimum",
-                Int32.rem(minimumInt32, minimumInt32),
+                Int32.rem(Int32.minimumValue, Int32.minimumValue),
                 M.equals(Int32Testable(0))
             )
         ]
@@ -1168,22 +1186,22 @@ run(
             ),
             test(
                 "maximum and zero",
-                Int32.pow(maximumInt32, 0),
+                Int32.pow(Int32.maximumValue, 0),
                 M.equals(Int32Testable(1))
             ),
             test(
                 "minimum and zero",
-                Int32.pow(minimumInt32, 0),
+                Int32.pow(Int32.minimumValue, 0),
                 M.equals(Int32Testable(1))
             ),
             test(
                 "plus one and maximum",
-                Int32.pow(1, maximumInt32),
+                Int32.pow(1, Int32.maximumValue),
                 M.equals(Int32Testable(1))
             ),
             test(
                 "minus one and maximum",
-                Int32.pow(-1, maximumInt32),
+                Int32.pow(-1, Int32.maximumValue),
                 M.equals(Int32Testable(-1))
             )
         ]
@@ -1192,35 +1210,33 @@ run(
 
 /* --------------------------------------- */
 
-let unused = 0 : Int32; // Issue: bitnot has superfluous second argument.
-
 run(
     suite(
         "bitnot",
         [
             test(
                 "zero",
-                Int32.bitnot(0, unused),
+                Int32.bitnot(0),
                 M.equals(Int32Testable(-1))
             ),
             test(
                 "minus 1",
-                Int32.bitnot(-1, unused),
+                Int32.bitnot(-1),
                 M.equals(Int32Testable(0))
             ),
             test(
                 "maximum",
-                Int32.bitnot(maximumInt32, unused),
-                M.equals(Int32Testable(minimumInt32))
+                Int32.bitnot(Int32.maximumValue),
+                M.equals(Int32Testable(Int32.minimumValue))
             ),
             test(
                 "minimum",
-                Int32.bitnot(minimumInt32, unused),
-                M.equals(Int32Testable(maximumInt32))
+                Int32.bitnot(Int32.minimumValue),
+                M.equals(Int32Testable(Int32.maximumValue))
             ),
             test(
                 "arbitrary",
-                Int32.bitnot(1234, 0),
+                Int32.bitnot(1234),
                 M.equals(Int32Testable(-1235))
             )
         ]
@@ -1265,17 +1281,17 @@ run(
             ),
             test(
                 "zero and maximum",
-                Int32.bitand(0, maximumInt32),
+                Int32.bitand(0, Int32.maximumValue),
                 M.equals(Int32Testable(0))
             ),
             test(
                 "minimum and zero",
-                Int32.bitand(minimumInt32, 0),
+                Int32.bitand(Int32.minimumValue, 0),
                 M.equals(Int32Testable(0))
             ),
             test(
                 "minimum and maximum",
-                Int32.bitand(minimumInt32, maximumInt32),
+                Int32.bitand(Int32.minimumValue, Int32.maximumValue),
                 M.equals(Int32Testable(0))
             )
         ]
@@ -1320,17 +1336,17 @@ run(
             ),
             test(
                 "zero and maximum",
-                Int32.bitor(0, maximumInt32),
-                M.equals(Int32Testable(maximumInt32))
+                Int32.bitor(0, Int32.maximumValue),
+                M.equals(Int32Testable(Int32.maximumValue))
             ),
             test(
                 "minimum and zero",
-                Int32.bitor(minimumInt32, 0),
-                M.equals(Int32Testable(minimumInt32))
+                Int32.bitor(Int32.minimumValue, 0),
+                M.equals(Int32Testable(Int32.minimumValue))
             ),
             test(
                 "minimum and maximum",
-                Int32.bitor(minimumInt32, maximumInt32),
+                Int32.bitor(Int32.minimumValue, Int32.maximumValue),
                 M.equals(Int32Testable(-1))
             )
         ]
@@ -1375,17 +1391,17 @@ run(
             ),
             test(
                 "zero and maximum",
-                Int32.bitxor(0, maximumInt32),
-                M.equals(Int32Testable(maximumInt32))
+                Int32.bitxor(0, Int32.maximumValue),
+                M.equals(Int32Testable(Int32.maximumValue))
             ),
             test(
                 "minimum and zero",
-                Int32.bitxor(minimumInt32, 0),
-                M.equals(Int32Testable(minimumInt32))
+                Int32.bitxor(Int32.minimumValue, 0),
+                M.equals(Int32Testable(Int32.minimumValue))
             ),
             test(
                 "minimum and maximum",
-                Int32.bitxor(minimumInt32, maximumInt32),
+                Int32.bitxor(Int32.minimumValue, Int32.maximumValue),
                 M.equals(Int32Testable(-1))
             )
         ]
@@ -1421,12 +1437,12 @@ run(
             test(
                 "one maximum shift",
                 Int32.bitshiftLeft(1, 31),
-                M.equals(Int32Testable(minimumInt32))
+                M.equals(Int32Testable(Int32.minimumValue))
             ),
             test(
                 "minimum number",
                 Int32.bitshiftLeft(-1, 31),
-                M.equals(Int32Testable(minimumInt32))
+                M.equals(Int32Testable(Int32.minimumValue))
             ),
             test(
                 "discard overflow",
@@ -1485,7 +1501,7 @@ run(
             ),
             test(
                 "minimum number",
-                Int32.bitshiftRight(minimumInt32, 31),
+                Int32.bitshiftRight(Int32.minimumValue, 31),
                 M.equals(Int32Testable(-1))
             ),
             test(
@@ -1550,13 +1566,13 @@ run(
             ),
             test(
                 "maximum number",
-                Int32.bitrotLeft(maximumInt32, 1),
+                Int32.bitrotLeft(Int32.maximumValue, 1),
                 M.equals(Int32Testable(-2))
             ),
             test(
                 "minimum number",
                 Int32.bitrotLeft(1, 31),
-                M.equals(Int32Testable(minimumInt32))
+                M.equals(Int32Testable(Int32.minimumValue))
             ),
             test(
                 "opposite rotation",
@@ -1611,11 +1627,11 @@ run(
             test(
                 "maximum number",
                 Int32.bitrotRight(-2, 1),
-                M.equals(Int32Testable(maximumInt32))
+                M.equals(Int32Testable(Int32.maximumValue))
             ),
             test(
                 "minimum number",
-                Int32.bitrotRight(minimumInt32, 31),
+                Int32.bitrotRight(Int32.minimumValue, 31),
                 M.equals(Int32Testable(1))
             ),
             test(
@@ -1889,12 +1905,12 @@ run(
             ),
             test(
                 "minimum value",
-                Int32.bitcountNonZero(minimumInt32),
+                Int32.bitcountNonZero(Int32.minimumValue),
                 M.equals(Int32Testable(1))
             ),
             test(
                 "maximum value",
-                Int32.bitcountNonZero(maximumInt32),
+                Int32.bitcountNonZero(Int32.maximumValue),
                 M.equals(Int32Testable(31))
             ),
             test(
@@ -1949,12 +1965,12 @@ run(
             ),
             test(
                 "minimum value",
-                Int32.bitcountLeadingZero(minimumInt32),
+                Int32.bitcountLeadingZero(Int32.minimumValue),
                 M.equals(Int32Testable(0))
             ),
             test(
                 "maximum value",
-                Int32.bitcountLeadingZero(maximumInt32),
+                Int32.bitcountLeadingZero(Int32.maximumValue),
                 M.equals(Int32Testable(1))
             ),
             test(
@@ -2009,12 +2025,12 @@ run(
             ),
             test(
                 "minimum value",
-                Int32.bitcountTrailingZero(minimumInt32),
+                Int32.bitcountTrailingZero(Int32.minimumValue),
                 M.equals(Int32Testable(31))
             ),
             test(
                 "maximum value",
-                Int32.bitcountTrailingZero(maximumInt32),
+                Int32.bitcountTrailingZero(Int32.maximumValue),
                 M.equals(Int32Testable(0))
             ),
             test(
@@ -2059,27 +2075,27 @@ run(
             ),
             test(
                 "minimum and maximum",
-                Int32.addWrap(minimumInt32, maximumInt32),
+                Int32.addWrap(Int32.minimumValue, Int32.maximumValue),
                 M.equals(Int32Testable(-1))
             ),
             test(
                 "small overflow",
-                Int32.addWrap(maximumInt32, 1),
-                M.equals(Int32Testable(minimumInt32))
+                Int32.addWrap(Int32.maximumValue, 1),
+                M.equals(Int32Testable(Int32.minimumValue))
             ),
             test(
                 "large overflow",
-                Int32.addWrap(maximumInt32, maximumInt32),
+                Int32.addWrap(Int32.maximumValue, Int32.maximumValue),
                 M.equals(Int32Testable(-2))
             ),
             test(
                 "small underflow",
-                Int32.addWrap(minimumInt32, -1),
-                M.equals(Int32Testable(maximumInt32))
+                Int32.addWrap(Int32.minimumValue, -1),
+                M.equals(Int32Testable(Int32.maximumValue))
             ),
             test(
                 "large underflow",
-                Int32.addWrap(minimumInt32, minimumInt32),
+                Int32.addWrap(Int32.minimumValue, Int32.minimumValue),
                 M.equals(Int32Testable(0))
             ),
         ]
@@ -2114,27 +2130,27 @@ run(
             ),
             test(
                 "maximum and maximum",
-                Int32.subWrap(maximumInt32, maximumInt32),
+                Int32.subWrap(Int32.maximumValue, Int32.maximumValue),
                 M.equals(Int32Testable(0))
             ),
             test(
                 "small overflow",
-                Int32.subWrap(maximumInt32, -1),
-                M.equals(Int32Testable(minimumInt32))
+                Int32.subWrap(Int32.maximumValue, -1),
+                M.equals(Int32Testable(Int32.minimumValue))
             ),
             test(
                 "large overflow",
-                Int32.subWrap(maximumInt32, minimumInt32),
+                Int32.subWrap(Int32.maximumValue, Int32.minimumValue),
                 M.equals(Int32Testable(-1))
             ),
             test(
                 "small underflow",
-                Int32.subWrap(minimumInt32, 1),
-                M.equals(Int32Testable(maximumInt32))
+                Int32.subWrap(Int32.minimumValue, 1),
+                M.equals(Int32Testable(Int32.maximumValue))
             ),
             test(
                 "large underflow",
-                Int32.subWrap(minimumInt32, maximumInt32),
+                Int32.subWrap(Int32.minimumValue, Int32.maximumValue),
                 M.equals(Int32Testable(1))
             ),
         ]
@@ -2169,42 +2185,42 @@ run(
             ),
             test(
                 "zero and maximum",
-                Int32.mulWrap(0, maximumInt32),
+                Int32.mulWrap(0, Int32.maximumValue),
                 M.equals(Int32Testable(0))
             ),
             test(
                 "minimum and zero",
-                Int32.mulWrap(minimumInt32, 0),
+                Int32.mulWrap(Int32.minimumValue, 0),
                 M.equals(Int32Testable(0))
             ),
             test(
                 "one and maximum",
-                Int32.mulWrap(1, maximumInt32),
-                M.equals(Int32Testable(maximumInt32))
+                Int32.mulWrap(1, Int32.maximumValue),
+                M.equals(Int32Testable(Int32.maximumValue))
             ),
             test(
                 "minimum and one",
-                Int32.mulWrap(minimumInt32, 1),
-                M.equals(Int32Testable(minimumInt32))
+                Int32.mulWrap(Int32.minimumValue, 1),
+                M.equals(Int32Testable(Int32.minimumValue))
             ),
             test(
                 "small overflow",
-                Int32.mulWrap(2, maximumInt32),
+                Int32.mulWrap(2, Int32.maximumValue),
                 M.equals(Int32Testable(-2))
             ),
             test(
                 "large overflow",
-                Int32.mulWrap(maximumInt32, maximumInt32),
+                Int32.mulWrap(Int32.maximumValue, Int32.maximumValue),
                 M.equals(Int32Testable(1))
             ),
             test(
                 "small underflow",
-                Int32.mulWrap(minimumInt32, 2),
+                Int32.mulWrap(Int32.minimumValue, 2),
                 M.equals(Int32Testable(0))
             ),
             test(
                 "large underflow",
-                Int32.mulWrap(minimumInt32, minimumInt32),
+                Int32.mulWrap(Int32.minimumValue, Int32.minimumValue),
                 M.equals(Int32Testable(0))
             ),
         ]
@@ -2239,37 +2255,37 @@ run(
             ),
             test(
                 "maximum and zero",
-                Int32.powWrap(maximumInt32, 0),
+                Int32.powWrap(Int32.maximumValue, 0),
                 M.equals(Int32Testable(1))
             ),
             test(
                 "minimum and zero",
-                Int32.powWrap(minimumInt32, 0),
+                Int32.powWrap(Int32.minimumValue, 0),
                 M.equals(Int32Testable(1))
             ),
             test(
                 "plus one and maximum",
-                Int32.powWrap(1, maximumInt32),
+                Int32.powWrap(1, Int32.maximumValue),
                 M.equals(Int32Testable(1))
             ),
             test(
                 "minus one and maximum",
-                Int32.powWrap(-1, maximumInt32),
+                Int32.powWrap(-1, Int32.maximumValue),
                 M.equals(Int32Testable(-1))
             ),
             test(
                 "minimum value",
                 Int32.powWrap(-2, 31),
-                M.equals(Int32Testable(minimumInt32))
+                M.equals(Int32Testable(Int32.minimumValue))
             ),
             test(
                 "small overflow",
                 Int32.powWrap(2, 31),
-                M.equals(Int32Testable(minimumInt32))
+                M.equals(Int32Testable(Int32.minimumValue))
             ),
             test(
                 "large overflow",
-                Int32.powWrap(maximumInt32, 10),
+                Int32.powWrap(Int32.maximumValue, 10),
                 M.equals(Int32Testable(1))
             ),
             test(
@@ -2279,7 +2295,7 @@ run(
             ),
             test(
                 "large underflow",
-                Int32.powWrap(minimumInt32, 10),
+                Int32.powWrap(Int32.minimumValue, 10),
                 M.equals(Int32Testable(0))
             ),
         ]

--- a/test/int64Test.mo
+++ b/test/int64Test.mo
@@ -8,12 +8,10 @@ import M "mo:matchers/Matchers";
 
 let { run; test; suite } = Suite;
 
-let maximumInt64 = 9_223_372_036_854_775_807 : Int64;
-let maximumInt64asInt = 9_223_372_036_854_775_807 : Int;
-let maximumInt64asNat64 = 9_223_372_036_854_775_807 : Nat64;
+let maximumInt64asInt = +2 ** 63 - 1 : Int;
+let maximumInt64asNat64 = 2 ** 63 - 1 : Nat64;
 
-let minimumInt64 = -9_223_372_036_854_775_808 : Int64;
-let minimumInt64asInt = -9_223_372_036_854_775_808 : Int;
+let minimumInt64asInt = -2 ** 63 : Int;
 
 let maximumNat64 = 18_446_744_073_709_551_615 : Nat64;
 
@@ -53,16 +51,36 @@ class OrderTestable(value : Order) : T.TestableItem<Order> {
 
 run(
     suite(
+        "constants",
+        [
+            test(
+                "minimum value",
+                Int64.minimumValue,
+                M.equals(Int64Testable(Int64.fromInt(-2 ** 63)))
+            ),
+            test(
+                "maximum value",
+                Int64.maximumValue,
+                M.equals(Int64Testable(Int64.fromInt(+2 ** 63 - 1)))
+            ),
+        ]
+    )
+);
+
+/* --------------------------------------- */
+
+run(
+    suite(
         "toInt",
         [
             test(
                 "maximum number",
-                Int64.toInt(maximumInt64),
+                Int64.toInt(Int64.maximumValue),
                 M.equals(T.int(maximumInt64asInt))
             ),
             test(
                 "minimum number",
-                Int64.toInt(minimumInt64),
+                Int64.toInt(Int64.minimumValue),
                 M.equals(T.int(minimumInt64asInt))
             ),
             test(
@@ -93,12 +111,12 @@ run(
             test(
                 "maximum number",
                 Int64.fromInt(maximumInt64asInt),
-                M.equals(Int64Testable(maximumInt64))
+                M.equals(Int64Testable(Int64.maximumValue))
             ),
             test(
                 "minimum number",
                 Int64.fromInt(minimumInt64asInt),
-                M.equals(Int64Testable(minimumInt64))
+                M.equals(Int64Testable(Int64.minimumValue))
             ),
             test(
                 "one",
@@ -128,12 +146,12 @@ run(
             test(
                 "maximum number",
                 Int64.fromIntWrap(maximumInt64asInt),
-                M.equals(Int64Testable(maximumInt64))
+                M.equals(Int64Testable(Int64.maximumValue))
             ),
             test(
                 "minimum number",
                 Int64.fromIntWrap(minimumInt64asInt),
-                M.equals(Int64Testable(minimumInt64))
+                M.equals(Int64Testable(Int64.minimumValue))
             ),
             test(
                 "one",
@@ -153,12 +171,12 @@ run(
             test(
                 "overflow",
                 Int64.fromIntWrap(maximumInt64asInt + 1),
-                M.equals(Int64Testable(minimumInt64))
+                M.equals(Int64Testable(Int64.minimumValue))
             ),
             test(
                 "underflow",
                 Int64.fromIntWrap(minimumInt64asInt - 1),
-                M.equals(Int64Testable(maximumInt64))
+                M.equals(Int64Testable(Int64.maximumValue))
             )
         ]
     )
@@ -173,7 +191,7 @@ run(
             test(
                 "maximum number",
                 Int64.fromNat64(maximumInt64asNat64),
-                M.equals(Int64Testable(maximumInt64))
+                M.equals(Int64Testable(Int64.maximumValue))
             ),
             test(
                 "one",
@@ -188,7 +206,7 @@ run(
             test(
                 "overflow",
                 Int64.fromNat64(maximumInt64asNat64 + 1),
-                M.equals(Int64Testable(minimumInt64))
+                M.equals(Int64Testable(Int64.minimumValue))
             )
         ]
     )
@@ -202,7 +220,7 @@ run(
         [
             test(
                 "maximum number",
-                Int64.toNat64(maximumInt64),
+                Int64.toNat64(Int64.maximumValue),
                 M.equals(Nat64Testable(maximumInt64asNat64))
             ),
             test(
@@ -247,12 +265,12 @@ run(
             ),
             test(
                 "maximum number",
-                Int64.toText(maximumInt64),
+                Int64.toText(Int64.maximumValue),
                 M.equals(T.text("9223372036854775807"))
             ),
             test(
                 "minimum number",
-                Int64.toText(minimumInt64),
+                Int64.toText(Int64.minimumValue),
                 M.equals(T.text("-9223372036854775808"))
             )
         ]
@@ -282,13 +300,13 @@ run(
             ),
             test(
                 "maximum number",
-                Int64.abs(maximumInt64),
-                M.equals(Int64Testable(maximumInt64))
+                Int64.abs(Int64.maximumValue),
+                M.equals(Int64Testable(Int64.maximumValue))
             ),
             test(
                 "smallest possible",
-                Int64.abs(-maximumInt64),
-                M.equals(Int64Testable(maximumInt64))
+                Int64.abs(-Int64.maximumValue),
+                M.equals(Int64Testable(Int64.maximumValue))
             )
         ]
     )
@@ -327,8 +345,8 @@ run(
             ),
             test(
                 "maximum and minimum number",
-                Int64.min(maximumInt64, minimumInt64),
-                M.equals(Int64Testable(minimumInt64))
+                Int64.min(Int64.maximumValue, Int64.minimumValue),
+                M.equals(Int64Testable(Int64.minimumValue))
             )
         ]
     )
@@ -367,8 +385,8 @@ run(
             ),
             test(
                 "maximum and minimum number",
-                Int64.max(maximumInt64, minimumInt64),
-                M.equals(Int64Testable(maximumInt64))
+                Int64.max(Int64.maximumValue, Int64.minimumValue),
+                M.equals(Int64Testable(Int64.maximumValue))
             )
         ]
     )
@@ -412,17 +430,17 @@ run(
             ),
             test(
                 "maxmimum equal",
-                Int64.equal(maximumInt64, maximumInt64),
+                Int64.equal(Int64.maximumValue, Int64.maximumValue),
                 M.equals(T.bool(true))
             ),
             test(
                 "minimum equal",
-                Int64.equal(minimumInt64, minimumInt64),
+                Int64.equal(Int64.minimumValue, Int64.minimumValue),
                 M.equals(T.bool(true))
             ),
             test(
                 "minimum and maximum",
-                Int64.equal(minimumInt64, maximumInt64),
+                Int64.equal(Int64.minimumValue, Int64.maximumValue),
                 M.equals(T.bool(false))
             )
         ]
@@ -467,17 +485,17 @@ run(
             ),
             test(
                 "maxmimum equal",
-                Int64.notEqual(maximumInt64, maximumInt64),
+                Int64.notEqual(Int64.maximumValue, Int64.maximumValue),
                 M.equals(T.bool(false))
             ),
             test(
                 "minimum equal",
-                Int64.notEqual(minimumInt64, minimumInt64),
+                Int64.notEqual(Int64.minimumValue, Int64.minimumValue),
                 M.equals(T.bool(false))
             ),
             test(
                 "minimum and maximum",
-                Int64.notEqual(minimumInt64, maximumInt64),
+                Int64.notEqual(Int64.minimumValue, Int64.maximumValue),
                 M.equals(T.bool(true))
             )
         ]
@@ -537,22 +555,22 @@ run(
             ),
             test(
                 "minimum and maximum",
-                Int64.less(minimumInt64, maximumInt64),
+                Int64.less(Int64.minimumValue, Int64.maximumValue),
                 M.equals(T.bool(true))
             ),
             test(
                 "maximum and minimum",
-                Int64.less(maximumInt64, minimumInt64),
+                Int64.less(Int64.maximumValue, Int64.minimumValue),
                 M.equals(T.bool(false))
             ),
             test(
                 "maximum and maximum",
-                Int64.less(maximumInt64, maximumInt64),
+                Int64.less(Int64.maximumValue, Int64.maximumValue),
                 M.equals(T.bool(false))
             ),
             test(
                 "minimum and minimum",
-                Int64.less(minimumInt64, minimumInt64),
+                Int64.less(Int64.minimumValue, Int64.minimumValue),
                 M.equals(T.bool(false))
             )
         ]
@@ -612,22 +630,22 @@ run(
             ),
             test(
                 "minimum and maximum",
-                Int64.lessOrEqual(minimumInt64, maximumInt64),
+                Int64.lessOrEqual(Int64.minimumValue, Int64.maximumValue),
                 M.equals(T.bool(true))
             ),
             test(
                 "maximum and minimum",
-                Int64.lessOrEqual(maximumInt64, minimumInt64),
+                Int64.lessOrEqual(Int64.maximumValue, Int64.minimumValue),
                 M.equals(T.bool(false))
             ),
             test(
                 "maximum and maximum",
-                Int64.lessOrEqual(maximumInt64, maximumInt64),
+                Int64.lessOrEqual(Int64.maximumValue, Int64.maximumValue),
                 M.equals(T.bool(true))
             ),
             test(
                 "minimum and minimum",
-                Int64.lessOrEqual(minimumInt64, minimumInt64),
+                Int64.lessOrEqual(Int64.minimumValue, Int64.minimumValue),
                 M.equals(T.bool(true))
             )
         ]
@@ -687,22 +705,22 @@ run(
             ),
             test(
                 "minimum and maximum",
-                Int64.greater(minimumInt64, maximumInt64),
+                Int64.greater(Int64.minimumValue, Int64.maximumValue),
                 M.equals(T.bool(false))
             ),
             test(
                 "maximum and minimum",
-                Int64.greater(maximumInt64, minimumInt64),
+                Int64.greater(Int64.maximumValue, Int64.minimumValue),
                 M.equals(T.bool(true))
             ),
             test(
                 "maximum and maximum",
-                Int64.greater(maximumInt64, maximumInt64),
+                Int64.greater(Int64.maximumValue, Int64.maximumValue),
                 M.equals(T.bool(false))
             ),
             test(
                 "minimum and minimum",
-                Int64.greater(minimumInt64, minimumInt64),
+                Int64.greater(Int64.minimumValue, Int64.minimumValue),
                 M.equals(T.bool(false))
             )
         ]
@@ -762,22 +780,22 @@ run(
             ),
             test(
                 "minimum and maximum",
-                Int64.greaterOrEqual(minimumInt64, maximumInt64),
+                Int64.greaterOrEqual(Int64.minimumValue, Int64.maximumValue),
                 M.equals(T.bool(false))
             ),
             test(
                 "maximum and minimum",
-                Int64.greaterOrEqual(maximumInt64, minimumInt64),
+                Int64.greaterOrEqual(Int64.maximumValue, Int64.minimumValue),
                 M.equals(T.bool(true))
             ),
             test(
                 "maximum and maximum",
-                Int64.greaterOrEqual(maximumInt64, maximumInt64),
+                Int64.greaterOrEqual(Int64.maximumValue, Int64.maximumValue),
                 M.equals(T.bool(true))
             ),
             test(
                 "minimum and minimum",
-                Int64.greaterOrEqual(minimumInt64, minimumInt64),
+                Int64.greaterOrEqual(Int64.minimumValue, Int64.minimumValue),
                 M.equals(T.bool(true))
             )
         ]
@@ -837,22 +855,22 @@ run(
             ),
             test(
                 "minimum and maximum",
-                Int64.compare(minimumInt64, maximumInt64),
+                Int64.compare(Int64.minimumValue, Int64.maximumValue),
                 M.equals(OrderTestable(#less))
             ),
             test(
                 "maximum and minimum",
-                Int64.compare(maximumInt64, minimumInt64),
+                Int64.compare(Int64.maximumValue, Int64.minimumValue),
                 M.equals(OrderTestable(#greater))
             ),
             test(
                 "maximum and maximum",
-                Int64.compare(maximumInt64, maximumInt64),
+                Int64.compare(Int64.maximumValue, Int64.maximumValue),
                 M.equals(OrderTestable(#equal))
             ),
             test(
                 "minimum and minimum",
-                Int64.compare(minimumInt64, minimumInt64),
+                Int64.compare(Int64.minimumValue, Int64.minimumValue),
                 M.equals(OrderTestable(#equal))
             )
         ]
@@ -882,13 +900,13 @@ run(
             ),
             test(
                 "maximum number",
-                Int64.neg(maximumInt64),
-                M.equals(Int64Testable(-maximumInt64))
+                Int64.neg(Int64.maximumValue),
+                M.equals(Int64Testable(-Int64.maximumValue))
             ),
             test(
                 "smallest possible",
-                Int64.neg(-maximumInt64),
-                M.equals(Int64Testable(maximumInt64))
+                Int64.neg(-Int64.maximumValue),
+                M.equals(Int64Testable(Int64.maximumValue))
             )
         ]
     )
@@ -922,7 +940,7 @@ run(
             ),
             test(
                 "minimum and maximum",
-                Int64.add(minimumInt64, maximumInt64),
+                Int64.add(Int64.minimumValue, Int64.maximumValue),
                 M.equals(Int64Testable(-1))
             )
         ]
@@ -957,7 +975,7 @@ run(
             ),
             test(
                 "maximum and maximum",
-                Int64.sub(maximumInt64, maximumInt64),
+                Int64.sub(Int64.maximumValue, Int64.maximumValue),
                 M.equals(Int64Testable(0))
             )
         ]
@@ -992,23 +1010,23 @@ run(
             ),
             test(
                 "zero and maximum",
-                Int64.mul(0, maximumInt64),
+                Int64.mul(0, Int64.maximumValue),
                 M.equals(Int64Testable(0))
             ),
             test(
                 "minimum and zero",
-                Int64.mul(minimumInt64, 0),
+                Int64.mul(Int64.minimumValue, 0),
                 M.equals(Int64Testable(0))
             ),
             test(
                 "one and maximum",
-                Int64.mul(1, maximumInt64),
-                M.equals(Int64Testable(maximumInt64))
+                Int64.mul(1, Int64.maximumValue),
+                M.equals(Int64Testable(Int64.maximumValue))
             ),
             test(
                 "minimum and one",
-                Int64.mul(minimumInt64, 1),
-                M.equals(Int64Testable(minimumInt64))
+                Int64.mul(Int64.minimumValue, 1),
+                M.equals(Int64Testable(Int64.minimumValue))
             )
         ]
     )
@@ -1052,22 +1070,22 @@ run(
             ),
             test(
                 "zero and maximum",
-                Int64.div(0, maximumInt64),
+                Int64.div(0, Int64.maximumValue),
                 M.equals(Int64Testable(0))
             ),
             test(
                 "zero and minimum",
-                Int64.div(0, minimumInt64),
+                Int64.div(0, Int64.minimumValue),
                 M.equals(Int64Testable(0))
             ),
             test(
                 "maximum and maximum",
-                Int64.div(maximumInt64, maximumInt64),
+                Int64.div(Int64.maximumValue, Int64.maximumValue),
                 M.equals(Int64Testable(1))
             ),
             test(
                 "minimum and minimum",
-                Int64.div(minimumInt64, minimumInt64),
+                Int64.div(Int64.minimumValue, Int64.minimumValue),
                 M.equals(Int64Testable(1))
             )
         ]
@@ -1112,22 +1130,22 @@ run(
             ),
             test(
                 "zero and maximum",
-                Int64.rem(0, maximumInt64),
+                Int64.rem(0, Int64.maximumValue),
                 M.equals(Int64Testable(0))
             ),
             test(
                 "zero and minimum",
-                Int64.rem(0, minimumInt64),
+                Int64.rem(0, Int64.minimumValue),
                 M.equals(Int64Testable(0))
             ),
             test(
                 "maximum and maximum",
-                Int64.rem(maximumInt64, maximumInt64),
+                Int64.rem(Int64.maximumValue, Int64.maximumValue),
                 M.equals(Int64Testable(0))
             ),
             test(
                 "minimum and minimum",
-                Int64.rem(minimumInt64, minimumInt64),
+                Int64.rem(Int64.minimumValue, Int64.minimumValue),
                 M.equals(Int64Testable(0))
             )
         ]
@@ -1167,22 +1185,22 @@ run(
             ),
             test(
                 "maximum and zero",
-                Int64.pow(maximumInt64, 0),
+                Int64.pow(Int64.maximumValue, 0),
                 M.equals(Int64Testable(1))
             ),
             test(
                 "minimum and zero",
-                Int64.pow(minimumInt64, 0),
+                Int64.pow(Int64.minimumValue, 0),
                 M.equals(Int64Testable(1))
             ),
             test(
                 "plus one and maximum",
-                Int64.pow(1, maximumInt64),
+                Int64.pow(1, Int64.maximumValue),
                 M.equals(Int64Testable(1))
             ),
             test(
                 "minus one and maximum",
-                Int64.pow(-1, maximumInt64),
+                Int64.pow(-1, Int64.maximumValue),
                 M.equals(Int64Testable(-1))
             )
         ]
@@ -1191,35 +1209,33 @@ run(
 
 /* --------------------------------------- */
 
-let unused = 0 : Int64; // Issue: bitnot has superfluous second argument.
-
 run(
     suite(
         "bitnot",
         [
             test(
                 "zero",
-                Int64.bitnot(0, unused),
+                Int64.bitnot(0),
                 M.equals(Int64Testable(-1))
             ),
             test(
                 "minus 1",
-                Int64.bitnot(-1, unused),
+                Int64.bitnot(-1),
                 M.equals(Int64Testable(0))
             ),
             test(
                 "maximum",
-                Int64.bitnot(maximumInt64, unused),
-                M.equals(Int64Testable(minimumInt64))
+                Int64.bitnot(Int64.maximumValue),
+                M.equals(Int64Testable(Int64.minimumValue))
             ),
             test(
                 "minimum",
-                Int64.bitnot(minimumInt64, unused),
-                M.equals(Int64Testable(maximumInt64))
+                Int64.bitnot(Int64.minimumValue),
+                M.equals(Int64Testable(Int64.maximumValue))
             ),
             test(
                 "arbitrary",
-                Int64.bitnot(1234, 0),
+                Int64.bitnot(1234),
                 M.equals(Int64Testable(-1235))
             )
         ]
@@ -1264,17 +1280,17 @@ run(
             ),
             test(
                 "zero and maximum",
-                Int64.bitand(0, maximumInt64),
+                Int64.bitand(0, Int64.maximumValue),
                 M.equals(Int64Testable(0))
             ),
             test(
                 "minimum and zero",
-                Int64.bitand(minimumInt64, 0),
+                Int64.bitand(Int64.minimumValue, 0),
                 M.equals(Int64Testable(0))
             ),
             test(
                 "minimum and maximum",
-                Int64.bitand(minimumInt64, maximumInt64),
+                Int64.bitand(Int64.minimumValue, Int64.maximumValue),
                 M.equals(Int64Testable(0))
             )
         ]
@@ -1319,17 +1335,17 @@ run(
             ),
             test(
                 "zero and maximum",
-                Int64.bitor(0, maximumInt64),
-                M.equals(Int64Testable(maximumInt64))
+                Int64.bitor(0, Int64.maximumValue),
+                M.equals(Int64Testable(Int64.maximumValue))
             ),
             test(
                 "minimum and zero",
-                Int64.bitor(minimumInt64, 0),
-                M.equals(Int64Testable(minimumInt64))
+                Int64.bitor(Int64.minimumValue, 0),
+                M.equals(Int64Testable(Int64.minimumValue))
             ),
             test(
                 "minimum and maximum",
-                Int64.bitor(minimumInt64, maximumInt64),
+                Int64.bitor(Int64.minimumValue, Int64.maximumValue),
                 M.equals(Int64Testable(-1))
             )
         ]
@@ -1374,17 +1390,17 @@ run(
             ),
             test(
                 "zero and maximum",
-                Int64.bitxor(0, maximumInt64),
-                M.equals(Int64Testable(maximumInt64))
+                Int64.bitxor(0, Int64.maximumValue),
+                M.equals(Int64Testable(Int64.maximumValue))
             ),
             test(
                 "minimum and zero",
-                Int64.bitxor(minimumInt64, 0),
-                M.equals(Int64Testable(minimumInt64))
+                Int64.bitxor(Int64.minimumValue, 0),
+                M.equals(Int64Testable(Int64.minimumValue))
             ),
             test(
                 "minimum and maximum",
-                Int64.bitxor(minimumInt64, maximumInt64),
+                Int64.bitxor(Int64.minimumValue, Int64.maximumValue),
                 M.equals(Int64Testable(-1))
             )
         ]
@@ -1420,12 +1436,12 @@ run(
             test(
                 "one maximum shift",
                 Int64.bitshiftLeft(1, 63),
-                M.equals(Int64Testable(minimumInt64))
+                M.equals(Int64Testable(Int64.minimumValue))
             ),
             test(
                 "minimum number",
                 Int64.bitshiftLeft(-1, 63),
-                M.equals(Int64Testable(minimumInt64))
+                M.equals(Int64Testable(Int64.minimumValue))
             ),
             test(
                 "discard overflow",
@@ -1484,7 +1500,7 @@ run(
             ),
             test(
                 "minimum number",
-                Int64.bitshiftRight(minimumInt64, 63),
+                Int64.bitshiftRight(Int64.minimumValue, 63),
                 M.equals(Int64Testable(-1))
             ),
             test(
@@ -1549,13 +1565,13 @@ run(
             ),
             test(
                 "maximum number",
-                Int64.bitrotLeft(maximumInt64, 1),
+                Int64.bitrotLeft(Int64.maximumValue, 1),
                 M.equals(Int64Testable(-2))
             ),
             test(
                 "minimum number",
                 Int64.bitrotLeft(1, 63),
-                M.equals(Int64Testable(minimumInt64))
+                M.equals(Int64Testable(Int64.minimumValue))
             ),
             test(
                 "opposite rotation",
@@ -1610,11 +1626,11 @@ run(
             test(
                 "maximum number",
                 Int64.bitrotRight(-2, 1),
-                M.equals(Int64Testable(maximumInt64))
+                M.equals(Int64Testable(Int64.maximumValue))
             ),
             test(
                 "minimum number",
-                Int64.bitrotRight(minimumInt64, 63),
+                Int64.bitrotRight(Int64.minimumValue, 63),
                 M.equals(Int64Testable(1))
             ),
             test(
@@ -1888,12 +1904,12 @@ run(
             ),
             test(
                 "minimum value",
-                Int64.bitcountNonZero(minimumInt64),
+                Int64.bitcountNonZero(Int64.minimumValue),
                 M.equals(Int64Testable(1))
             ),
             test(
                 "maximum value",
-                Int64.bitcountNonZero(maximumInt64),
+                Int64.bitcountNonZero(Int64.maximumValue),
                 M.equals(Int64Testable(63))
             ),
             test(
@@ -1948,12 +1964,12 @@ run(
             ),
             test(
                 "minimum value",
-                Int64.bitcountLeadingZero(minimumInt64),
+                Int64.bitcountLeadingZero(Int64.minimumValue),
                 M.equals(Int64Testable(0))
             ),
             test(
                 "maximum value",
-                Int64.bitcountLeadingZero(maximumInt64),
+                Int64.bitcountLeadingZero(Int64.maximumValue),
                 M.equals(Int64Testable(1))
             ),
             test(
@@ -2008,12 +2024,12 @@ run(
             ),
             test(
                 "minimum value",
-                Int64.bitcountTrailingZero(minimumInt64),
+                Int64.bitcountTrailingZero(Int64.minimumValue),
                 M.equals(Int64Testable(63))
             ),
             test(
                 "maximum value",
-                Int64.bitcountTrailingZero(maximumInt64),
+                Int64.bitcountTrailingZero(Int64.maximumValue),
                 M.equals(Int64Testable(0))
             ),
             test(
@@ -2058,27 +2074,27 @@ run(
             ),
             test(
                 "minimum and maximum",
-                Int64.addWrap(minimumInt64, maximumInt64),
+                Int64.addWrap(Int64.minimumValue, Int64.maximumValue),
                 M.equals(Int64Testable(-1))
             ),
             test(
                 "small overflow",
-                Int64.addWrap(maximumInt64, 1),
-                M.equals(Int64Testable(minimumInt64))
+                Int64.addWrap(Int64.maximumValue, 1),
+                M.equals(Int64Testable(Int64.minimumValue))
             ),
             test(
                 "large overflow",
-                Int64.addWrap(maximumInt64, maximumInt64),
+                Int64.addWrap(Int64.maximumValue, Int64.maximumValue),
                 M.equals(Int64Testable(-2))
             ),
             test(
                 "small underflow",
-                Int64.addWrap(minimumInt64, -1),
-                M.equals(Int64Testable(maximumInt64))
+                Int64.addWrap(Int64.minimumValue, -1),
+                M.equals(Int64Testable(Int64.maximumValue))
             ),
             test(
                 "large underflow",
-                Int64.addWrap(minimumInt64, minimumInt64),
+                Int64.addWrap(Int64.minimumValue, Int64.minimumValue),
                 M.equals(Int64Testable(0))
             ),
         ]
@@ -2113,27 +2129,27 @@ run(
             ),
             test(
                 "maximum and maximum",
-                Int64.subWrap(maximumInt64, maximumInt64),
+                Int64.subWrap(Int64.maximumValue, Int64.maximumValue),
                 M.equals(Int64Testable(0))
             ),
             test(
                 "small overflow",
-                Int64.subWrap(maximumInt64, -1),
-                M.equals(Int64Testable(minimumInt64))
+                Int64.subWrap(Int64.maximumValue, -1),
+                M.equals(Int64Testable(Int64.minimumValue))
             ),
             test(
                 "large overflow",
-                Int64.subWrap(maximumInt64, minimumInt64),
+                Int64.subWrap(Int64.maximumValue, Int64.minimumValue),
                 M.equals(Int64Testable(-1))
             ),
             test(
                 "small underflow",
-                Int64.subWrap(minimumInt64, 1),
-                M.equals(Int64Testable(maximumInt64))
+                Int64.subWrap(Int64.minimumValue, 1),
+                M.equals(Int64Testable(Int64.maximumValue))
             ),
             test(
                 "large underflow",
-                Int64.subWrap(minimumInt64, maximumInt64),
+                Int64.subWrap(Int64.minimumValue, Int64.maximumValue),
                 M.equals(Int64Testable(1))
             ),
         ]
@@ -2168,42 +2184,42 @@ run(
             ),
             test(
                 "zero and maximum",
-                Int64.mulWrap(0, maximumInt64),
+                Int64.mulWrap(0, Int64.maximumValue),
                 M.equals(Int64Testable(0))
             ),
             test(
                 "minimum and zero",
-                Int64.mulWrap(minimumInt64, 0),
+                Int64.mulWrap(Int64.minimumValue, 0),
                 M.equals(Int64Testable(0))
             ),
             test(
                 "one and maximum",
-                Int64.mulWrap(1, maximumInt64),
-                M.equals(Int64Testable(maximumInt64))
+                Int64.mulWrap(1, Int64.maximumValue),
+                M.equals(Int64Testable(Int64.maximumValue))
             ),
             test(
                 "minimum and one",
-                Int64.mulWrap(minimumInt64, 1),
-                M.equals(Int64Testable(minimumInt64))
+                Int64.mulWrap(Int64.minimumValue, 1),
+                M.equals(Int64Testable(Int64.minimumValue))
             ),
             test(
                 "small overflow",
-                Int64.mulWrap(2, maximumInt64),
+                Int64.mulWrap(2, Int64.maximumValue),
                 M.equals(Int64Testable(-2))
             ),
             test(
                 "large overflow",
-                Int64.mulWrap(maximumInt64, maximumInt64),
+                Int64.mulWrap(Int64.maximumValue, Int64.maximumValue),
                 M.equals(Int64Testable(1))
             ),
             test(
                 "small underflow",
-                Int64.mulWrap(minimumInt64, 2),
+                Int64.mulWrap(Int64.minimumValue, 2),
                 M.equals(Int64Testable(0))
             ),
             test(
                 "large underflow",
-                Int64.mulWrap(minimumInt64, minimumInt64),
+                Int64.mulWrap(Int64.minimumValue, Int64.minimumValue),
                 M.equals(Int64Testable(0))
             ),
         ]
@@ -2238,37 +2254,37 @@ run(
             ),
             test(
                 "maximum and zero",
-                Int64.powWrap(maximumInt64, 0),
+                Int64.powWrap(Int64.maximumValue, 0),
                 M.equals(Int64Testable(1))
             ),
             test(
                 "minimum and zero",
-                Int64.powWrap(minimumInt64, 0),
+                Int64.powWrap(Int64.minimumValue, 0),
                 M.equals(Int64Testable(1))
             ),
             test(
                 "plus one and maximum",
-                Int64.powWrap(1, maximumInt64),
+                Int64.powWrap(1, Int64.maximumValue),
                 M.equals(Int64Testable(1))
             ),
             test(
                 "minus one and maximum",
-                Int64.powWrap(-1, maximumInt64),
+                Int64.powWrap(-1, Int64.maximumValue),
                 M.equals(Int64Testable(-1))
             ),
             test(
                 "minimum value",
                 Int64.powWrap(-2, 63),
-                M.equals(Int64Testable(minimumInt64))
+                M.equals(Int64Testable(Int64.minimumValue))
             ),
             test(
                 "small overflow",
                 Int64.powWrap(2, 63),
-                M.equals(Int64Testable(minimumInt64))
+                M.equals(Int64Testable(Int64.minimumValue))
             ),
             test(
                 "large overflow",
-                Int64.powWrap(maximumInt64, 10),
+                Int64.powWrap(Int64.maximumValue, 10),
                 M.equals(Int64Testable(1))
             ),
             test(
@@ -2278,7 +2294,7 @@ run(
             ),
             test(
                 "large underflow",
-                Int64.powWrap(minimumInt64, 10),
+                Int64.powWrap(Int64.minimumValue, 10),
                 M.equals(Int64Testable(0))
             ),
         ]

--- a/test/int8Test.mo
+++ b/test/int8Test.mo
@@ -1211,35 +1211,33 @@ run(
 
 /* --------------------------------------- */
 
-let unused = 0 : Int8; // Issue: bitnot has superfluous second argument.
-
 run(
     suite(
         "bitnot",
         [
             test(
                 "zero",
-                Int8.bitnot(0, unused),
+                Int8.bitnot(0),
                 M.equals(Int8Testable(-1))
             ),
             test(
                 "minus 1",
-                Int8.bitnot(-1, unused),
+                Int8.bitnot(-1),
                 M.equals(Int8Testable(0))
             ),
             test(
                 "maximum",
-                Int8.bitnot(Int8.maximumValue, unused),
+                Int8.bitnot(Int8.maximumValue),
                 M.equals(Int8Testable(Int8.minimumValue))
             ),
             test(
                 "minimum",
-                Int8.bitnot(Int8.minimumValue, unused),
+                Int8.bitnot(Int8.minimumValue),
                 M.equals(Int8Testable(Int8.maximumValue))
             ),
             test(
                 "arbitrary",
-                Int8.bitnot(123, 0),
+                Int8.bitnot(123),
                 M.equals(Int8Testable(-124))
             )
         ]

--- a/test/int8Test.mo
+++ b/test/int8Test.mo
@@ -8,12 +8,10 @@ import M "mo:matchers/Matchers";
 
 let { run; test; suite } = Suite;
 
-let maximumInt8 = 127 : Int8;
-let maximumInt8asInt = 127 : Int;
-let maximumInt8asNat8 = 127 : Nat8;
+let maximumInt8asInt = +2 ** 7 - 1 : Int;
+let maximumInt8asNat8 = 2 ** 7 - 1 : Nat8;
 
-let minimumInt8 = -128 : Int8;
-let minimumInt8asInt = -128 : Int;
+let minimumInt8asInt = -2 ** 7 : Int;
 
 let maximumNat8 = 255 : Nat8;
 
@@ -53,16 +51,36 @@ class OrderTestable(value : Order) : T.TestableItem<Order> {
 
 run(
     suite(
+        "constants",
+        [
+            test(
+                "minimum value",
+                Int8.minimumValue,
+                M.equals(Int8Testable(Int8.fromInt(-2 ** 7)))
+            ),
+            test(
+                "maximum value",
+                Int8.maximumValue,
+                M.equals(Int8Testable(Int8.fromInt(+2 ** 7 - 1)))
+            ),
+        ]
+    )
+);
+
+/* --------------------------------------- */
+
+run(
+    suite(
         "toInt",
         [
             test(
                 "maximum number",
-                Int8.toInt(maximumInt8),
+                Int8.toInt(Int8.maximumValue),
                 M.equals(T.int(maximumInt8asInt))
             ),
             test(
                 "minimum number",
-                Int8.toInt(minimumInt8),
+                Int8.toInt(Int8.minimumValue),
                 M.equals(T.int(minimumInt8asInt))
             ),
             test(
@@ -93,12 +111,12 @@ run(
             test(
                 "maximum number",
                 Int8.fromInt(maximumInt8asInt),
-                M.equals(Int8Testable(maximumInt8))
+                M.equals(Int8Testable(Int8.maximumValue))
             ),
             test(
                 "minimum number",
                 Int8.fromInt(minimumInt8asInt),
-                M.equals(Int8Testable(minimumInt8))
+                M.equals(Int8Testable(Int8.minimumValue))
             ),
             test(
                 "one",
@@ -128,12 +146,12 @@ run(
             test(
                 "maximum number",
                 Int8.fromIntWrap(maximumInt8asInt),
-                M.equals(Int8Testable(maximumInt8))
+                M.equals(Int8Testable(Int8.maximumValue))
             ),
             test(
                 "minimum number",
                 Int8.fromIntWrap(minimumInt8asInt),
-                M.equals(Int8Testable(minimumInt8))
+                M.equals(Int8Testable(Int8.minimumValue))
             ),
             test(
                 "one",
@@ -153,12 +171,12 @@ run(
             test(
                 "overflow",
                 Int8.fromIntWrap(maximumInt8asInt + 1),
-                M.equals(Int8Testable(minimumInt8))
+                M.equals(Int8Testable(Int8.minimumValue))
             ),
             test(
                 "underflow",
                 Int8.fromIntWrap(minimumInt8asInt - 1),
-                M.equals(Int8Testable(maximumInt8))
+                M.equals(Int8Testable(Int8.maximumValue))
             )
         ]
     )
@@ -173,7 +191,7 @@ run(
             test(
                 "maximum number",
                 Int8.fromNat8(maximumInt8asNat8),
-                M.equals(Int8Testable(maximumInt8))
+                M.equals(Int8Testable(Int8.maximumValue))
             ),
             test(
                 "one",
@@ -188,7 +206,7 @@ run(
             test(
                 "overflow",
                 Int8.fromNat8(maximumInt8asNat8 + 1),
-                M.equals(Int8Testable(minimumInt8))
+                M.equals(Int8Testable(Int8.minimumValue))
             )
         ]
     )
@@ -202,7 +220,7 @@ run(
         [
             test(
                 "maximum number",
-                Int8.toNat8(maximumInt8),
+                Int8.toNat8(Int8.maximumValue),
                 M.equals(Nat8Testable(maximumInt8asNat8))
             ),
             test(
@@ -248,12 +266,12 @@ run(
             ),
             test(
                 "maximum number",
-                Int8.toText(maximumInt8),
+                Int8.toText(Int8.maximumValue),
                 M.equals(T.text("127"))
             ),
             test(
                 "minimum number",
-                Int8.toText(minimumInt8),
+                Int8.toText(Int8.minimumValue),
                 M.equals(T.text("-128"))
             )
         ]
@@ -284,13 +302,13 @@ run(
             ),
             test(
                 "maximum number",
-                Int8.abs(maximumInt8),
-                M.equals(Int8Testable(maximumInt8))
+                Int8.abs(Int8.maximumValue),
+                M.equals(Int8Testable(Int8.maximumValue))
             ),
             test(
                 "smallest possible",
-                Int8.abs(-maximumInt8),
-                M.equals(Int8Testable(maximumInt8))
+                Int8.abs(-Int8.maximumValue),
+                M.equals(Int8Testable(Int8.maximumValue))
             )
         ]
     )
@@ -329,8 +347,8 @@ run(
             ),
             test(
                 "maximum and minimum number",
-                Int8.min(maximumInt8, minimumInt8),
-                M.equals(Int8Testable(minimumInt8))
+                Int8.min(Int8.maximumValue, Int8.minimumValue),
+                M.equals(Int8Testable(Int8.minimumValue))
             )
         ]
     )
@@ -369,8 +387,8 @@ run(
             ),
             test(
                 "maximum and minimum number",
-                Int8.max(maximumInt8, minimumInt8),
-                M.equals(Int8Testable(maximumInt8))
+                Int8.max(Int8.maximumValue, Int8.minimumValue),
+                M.equals(Int8Testable(Int8.maximumValue))
             )
         ]
     )
@@ -414,17 +432,17 @@ run(
             ),
             test(
                 "maxmimum equal",
-                Int8.equal(maximumInt8, maximumInt8),
+                Int8.equal(Int8.maximumValue, Int8.maximumValue),
                 M.equals(T.bool(true))
             ),
             test(
                 "minimum equal",
-                Int8.equal(minimumInt8, minimumInt8),
+                Int8.equal(Int8.minimumValue, Int8.minimumValue),
                 M.equals(T.bool(true))
             ),
             test(
                 "minimum and maximum",
-                Int8.equal(minimumInt8, maximumInt8),
+                Int8.equal(Int8.minimumValue, Int8.maximumValue),
                 M.equals(T.bool(false))
             )
         ]
@@ -469,17 +487,17 @@ run(
             ),
             test(
                 "maxmimum equal",
-                Int8.notEqual(maximumInt8, maximumInt8),
+                Int8.notEqual(Int8.maximumValue, Int8.maximumValue),
                 M.equals(T.bool(false))
             ),
             test(
                 "minimum equal",
-                Int8.notEqual(minimumInt8, minimumInt8),
+                Int8.notEqual(Int8.minimumValue, Int8.minimumValue),
                 M.equals(T.bool(false))
             ),
             test(
                 "minimum and maximum",
-                Int8.notEqual(minimumInt8, maximumInt8),
+                Int8.notEqual(Int8.minimumValue, Int8.maximumValue),
                 M.equals(T.bool(true))
             )
         ]
@@ -539,22 +557,22 @@ run(
             ),
             test(
                 "minimum and maximum",
-                Int8.less(minimumInt8, maximumInt8),
+                Int8.less(Int8.minimumValue, Int8.maximumValue),
                 M.equals(T.bool(true))
             ),
             test(
                 "maximum and minimum",
-                Int8.less(maximumInt8, minimumInt8),
+                Int8.less(Int8.maximumValue, Int8.minimumValue),
                 M.equals(T.bool(false))
             ),
             test(
                 "maximum and maximum",
-                Int8.less(maximumInt8, maximumInt8),
+                Int8.less(Int8.maximumValue, Int8.maximumValue),
                 M.equals(T.bool(false))
             ),
             test(
                 "minimum and minimum",
-                Int8.less(minimumInt8, minimumInt8),
+                Int8.less(Int8.minimumValue, Int8.minimumValue),
                 M.equals(T.bool(false))
             )
         ]
@@ -614,22 +632,22 @@ run(
             ),
             test(
                 "minimum and maximum",
-                Int8.lessOrEqual(minimumInt8, maximumInt8),
+                Int8.lessOrEqual(Int8.minimumValue, Int8.maximumValue),
                 M.equals(T.bool(true))
             ),
             test(
                 "maximum and minimum",
-                Int8.lessOrEqual(maximumInt8, minimumInt8),
+                Int8.lessOrEqual(Int8.maximumValue, Int8.minimumValue),
                 M.equals(T.bool(false))
             ),
             test(
                 "maximum and maximum",
-                Int8.lessOrEqual(maximumInt8, maximumInt8),
+                Int8.lessOrEqual(Int8.maximumValue, Int8.maximumValue),
                 M.equals(T.bool(true))
             ),
             test(
                 "minimum and minimum",
-                Int8.lessOrEqual(minimumInt8, minimumInt8),
+                Int8.lessOrEqual(Int8.minimumValue, Int8.minimumValue),
                 M.equals(T.bool(true))
             )
         ]
@@ -689,22 +707,22 @@ run(
             ),
             test(
                 "minimum and maximum",
-                Int8.greater(minimumInt8, maximumInt8),
+                Int8.greater(Int8.minimumValue, Int8.maximumValue),
                 M.equals(T.bool(false))
             ),
             test(
                 "maximum and minimum",
-                Int8.greater(maximumInt8, minimumInt8),
+                Int8.greater(Int8.maximumValue, Int8.minimumValue),
                 M.equals(T.bool(true))
             ),
             test(
                 "maximum and maximum",
-                Int8.greater(maximumInt8, maximumInt8),
+                Int8.greater(Int8.maximumValue, Int8.maximumValue),
                 M.equals(T.bool(false))
             ),
             test(
                 "minimum and minimum",
-                Int8.greater(minimumInt8, minimumInt8),
+                Int8.greater(Int8.minimumValue, Int8.minimumValue),
                 M.equals(T.bool(false))
             )
         ]
@@ -764,22 +782,22 @@ run(
             ),
             test(
                 "minimum and maximum",
-                Int8.greaterOrEqual(minimumInt8, maximumInt8),
+                Int8.greaterOrEqual(Int8.minimumValue, Int8.maximumValue),
                 M.equals(T.bool(false))
             ),
             test(
                 "maximum and minimum",
-                Int8.greaterOrEqual(maximumInt8, minimumInt8),
+                Int8.greaterOrEqual(Int8.maximumValue, Int8.minimumValue),
                 M.equals(T.bool(true))
             ),
             test(
                 "maximum and maximum",
-                Int8.greaterOrEqual(maximumInt8, maximumInt8),
+                Int8.greaterOrEqual(Int8.maximumValue, Int8.maximumValue),
                 M.equals(T.bool(true))
             ),
             test(
                 "minimum and minimum",
-                Int8.greaterOrEqual(minimumInt8, minimumInt8),
+                Int8.greaterOrEqual(Int8.minimumValue, Int8.minimumValue),
                 M.equals(T.bool(true))
             )
         ]
@@ -839,22 +857,22 @@ run(
             ),
             test(
                 "minimum and maximum",
-                Int8.compare(minimumInt8, maximumInt8),
+                Int8.compare(Int8.minimumValue, Int8.maximumValue),
                 M.equals(OrderTestable(#less))
             ),
             test(
                 "maximum and minimum",
-                Int8.compare(maximumInt8, minimumInt8),
+                Int8.compare(Int8.maximumValue, Int8.minimumValue),
                 M.equals(OrderTestable(#greater))
             ),
             test(
                 "maximum and maximum",
-                Int8.compare(maximumInt8, maximumInt8),
+                Int8.compare(Int8.maximumValue, Int8.maximumValue),
                 M.equals(OrderTestable(#equal))
             ),
             test(
                 "minimum and minimum",
-                Int8.compare(minimumInt8, minimumInt8),
+                Int8.compare(Int8.minimumValue, Int8.minimumValue),
                 M.equals(OrderTestable(#equal))
             )
         ]
@@ -884,13 +902,13 @@ run(
             ),
             test(
                 "maximum number",
-                Int8.neg(maximumInt8),
-                M.equals(Int8Testable(-maximumInt8))
+                Int8.neg(Int8.maximumValue),
+                M.equals(Int8Testable(-Int8.maximumValue))
             ),
             test(
                 "smallest possible",
-                Int8.neg(-maximumInt8),
-                M.equals(Int8Testable(maximumInt8))
+                Int8.neg(-Int8.maximumValue),
+                M.equals(Int8Testable(Int8.maximumValue))
             )
         ]
     )
@@ -924,7 +942,7 @@ run(
             ),
             test(
                 "minimum and maximum",
-                Int8.add(minimumInt8, maximumInt8),
+                Int8.add(Int8.minimumValue, Int8.maximumValue),
                 M.equals(Int8Testable(-1))
             )
         ]
@@ -959,7 +977,7 @@ run(
             ),
             test(
                 "maximum and maximum",
-                Int8.sub(maximumInt8, maximumInt8),
+                Int8.sub(Int8.maximumValue, Int8.maximumValue),
                 M.equals(Int8Testable(0))
             )
         ]
@@ -994,23 +1012,23 @@ run(
             ),
             test(
                 "zero and maximum",
-                Int8.mul(0, maximumInt8),
+                Int8.mul(0, Int8.maximumValue),
                 M.equals(Int8Testable(0))
             ),
             test(
                 "minimum and zero",
-                Int8.mul(minimumInt8, 0),
+                Int8.mul(Int8.minimumValue, 0),
                 M.equals(Int8Testable(0))
             ),
             test(
                 "one and maximum",
-                Int8.mul(1, maximumInt8),
-                M.equals(Int8Testable(maximumInt8))
+                Int8.mul(1, Int8.maximumValue),
+                M.equals(Int8Testable(Int8.maximumValue))
             ),
             test(
                 "minimum and one",
-                Int8.mul(minimumInt8, 1),
-                M.equals(Int8Testable(minimumInt8))
+                Int8.mul(Int8.minimumValue, 1),
+                M.equals(Int8Testable(Int8.minimumValue))
             )
         ]
     )
@@ -1054,22 +1072,22 @@ run(
             ),
             test(
                 "zero and maximum",
-                Int8.div(0, maximumInt8),
+                Int8.div(0, Int8.maximumValue),
                 M.equals(Int8Testable(0))
             ),
             test(
                 "zero and minimum",
-                Int8.div(0, minimumInt8),
+                Int8.div(0, Int8.minimumValue),
                 M.equals(Int8Testable(0))
             ),
             test(
                 "maximum and maximum",
-                Int8.div(maximumInt8, maximumInt8),
+                Int8.div(Int8.maximumValue, Int8.maximumValue),
                 M.equals(Int8Testable(1))
             ),
             test(
                 "minimum and minimum",
-                Int8.div(minimumInt8, minimumInt8),
+                Int8.div(Int8.minimumValue, Int8.minimumValue),
                 M.equals(Int8Testable(1))
             )
         ]
@@ -1114,22 +1132,22 @@ run(
             ),
             test(
                 "zero and maximum",
-                Int8.rem(0, maximumInt8),
+                Int8.rem(0, Int8.maximumValue),
                 M.equals(Int8Testable(0))
             ),
             test(
                 "zero and minimum",
-                Int8.rem(0, minimumInt8),
+                Int8.rem(0, Int8.minimumValue),
                 M.equals(Int8Testable(0))
             ),
             test(
                 "maximum and maximum",
-                Int8.rem(maximumInt8, maximumInt8),
+                Int8.rem(Int8.maximumValue, Int8.maximumValue),
                 M.equals(Int8Testable(0))
             ),
             test(
                 "minimum and minimum",
-                Int8.rem(minimumInt8, minimumInt8),
+                Int8.rem(Int8.minimumValue, Int8.minimumValue),
                 M.equals(Int8Testable(0))
             )
         ]
@@ -1169,22 +1187,22 @@ run(
             ),
             test(
                 "maximum and zero",
-                Int8.pow(maximumInt8, 0),
+                Int8.pow(Int8.maximumValue, 0),
                 M.equals(Int8Testable(1))
             ),
             test(
                 "minimum and zero",
-                Int8.pow(minimumInt8, 0),
+                Int8.pow(Int8.minimumValue, 0),
                 M.equals(Int8Testable(1))
             ),
             test(
                 "plus one and maximum",
-                Int8.pow(1, maximumInt8),
+                Int8.pow(1, Int8.maximumValue),
                 M.equals(Int8Testable(1))
             ),
             test(
                 "minus one and maximum",
-                Int8.pow(-1, maximumInt8),
+                Int8.pow(-1, Int8.maximumValue),
                 M.equals(Int8Testable(-1))
             )
         ]
@@ -1211,13 +1229,13 @@ run(
             ),
             test(
                 "maximum",
-                Int8.bitnot(maximumInt8, unused),
-                M.equals(Int8Testable(minimumInt8))
+                Int8.bitnot(Int8.maximumValue, unused),
+                M.equals(Int8Testable(Int8.minimumValue))
             ),
             test(
                 "minimum",
-                Int8.bitnot(minimumInt8, unused),
-                M.equals(Int8Testable(maximumInt8))
+                Int8.bitnot(Int8.minimumValue, unused),
+                M.equals(Int8Testable(Int8.maximumValue))
             ),
             test(
                 "arbitrary",
@@ -1266,17 +1284,17 @@ run(
             ),
             test(
                 "zero and maximum",
-                Int8.bitand(0, maximumInt8),
+                Int8.bitand(0, Int8.maximumValue),
                 M.equals(Int8Testable(0))
             ),
             test(
                 "minimum and zero",
-                Int8.bitand(minimumInt8, 0),
+                Int8.bitand(Int8.minimumValue, 0),
                 M.equals(Int8Testable(0))
             ),
             test(
                 "minimum and maximum",
-                Int8.bitand(minimumInt8, maximumInt8),
+                Int8.bitand(Int8.minimumValue, Int8.maximumValue),
                 M.equals(Int8Testable(0))
             )
         ]
@@ -1321,17 +1339,17 @@ run(
             ),
             test(
                 "zero and maximum",
-                Int8.bitor(0, maximumInt8),
-                M.equals(Int8Testable(maximumInt8))
+                Int8.bitor(0, Int8.maximumValue),
+                M.equals(Int8Testable(Int8.maximumValue))
             ),
             test(
                 "minimum and zero",
-                Int8.bitor(minimumInt8, 0),
-                M.equals(Int8Testable(minimumInt8))
+                Int8.bitor(Int8.minimumValue, 0),
+                M.equals(Int8Testable(Int8.minimumValue))
             ),
             test(
                 "minimum and maximum",
-                Int8.bitor(minimumInt8, maximumInt8),
+                Int8.bitor(Int8.minimumValue, Int8.maximumValue),
                 M.equals(Int8Testable(-1))
             )
         ]
@@ -1376,17 +1394,17 @@ run(
             ),
             test(
                 "zero and maximum",
-                Int8.bitxor(0, maximumInt8),
-                M.equals(Int8Testable(maximumInt8))
+                Int8.bitxor(0, Int8.maximumValue),
+                M.equals(Int8Testable(Int8.maximumValue))
             ),
             test(
                 "minimum and zero",
-                Int8.bitxor(minimumInt8, 0),
-                M.equals(Int8Testable(minimumInt8))
+                Int8.bitxor(Int8.minimumValue, 0),
+                M.equals(Int8Testable(Int8.minimumValue))
             ),
             test(
                 "minimum and maximum",
-                Int8.bitxor(minimumInt8, maximumInt8),
+                Int8.bitxor(Int8.minimumValue, Int8.maximumValue),
                 M.equals(Int8Testable(-1))
             )
         ]
@@ -1422,12 +1440,12 @@ run(
             test(
                 "one maximum shift",
                 Int8.bitshiftLeft(1, 7),
-                M.equals(Int8Testable(minimumInt8))
+                M.equals(Int8Testable(Int8.minimumValue))
             ),
             test(
                 "minimum number",
                 Int8.bitshiftLeft(-1, 7),
-                M.equals(Int8Testable(minimumInt8))
+                M.equals(Int8Testable(Int8.minimumValue))
             ),
             test(
                 "discard overflow",
@@ -1486,7 +1504,7 @@ run(
             ),
             test(
                 "minimum number",
-                Int8.bitshiftRight(minimumInt8, 7),
+                Int8.bitshiftRight(Int8.minimumValue, 7),
                 M.equals(Int8Testable(-1))
             ),
             test(
@@ -1551,13 +1569,13 @@ run(
             ),
             test(
                 "maximum number",
-                Int8.bitrotLeft(maximumInt8, 1),
+                Int8.bitrotLeft(Int8.maximumValue, 1),
                 M.equals(Int8Testable(-2))
             ),
             test(
                 "minimum number",
                 Int8.bitrotLeft(1, 7),
-                M.equals(Int8Testable(minimumInt8))
+                M.equals(Int8Testable(Int8.minimumValue))
             ),
             test(
                 "opposite rotation",
@@ -1612,11 +1630,11 @@ run(
             test(
                 "maximum number",
                 Int8.bitrotRight(-2, 1),
-                M.equals(Int8Testable(maximumInt8))
+                M.equals(Int8Testable(Int8.maximumValue))
             ),
             test(
                 "minimum number",
-                Int8.bitrotRight(minimumInt8, 7),
+                Int8.bitrotRight(Int8.minimumValue, 7),
                 M.equals(Int8Testable(1))
             ),
             test(
@@ -1890,12 +1908,12 @@ run(
             ),
             test(
                 "minimum value",
-                Int8.bitcountNonZero(minimumInt8),
+                Int8.bitcountNonZero(Int8.minimumValue),
                 M.equals(Int8Testable(1))
             ),
             test(
                 "maximum value",
-                Int8.bitcountNonZero(maximumInt8),
+                Int8.bitcountNonZero(Int8.maximumValue),
                 M.equals(Int8Testable(7))
             ),
             test(
@@ -1950,12 +1968,12 @@ run(
             ),
             test(
                 "minimum value",
-                Int8.bitcountLeadingZero(minimumInt8),
+                Int8.bitcountLeadingZero(Int8.minimumValue),
                 M.equals(Int8Testable(0))
             ),
             test(
                 "maximum value",
-                Int8.bitcountLeadingZero(maximumInt8),
+                Int8.bitcountLeadingZero(Int8.maximumValue),
                 M.equals(Int8Testable(1))
             ),
             test(
@@ -2010,12 +2028,12 @@ run(
             ),
             test(
                 "minimum value",
-                Int8.bitcountTrailingZero(minimumInt8),
+                Int8.bitcountTrailingZero(Int8.minimumValue),
                 M.equals(Int8Testable(7))
             ),
             test(
                 "maximum value",
-                Int8.bitcountTrailingZero(maximumInt8),
+                Int8.bitcountTrailingZero(Int8.maximumValue),
                 M.equals(Int8Testable(0))
             ),
             test(
@@ -2060,27 +2078,27 @@ run(
             ),
             test(
                 "minimum and maximum",
-                Int8.addWrap(minimumInt8, maximumInt8),
+                Int8.addWrap(Int8.minimumValue, Int8.maximumValue),
                 M.equals(Int8Testable(-1))
             ),
             test(
                 "small overflow",
-                Int8.addWrap(maximumInt8, 1),
-                M.equals(Int8Testable(minimumInt8))
+                Int8.addWrap(Int8.maximumValue, 1),
+                M.equals(Int8Testable(Int8.minimumValue))
             ),
             test(
                 "large overflow",
-                Int8.addWrap(maximumInt8, maximumInt8),
+                Int8.addWrap(Int8.maximumValue, Int8.maximumValue),
                 M.equals(Int8Testable(-2))
             ),
             test(
                 "small underflow",
-                Int8.addWrap(minimumInt8, -1),
-                M.equals(Int8Testable(maximumInt8))
+                Int8.addWrap(Int8.minimumValue, -1),
+                M.equals(Int8Testable(Int8.maximumValue))
             ),
             test(
                 "large underflow",
-                Int8.addWrap(minimumInt8, minimumInt8),
+                Int8.addWrap(Int8.minimumValue, Int8.minimumValue),
                 M.equals(Int8Testable(0))
             ),
         ]
@@ -2115,27 +2133,27 @@ run(
             ),
             test(
                 "maximum and maximum",
-                Int8.subWrap(maximumInt8, maximumInt8),
+                Int8.subWrap(Int8.maximumValue, Int8.maximumValue),
                 M.equals(Int8Testable(0))
             ),
             test(
                 "small overflow",
-                Int8.subWrap(maximumInt8, -1),
-                M.equals(Int8Testable(minimumInt8))
+                Int8.subWrap(Int8.maximumValue, -1),
+                M.equals(Int8Testable(Int8.minimumValue))
             ),
             test(
                 "large overflow",
-                Int8.subWrap(maximumInt8, minimumInt8),
+                Int8.subWrap(Int8.maximumValue, Int8.minimumValue),
                 M.equals(Int8Testable(-1))
             ),
             test(
                 "small underflow",
-                Int8.subWrap(minimumInt8, 1),
-                M.equals(Int8Testable(maximumInt8))
+                Int8.subWrap(Int8.minimumValue, 1),
+                M.equals(Int8Testable(Int8.maximumValue))
             ),
             test(
                 "large underflow",
-                Int8.subWrap(minimumInt8, maximumInt8),
+                Int8.subWrap(Int8.minimumValue, Int8.maximumValue),
                 M.equals(Int8Testable(1))
             ),
         ]
@@ -2170,42 +2188,42 @@ run(
             ),
             test(
                 "zero and maximum",
-                Int8.mulWrap(0, maximumInt8),
+                Int8.mulWrap(0, Int8.maximumValue),
                 M.equals(Int8Testable(0))
             ),
             test(
                 "minimum and zero",
-                Int8.mulWrap(minimumInt8, 0),
+                Int8.mulWrap(Int8.minimumValue, 0),
                 M.equals(Int8Testable(0))
             ),
             test(
                 "one and maximum",
-                Int8.mulWrap(1, maximumInt8),
-                M.equals(Int8Testable(maximumInt8))
+                Int8.mulWrap(1, Int8.maximumValue),
+                M.equals(Int8Testable(Int8.maximumValue))
             ),
             test(
                 "minimum and one",
-                Int8.mulWrap(minimumInt8, 1),
-                M.equals(Int8Testable(minimumInt8))
+                Int8.mulWrap(Int8.minimumValue, 1),
+                M.equals(Int8Testable(Int8.minimumValue))
             ),
             test(
                 "small overflow",
-                Int8.mulWrap(2, maximumInt8),
+                Int8.mulWrap(2, Int8.maximumValue),
                 M.equals(Int8Testable(-2))
             ),
             test(
                 "large overflow",
-                Int8.mulWrap(maximumInt8, maximumInt8),
+                Int8.mulWrap(Int8.maximumValue, Int8.maximumValue),
                 M.equals(Int8Testable(1))
             ),
             test(
                 "small underflow",
-                Int8.mulWrap(minimumInt8, 2),
+                Int8.mulWrap(Int8.minimumValue, 2),
                 M.equals(Int8Testable(0))
             ),
             test(
                 "large underflow",
-                Int8.mulWrap(minimumInt8, minimumInt8),
+                Int8.mulWrap(Int8.minimumValue, Int8.minimumValue),
                 M.equals(Int8Testable(0))
             ),
         ]
@@ -2240,37 +2258,37 @@ run(
             ),
             test(
                 "maximum and zero",
-                Int8.powWrap(maximumInt8, 0),
+                Int8.powWrap(Int8.maximumValue, 0),
                 M.equals(Int8Testable(1))
             ),
             test(
                 "minimum and zero",
-                Int8.powWrap(minimumInt8, 0),
+                Int8.powWrap(Int8.minimumValue, 0),
                 M.equals(Int8Testable(1))
             ),
             test(
                 "plus one and maximum",
-                Int8.powWrap(1, maximumInt8),
+                Int8.powWrap(1, Int8.maximumValue),
                 M.equals(Int8Testable(1))
             ),
             test(
                 "minus one and maximum",
-                Int8.powWrap(-1, maximumInt8),
+                Int8.powWrap(-1, Int8.maximumValue),
                 M.equals(Int8Testable(-1))
             ),
             test(
                 "minimum value",
                 Int8.powWrap(-2, 7),
-                M.equals(Int8Testable(minimumInt8))
+                M.equals(Int8Testable(Int8.minimumValue))
             ),
             test(
                 "small overflow",
                 Int8.powWrap(2, 7),
-                M.equals(Int8Testable(minimumInt8))
+                M.equals(Int8Testable(Int8.minimumValue))
             ),
             test(
                 "large overflow",
-                Int8.powWrap(maximumInt8, 2),
+                Int8.powWrap(Int8.maximumValue, 2),
                 M.equals(Int8Testable(1))
             ),
             test(
@@ -2280,7 +2298,7 @@ run(
             ),
             test(
                 "large underflow",
-                Int8.powWrap(minimumInt8, 2),
+                Int8.powWrap(Int8.minimumValue, 2),
                 M.equals(Int8Testable(0))
             ),
         ]


### PR DESCRIPTION
Fix some most obvious issues reported in https://github.com/dfinity/motoko-base/issues/476:
* Offer minimum and maximum integer constants
* Remove superfluous second argument in `bitnot()`