### PR TITLE
Retain old Int negation function as deprecated for compatibility

### DIFF
--- a/src/Int.mo
+++ b/src/Int.mo
@@ -203,6 +203,10 @@ module {
   };
 
   /// Returns the negation of `x`, `-x` .
+  /// @deprecated Use `Int.neg()` since this function name is misspelled.;
+  public func neq(x : Int) : Int { -x }; // function name contains a typo, only retained for compatibility.
+
+  /// Returns the negation of `x`, `-x` .
   ///
   /// Example:
   /// ```motoko

--- a/src/Int.mo
+++ b/src/Int.mo
@@ -208,9 +208,9 @@ module {
   /// ```motoko
   /// import Int "mo:base/Int";
   ///
-  /// Int.neq(123) // => -123
+  /// Int.neg(123) // => -123
   /// ```
-  public func neq(x : Int) : Int { -x }; // Typo: Should be changed to `neg`
+  public func neg(x : Int) : Int { -x };
 
   /// Returns the sum of `x` and `y`, `x + y`.
   ///

--- a/test/intTest.mo
+++ b/test/intTest.mo
@@ -630,27 +630,27 @@ run(
     [
       test(
         "positive number",
-        Int.neq(123),
+        Int.neg(123),
         M.equals(T.int(-123))
       ),
       test(
         "negative number",
-        Int.neq(-123),
+        Int.neg(-123),
         M.equals(T.int(123))
       ),
       test(
         "zero",
-        Int.neq(0),
+        Int.neg(0),
         M.equals(T.int(0))
       ),
       test(
         "positive large number",
-        Int.neq(largeNumber),
+        Int.neg(largeNumber),
         M.equals(T.int(-largeNumber))
       ),
       test(
         "negative large number",
-        Int.neq(-largeNumber),
+        Int.neg(-largeNumber),
         M.equals(T.int(largeNumber))
       )
     ]


### PR DESCRIPTION
Should we retain `Int.neq()` as a deprecated function to avoid a breaking change?

The function name has been fixed to `neg()` in PR https://github.com/dfinity/motoko-base/pull/479