### PR TITLE
Add `Array.size`

### DIFF
--- a/src/Array.mo
+++ b/src/Array.mo
@@ -699,3 +699,19 @@ module {
   /// Space: O(1)
   public func keys<X>(array : [X]) : I.Iter<Nat> = array.keys()
 }
+  /// Returns the size of `array`.
+  ///
+  /// NOTE: You can also use `array.size()` instead of this function. See example
+  /// below.
+  ///
+  /// ```motoko include=import
+  ///
+  /// let array = [10, 11, 12];
+  /// array.size();
+  /// ```
+  ///
+  /// Runtime: O(1)
+  ///
+  /// Space: O(1)
+  public func size<X>(array : [X]) : Nat = array.size()
+}

--- a/src/Array.mo
+++ b/src/Array.mo
@@ -698,7 +698,7 @@ module {
   ///
   /// Space: O(1)
   public func keys<X>(array : [X]) : I.Iter<Nat> = array.keys()
-}
+
   /// Returns the size of `array`.
   ///
   /// NOTE: You can also use `array.size()` instead of this function. See example

--- a/src/Array.mo
+++ b/src/Array.mo
@@ -707,7 +707,7 @@ module {
   /// ```motoko include=import
   ///
   /// let array = [10, 11, 12];
-  /// array.size();
+  /// let size = Array.size(array);
   /// ```
   ///
   /// Runtime: O(1)

--- a/src/Array.mo
+++ b/src/Array.mo
@@ -697,7 +697,7 @@ module {
   /// Runtime: O(1)
   ///
   /// Space: O(1)
-  public func keys<X>(array : [X]) : I.Iter<Nat> = array.keys()
+  public func keys<X>(array : [X]) : I.Iter<Nat> = array.keys();
 
   /// Returns the size of `array`.
   ///


### PR DESCRIPTION
This aims to address https://forum.dfinity.org/t/how-to-get-a-array-lengh/8346 and other instances of people asking about how to get the size of an array due to it being omitted from the generated documentation.

------
This is #486, which had a botched merge. Sorry for rewriting history :-(