### PR TITLE
Un-deprecate Array Append

### DIFF
--- a/src/Array.mo
+++ b/src/Array.mo
@@ -162,8 +162,8 @@ module {
   };
 
   /// Create a new array by appending the values of `array1` and `array2`.
-  /// @deprecated `Array.append` copies its arguments and has linear complexity;
-  /// when used in a loop, consider using a `Buffer`, and `Buffer.append`, instead.
+  /// This function is ineffecient when used in a loop. If you need to repeatedly
+  /// grow the array, consider using a `Buffer` and `Buffer.append`, instead.
   ///
   /// ```motoko include=import
   /// let array1 = [1, 2, 3];


### PR DESCRIPTION
Array append is a useful function, and so should not be deprecated.

Documentation still includes warning of its linear complexity and suggestions to use a buffer instead.