### PR TITLE
perf: optimize AssocList.replace to avoid unnecesary allocation

### DIFF
--- a/src/AssocList.mo
+++ b/src/AssocList.mo
@@ -97,8 +97,8 @@ module {
           } else {
             let tl1 = del(tl);
             switch (prev) {
-              case (?_)  { ?(kv, tl1) };
-              case null { al }
+              case null { al };
+              case (?_) { ?(kv, tl1) }
             }
           }
         };

--- a/src/AssocList.mo
+++ b/src/AssocList.mo
@@ -87,36 +87,33 @@ module {
       equal : (K, K) -> Bool,
       value : ?V
     ) : (AssocList<K, V>, ?V) {
-      var prev : ?V = null;
-      func del(al : AssocList<K, V>) : AssocList<K, V> {
-        switch (al) {
-          case (?(kv, tl)) {
-            if (equal(key, kv.0)) {
-              prev := ?kv.1;
-              tl
-            } else {
-              let tl1 = del(tl);
-              switch (prev) {
-                case (?_)  { ?(kv, tl1) };
-                case null { al }
-              }
+    var prev : ?V = null;
+    func del(al : AssocList<K, V>) : AssocList<K, V> {
+      switch (al) {
+        case (?(kv, tl)) {
+          if (equal(key, kv.0)) {
+            prev := ?kv.1;
+            tl
+          } else {
+            let tl1 = del(tl);
+            switch (prev) {
+              case (?_)  { ?(kv, tl1) };
+              case null { al }
             }
-          };
-          case null {
-            null
           }
-        }
-      };
-      switch value {
-        case (?value) {
-          let map1 = del(map);
-          switch (prev) {
-            case (null) { (?((key, value), map), prev) };
-            case (?_) { (?((key, value), map1), prev) }
-        }
-        case null {
-          (del(map), prev)
         };
+        case null {
+          null
+        }
+      }
+    };
+    let map1 = del(map);
+    switch value {
+      case (?value) {
+        (?((key, value), map1), prev)
+      };
+      case null {
+        (map1, prev)
       };
     };
   };

--- a/src/AssocList.mo
+++ b/src/AssocList.mo
@@ -88,57 +88,39 @@ module {
       value : ?V
     ) : (AssocList<K, V>, ?V) {
       var prev : ?V = null;
-      switch value {
-        case null {
-          func del(al : AssocList<K, V>) : AssocList<K, V> {
-            switch (al) {
-              case (?((hd_k, hd_v), tl)) {
-                if (equal(key, hd_k)) {
-                  prev := ?hd_v;
-                  tl
-                } else {
-                  let tl1 = del(tl);
-                  switch (prev) {
-                    case (?_)  { ?((hd_k, hd_v), tl1) };
-                    case (null) { al }
-                  }
-                }
-              };
-              case (null) {
-                null
+      func del(al : AssocList<K, V>) : AssocList<K, V> {
+        switch (al) {
+          case (?(kv, tl)) {
+            if (equal(key, kv.0)) {
+              prev := ?kv.1;
+              tl
+            } else {
+              let tl1 = del(tl);
+              switch (prev) {
+                case (?_)  { ?(kv, tl1) };
+                case null { al }
               }
             }
           };
-          (del(map), prev)
-      };
-      case (?value) {
-        func ins(al : AssocList<K, V>) : AssocList<K, V> {
-          switch (al) {
-            case (?((hd_k, hd_v), tl)) {
-              if (equal(key, hd_k)) {
-                prev := ?hd_v;
-                tl
-              } else {
-                let tl0 = ins(tl);
-                switch prev {
-                  case (null) { al };
-                  case (?_) { ?((hd_k, hd_v), tl0)}
-                }
-              }
-            };
-            case (null) {
-              null
-            }
+          case null {
+            null
           }
-        };
-        let map1 = ins(map);
-        switch (prev) {
-          case (null) { (?((key,value), map), prev) };
-          case (?_) { (?((key,value), map1), prev) }
         }
+      };
+      switch value {
+        case (?value) {
+          let map1 = del(map);
+          switch (prev) {
+            case (null) { (?((key, value), map), prev) };
+            case (?_) { (?((key, value), map1), prev) }
+        }
+        case null {
+          (del(map), prev)
+        };
       };
     };
   };
+
   /// Produces a new map containing all entries from `map1` whose keys are not
   /// contained in `map2`. The "extra" entries in `map2` are ignored. Compares
   /// keys using the provided function `equal`.

--- a/test/Makefile
+++ b/test/Makefile
@@ -8,7 +8,7 @@ TESTS = $(wildcard *.mo)
 
 TEST_TARGETS = $(patsubst %.mo,_out/%.checked,$(TESTS))
 
-all: $(OUTDIR)/import_all.checked $(TEST_TARGETS) 
+all: $(OUTDIR)/import_all.checked $(TEST_TARGETS)
 
 STDLIB_FILES= $(wildcard $(STDLIB)/*.mo)
 

--- a/test/Makefile
+++ b/test/Makefile
@@ -30,7 +30,7 @@ $(OUTDIR)/%.wasm: $(OUTDIR)/%.mo | $(OUTDIR)
 	$(MOC) -c --package base $(STDLIB) $(VESSEL_PKGS) -wasi-system-api -o $@ $<
 
 $(OUTDIR)/%.checked: $(OUTDIR)/%.wasm
-	wasmtime run $(WASMTIME_OPTIONS) $< || true
+	wasmtime run $(WASMTIME_OPTIONS) $<
 	touch $@
 
 clean:

--- a/test/Makefile
+++ b/test/Makefile
@@ -30,7 +30,7 @@ $(OUTDIR)/%.wasm: $(OUTDIR)/%.mo | $(OUTDIR)
 	$(MOC) -c --package base $(STDLIB) $(VESSEL_PKGS) -wasi-system-api -o $@ $<
 
 $(OUTDIR)/%.checked: $(OUTDIR)/%.wasm
-	wasmtime run $(WASMTIME_OPTIONS) $<
+	wasmtime run $(WASMTIME_OPTIONS) $< || true
 	touch $@
 
 clean:

--- a/test/assocListTest.mo
+++ b/test/assocListTest.mo
@@ -52,7 +52,7 @@ let suite = Suite.suite(
         Suite.test(
             "replace",
             AssocList.replace(map1, 4, Nat.equal, ?24).0,
-            assocListTest([(0, 10), (2, 12), (4, 24)])
+            assocListTest([(4, 24), (0, 10), (2, 12) ])
         ),
         Suite.test(
             "replace empty",
@@ -62,7 +62,7 @@ let suite = Suite.suite(
         Suite.test(
             "replace new entry",
             AssocList.replace(map1, 1, Nat.equal, ?11).0,
-            assocListTest([(0, 10), (2, 12), (4, 14), (1, 11)])
+            assocListTest([(1, 11), (0, 10), (2, 12), (4, 14)])
         ),
         Suite.test(
             "diff no overlap",

--- a/test/trieSetTest.mo
+++ b/test/trieSetTest.mo
@@ -25,7 +25,7 @@ let simpleTests = do {
       ),
       Suite.test(
         "toArray",
-        TrieSet.toArray<Nat>(set1),
+        Array.sort(TrieSet.toArray<Nat>(set1), Nat.compare),
         M.equals(T.array<Nat>(T.natTestable, [1, 2, 3]))
       )
     ]
@@ -42,7 +42,7 @@ let binopTests = do {
     [
       Suite.test(
         "union",
-        TrieSet.toArray(TrieSet.union(a, b, Nat.equal)),
+        Array.sort(TrieSet.toArray(TrieSet.union(a, b, Nat.equal)), Nat.compare),
         M.equals(T.array<Nat>(T.natTestable, [1, 2, 3]))
       ),
       Suite.test(


### PR DESCRIPTION
Optimize AssocList.replace to:
* avoid reconstructing list on deletion of absent association, avoiding 0(n) allocations.
* insert association for new key at front (not end) of list on insertion, avoiding 0(n) allocations.

The trick is to use the `prev` value, set by recursive calls, to determine whether to to re-use or re-build the original assoc list.

TODO: factor our nested ins/del functions into top-level functions for easier review.

Caveat: This changes the concrete order of entries for Trie and probably HashMap, so breaks our tests and any other user code that relies on the ordering of entries.

https://m7sm4-2iaaa-aaaab-qabra-cai.ic0.app/?tag=1498380597

```
› testOld()
("{heap_diff = 24_076_000; instructions = 125_295_036}")
› testNew()
("{heap_diff = 16_080_000; instructions = 92_834_526}")
› testOpt()
("{heap_diff = 108_000; instructions = 44_916_526}")
```
where testOld is original impl of replace, pre #530
testNew is revised impl of replace in current master (#530)
testOpt is the optimized version suggested here.


The playground benchmark just measures the cost of constructing an AssocList with 1000 distinct bindings. Deletion is not measured.


playground code:

```
import AssocList = "mo:base/AssocList";
import List = "mo:base/List";
import Nat = "mo:base/Nat";
import IC = "mo:base/ExperimentalInternetComputer";
import Prim = "mo:prim";
actor {

  type AssocList<K, V> = AssocList.AssocList<K, V>;
  func replace<K, V>(
    map : AssocList<K, V>,
    key : K,
    equal : (K, K) -> Bool,
    value : ?V
  ) : (AssocList<K, V>, ?V) {
    var prev : ?V = null;
    func rec(al : AssocList<K, V>) : AssocList<K, V> {
      switch (al) {
        case (?((hd_k, hd_v), tl)) {
          if (equal(key, hd_k)) {
            // if value is null, remove the key; otherwise, replace key's old value
            // return old value
            prev := ?hd_v;
            switch value {
              case (null) { tl };
              case (?value) { ?((hd_k, value), tl) }
            }
          } else {
            ?((hd_k, hd_v), rec(tl))
          }
        };
        case (null) {
          switch value {
            case (null) { null };
            case (?value) { ?((key, value), null) }
          }
        }
      }
    };
    (rec(map), prev)
  };

  func replaceOpt<K, V>(
      map : AssocList<K, V>,
      key : K,
      equal : (K, K) -> Bool,
      value : ?V
    ) : (AssocList<K, V>, ?V) {
    var prev : ?V = null;
    func del(al : AssocList<K, V>) : AssocList<K, V> {
      switch (al) {
        case (?(kv, tl)) {
          if (equal(key, kv.0)) {
            prev := ?kv.1;
            tl
          } else {
            let tl1 = del(tl);
            switch (prev) {
              case null { al };
              case (?_)  { ?(kv, tl1) };
            }
          }
        };
        case null {
          null
        }
      }
    };
    let map1 = del(map);
    switch value {
      case (?value) {
        (?((key, value), map1), prev)
      };
      case null {
        (map1, prev)
      };
    };
  };


  public func testOld() : async Text {
  let heap_size = Prim.rts_heap_size();
   let c = IC.countInstructions(func () {
   var map = List.nil<(Nat,Nat)>();
   var n = 1000;
   while (n > 0) { 
    map := AssocList.replace(map, n, Nat.equal, ?n).0;
    n -= 1;
   }
   });
    debug_show { instructions = c; heap_diff = Prim.rts_heap_size() - heap_size};
  };

  public func testNew() : async Text {
    let heap_size = Prim.rts_heap_size();
   let c = IC.countInstructions(func () {
   var map = List.nil<(Nat,Nat)>();
   var n = 1000;
   while (n > 0) { 
    map := replace(map, n, Nat.equal, ?n).0;
    n -= 1;
   }
   });
    debug_show { instructions = c; heap_diff = Prim.rts_heap_size() - heap_size};
  };

  
  public func testOpt() : async Text {
   let heap_size = Prim.rts_heap_size();
   let c = IC.countInstructions(func () {
   var map = List.nil<(Nat,Nat)>();
   var n = 1000;
   while (n > 0) { 
    map := replaceOpt(map, n, Nat.equal, ?n).0;
    n -= 1;
   }
   });
   debug_show { instructions = c; heap_diff = Prim.rts_heap_size() - heap_size};
  };
}
```