### PR TITLE
feat: add `Iter.enumerate` method

### DIFF
--- a/src/Iter.mo
+++ b/src/Iter.mo
@@ -88,7 +88,7 @@ module {
 
   /// Takes an iterator and returns a new iterator that produces the same elements with corresponding indices.
   /// ```motoko
-  /// import Iter "mo:base/Iter"; 
+  /// import Iter "mo:base/Iter";
   /// let letters = [ "a", "b", "c" ];
   /// let enumeratedIter = Iter.enumerate(letters.vals());
   /// assert(?(0, "a") == enumeratedIter.next());
@@ -98,17 +98,13 @@ module {
   /// ```
   public func enumerate<A>(xs : Iter<A>) : Iter<(Nat, A)> = object {
     var i = 0;
-    public func next() : ?(Nat, A) {
-      switch (xs.next()) {
-        case (?next) {
-          let res = (i, next);
-          i += 1;
-          ?res
-        };
-        case (null) {
-          null
-        }
-      }
+    public func next() : ?(Nat, A) = switch (xs.next()) {
+      case (?next) {
+        let res = (i, next);
+        i += 1;
+        ?res
+      };
+      case null null
     }
   };
 

--- a/src/Iter.mo
+++ b/src/Iter.mo
@@ -86,6 +86,32 @@ module {
     len
   };
 
+  /// Takes an iterator and returns a new iterator that produces the same elements with corresponding indices.
+  /// ```motoko
+  /// import Iter "mo:base/Iter"; 
+  /// let letters = [ "a", "b", "c" ];
+  /// let enumeratedIter = Iter.enumerate(letters.vals());
+  /// assert(?(0, "a") == enumeratedIter.next());
+  /// assert(?(1, "b") == enumeratedIter.next());
+  /// assert(?(2, "c") == enumeratedIter.next());
+  /// assert(null == enumeratedIter.next());
+  /// ```
+  public func enumerate<A>(xs : Iter<A>) : Iter<(Nat, A)> = object {
+    var i = 0;
+    public func next() : ?(Nat, A) {
+      switch (xs.next()) {
+        case (?next) {
+          let res = (i, next);
+          i += 1;
+          ?res
+        };
+        case (null) {
+          null
+        }
+      }
+    }
+  };
+
   /// Takes a function and an iterator and returns a new iterator that lazily applies
   /// the function to every element produced by the argument iterator.
   /// ```motoko

--- a/test/Iter.test.mo
+++ b/test/Iter.test.mo
@@ -46,6 +46,21 @@ do {
 };
 
 do {
+  Debug.print("  enumerate");
+
+  let xs = ["a", "b", "c", "d", "e", "f"];
+  for ((i, x) in Iter.enumerate(xs.vals())) {
+    assert (x == xs[i])
+  };
+
+  let enumeratedIter = Iter.enumerate(["a", "b", "c"].vals());
+  assert (?(0, "a") == enumeratedIter.next());
+  assert (?(1, "b") == enumeratedIter.next());
+  assert (?(2, "c") == enumeratedIter.next());
+  assert (null == enumeratedIter.next())
+};
+
+do {
   Debug.print("  map");
 
   let isEven = func(x : Int) : Bool {


### PR DESCRIPTION
> Takes an iterator and returns a new iterator that produces the same elements with corresponding indices.

```motoko
import Iter "mo:base/Iter"; 

let letters = [ "a", "b", "c" ];
let enumeratedIter = Iter.enumerate(letters.vals());
assert(?(0, "a") == enumeratedIter.next());
assert(?(1, "b") == enumeratedIter.next());
assert(?(2, "c") == enumeratedIter.next());
assert(null == enumeratedIter.next());
```

Simplifies:

```motoko
var i = 0;
for (l in letters.vals()) {
  // Do somthing with `i` and `l`.
  i += 1;
}
```