### PR TITLE
Stable buffer

### DIFF
--- a/src/StableBuffer.mo
+++ b/src/StableBuffer.mo
@@ -1,0 +1,99 @@
+import Prim "mo:⛔";
+import Region "Region";
+
+module {
+    public type Index = Nat64;
+
+    public type Buffer = {
+        add : (blob : Blob) -> Index;
+        addClone : (Index) -> Index;
+        get : (Index) -> Blob;
+        size : () -> Nat;
+    };
+
+    // - - - Implementation details follow.
+
+    type Elem = {
+        pos : Nat64;
+        size : Nat64;
+    };
+
+    let elem_size = 16 : Nat64; /* two Nat64s, for pos and size. */
+
+    type BufferRep = {
+        bytes: Region;
+        var bytes_count: Nat64; // more fine-grained than "pages"
+
+        elems: Region;
+        var elems_count: Nat64; // more fine-grained than "pages"
+    };
+
+    func regionEnsureSizeBytes(r : Region, new_byte_count : Nat64) {
+        let pages = Region.size(r);
+        if (new_byte_count > pages << 16) {
+            let new_pages = pages - ((new_byte_count + ((1 << 16) - 1)) / (1 << 16));
+            assert Region.grow(r, new_pages) == pages
+        }
+    };
+
+    func bufferGetElem(self: BufferRep, index: Index) : Elem {
+        assert index < self.elems_count;
+        let pos = Region.loadNat64(self.elems, index * elem_size);
+        let size = Region.loadNat64(self.elems, index * elem_size + 8);
+        { pos ; size }
+    };
+
+    func bufferAdd(self: BufferRep, thing: { #blob: Blob; #index: Index }) : Index {
+        switch thing {
+          case (#blob blob) {
+                let elem_i = self.elems_count;
+                self.elems_count += 1;
+
+                let elem_pos = self.bytes_count;
+                self.bytes_count += Prim.natToNat64(blob.size());
+
+                regionEnsureSizeBytes(self.bytes, self.bytes_count);
+                Region.storeBlob(self.bytes, elem_pos, blob);
+
+                regionEnsureSizeBytes(self.elems, self.elems_count * elem_size);
+                Region.storeNat64(self.elems, elem_i * elem_size + 0, elem_pos);
+                Region.storeNat64(self.elems, elem_i * elem_size + 8, Prim.natToNat64(blob.size()));
+                elem_i
+            };
+            case (#index index) {
+                let elem = bufferGetElem(self, index);
+                let elem_i = self.elems_count;
+                self.elems_count += 1;
+
+                regionEnsureSizeBytes(self.elems, self.elems_count * elem_size);
+                Region.storeNat64(self.elems, elem_i * elem.size + 0, elem.pos);
+                Region.storeNat64(self.elems, elem_i * elem.size + 8, elem.size);
+                elem_i
+            };
+        }
+    };
+
+    public class Empty() : Buffer {
+        var rep : BufferRep = {
+            bytes = Region.new();
+            var bytes_count = 0;
+            elems = Region.new();
+            var elems_count = 0;
+        };
+        public func add(blob : Blob) : Index {
+            bufferAdd(rep, #blob blob)
+        };
+        public func addClone(index : Index) : Index {
+            bufferAdd(rep, #index index)
+        };
+        public func size() : Nat {
+            Prim.nat64ToNat(rep.elems_count)
+        };
+        public func get(index : Index) : Blob {
+            let elem = bufferGetElem(rep, index);
+            Region.loadBlob(rep.bytes, elem.pos, Prim.nat64ToNat(elem.size))
+        }
+    };
+
+
+}

--- a/src/StableMemory.mo
+++ b/src/StableMemory.mo
@@ -1,0 +1,373 @@
+/// Byte-level access to multiple, independent _stable memories_.
+///
+/// This is a lightweight abstraction over IC _stable memory_ and supports persisting
+/// raw binary data across Motoko upgrades.
+/// Use of this module is fully compatible with Motoko's use of
+/// _stable variables_, whose persistence mechanism also uses (real) IC stable memory internally, but does not interfere with this API.
+///
+/// ## Multple memories
+///
+/// This module provides a generalization over its predecessor (`ExperimentalStableMemory`),
+/// in that it offers a class with _multiple instances_, rather than a module with a single
+/// _monolitic_ (_shared, global_) instance, as before.
+///
+/// The number of these instances may be limited by its implementation, but will provide
+/// up to 256 independent instances, initially 
+/// (matching and reusing a recent Rust library-version of the same feature).
+///
+/// The API of the `class` provides the same low-level API as before, but where each instance
+/// can be used independently of the others.
+///
+/// Reclaiming space from one to use in another is
+/// unlocked by this new generalized API, but is not yet implemented.
+/// By creating a more sophisticated backing allocator, future implementations
+/// (more complex than the present one lifted from the Rust library)
+/// could support freeing memories transparently via the existing GC infrastructure,
+/// avoid growing the underlying canister stable memory when a new instance is required,
+/// or when an existing instance must grow.
+///
+/// ## Per-instance API
+///
+/// Memory is allocated, using `grow(pages)`, sequentially and on demand, in units of 64KiB pages, starting with 0 allocated pages.
+/// New pages are zero initialized.
+/// Growth is capped by a soft limit on page count controlled by compile-time flag
+/// `--max-stable-pages <n>` (the default is 65536, or 4GiB).
+///
+/// Each `load` operation loads from byte address `offset` in little-endian
+/// format using the natural bit-width of the type in question.
+/// The operation traps if attempting to read beyond the current stable memory size.
+///
+/// Each `store` operation stores to byte address `offset` in little-endian format using the natural bit-width of the type in question.
+/// The operation traps if attempting to write beyond the current stable memory size.
+///
+/// Text values can be handled by using `Text.decodeUtf8` and `Text.encodeUtf8`, in conjunction with `loadBlob` and `storeBlob`.
+///
+/// The current page allocation and page contents is preserved across upgrades.
+///
+/// NB: The IC's actual stable memory size (`ic0.stable_size`) may exceed the
+/// page size reported by Motoko function `size()`.
+/// This (and the cap on growth) are to accommodate Motoko's stable variables.
+/// Applications that plan to use Motoko stable variables sparingly or not at all can
+/// increase `--max-stable-pages` as desired, approaching the IC maximum (initially 8GiB, then 32Gib, currently 48Gib).
+/// All applications should reserve at least one page for stable variable data, even when no stable variables are used.
+///
+/// Usage:
+/// ```motoko no-repl
+/// import StableMemory "mo:base/ExperimentalStableMemory";
+/// ```
+
+import Prim "mo:⛔";
+
+module {
+
+  public class StableMemory () {
+
+  var id = Prim.multStableMemoryNew();
+
+  /// Current size of the stable memory, in pages.
+  /// Each page is 64KiB (65536 bytes).
+  /// Initially `0`.
+  /// Preserved across upgrades, together with contents of allocated
+  /// stable memory.
+  ///
+  /// Example:
+  /// ```motoko no-repl
+  /// let beforeSize = StableMemory.size();
+  /// ignore StableMemory.grow(10);
+  /// let afterSize = StableMemory.size();
+  /// afterSize - beforeSize // => 10
+  /// ```
+  public let size : () -> (pages : Nat64) = Prim.multStableMemorySize id;
+
+  /// Grow current `size` of stable memory by the given number of pages.
+  /// Each page is 64KiB (65536 bytes).
+  /// Returns the previous `size` when able to grow.
+  /// Returns `0xFFFF_FFFF_FFFF_FFFF` if remaining pages insufficient.
+  /// Every new page is zero-initialized, containing byte 0x00 at every offset.
+  /// Function `grow` is capped by a soft limit on `size` controlled by compile-time flag
+  ///  `--max-stable-pages <n>` (the default is 65536, or 4GiB).
+  ///
+  /// Example:
+  /// ```motoko no-repl
+  /// import Error "mo:base/Error";
+  ///
+  /// let beforeSize = StableMemory.grow(10);
+  /// if (beforeSize == 0xFFFF_FFFF_FFFF_FFFF) {
+  ///   throw Error.reject("Out of memory");
+  /// };
+  /// let afterSize = StableMemory.size();
+  /// afterSize - beforeSize // => 10
+  /// ```
+  public let grow : (newPages : Nat64) -> (oldPages : Nat64) = Prim.multStableMemoryGrow(id, newPages);
+
+  /// Returns a query that, when called, returns the number of bytes of (real) IC stable memory that would be
+  /// occupied by persisting its current stable variables before an upgrade.
+  /// This function may be used to monitor or limit real stable memory usage.
+  /// The query computes the estimate by running the first half of an upgrade, including any `preupgrade` system method.
+  /// Like any other query, its state changes are discarded so no actual upgrade (or other state change) takes place.
+  /// The query can only be called by the enclosing actor and will trap for other callers.
+  ///
+  /// Example:
+  /// ```motoko no-repl
+  /// actor {
+  ///   stable var state = "";
+  ///   public func example() : async Text {
+  ///     let memoryUsage = StableMemory.stableVarQuery();
+  ///     let beforeSize = (await memoryUsage()).size;
+  ///     state #= "abcdefghijklmnopqrstuvwxyz";
+  ///     let afterSize = (await memoryUsage()).size;
+  ///     debug_show (afterSize - beforeSize)
+  ///   };
+  /// };
+  /// ```
+  public let stableVarQuery : () -> (shared query () -> async { size : Nat64 }) = Prim.stableVarQuery;
+
+  /// Loads a `Nat32` value from stable memory at the given `offset`.
+  /// Traps on an out-of-bounds access.
+  ///
+  /// Example:
+  /// ```motoko no-repl
+  /// let offset = 0;
+  /// let value = 123;
+  /// StableMemory.storeNat32(offset, value);
+  /// StableMemory.loadNat32(offset) // => 123
+  /// ```
+  public let loadNat32 : (offset : Nat64) -> Nat32 = Prim.multStableMemoryLoadNat32(id, offset);
+
+  /// Stores a `Nat32` value in stable memory at the given `offset`.
+  /// Traps on an out-of-bounds access.
+  ///
+  /// Example:
+  /// ```motoko no-repl
+  /// let offset = 0;
+  /// let value = 123;
+  /// StableMemory.storeNat32(offset, value);
+  /// StableMemory.loadNat32(offset) // => 123
+  /// ```
+  public let storeNat32 : (offset : Nat64, value : Nat32) -> () = Prim.multStableMemoryStoreNat32(id, offset, value);
+
+  /// Loads a `Nat8` value from stable memory at the given `offset`.
+  /// Traps on an out-of-bounds access.
+  ///
+  /// Example:
+  /// ```motoko no-repl
+  /// let offset = 0;
+  /// let value = 123;
+  /// StableMemory.storeNat8(offset, value);
+  /// StableMemory.loadNat8(offset) // => 123
+  /// ```
+  public let loadNat8 : (offset : Nat64) -> Nat8 = Prim.multStableMemoryLoadNat8(id, offset);
+
+  /// Stores a `Nat8` value in stable memory at the given `offset`.
+  /// Traps on an out-of-bounds access.
+  ///
+  /// Example:
+  /// ```motoko no-repl
+  /// let offset = 0;
+  /// let value = 123;
+  /// StableMemory.storeNat8(offset, value);
+  /// StableMemory.loadNat8(offset) // => 123
+  /// ```
+  public let storeNat8 : (offset : Nat64, value : Nat8) -> () = Prim.multStableMemoryStoreNat8(id, offset, value);
+
+  /// Loads a `Nat16` value from stable memory at the given `offset`.
+  /// Traps on an out-of-bounds access.
+  ///
+  /// Example:
+  /// ```motoko no-repl
+  /// let offset = 0;
+  /// let value = 123;
+  /// StableMemory.storeNat16(offset, value);
+  /// StableMemory.loadNat16(offset) // => 123
+  /// ```
+  public let loadNat16 : (offset : Nat64) -> Nat16 = Prim.multStableMemoryLoadNat16(id, offset);
+
+  /// Stores a `Nat16` value in stable memory at the given `offset`.
+  /// Traps on an out-of-bounds access.
+  ///
+  /// Example:
+  /// ```motoko no-repl
+  /// let offset = 0;
+  /// let value = 123;
+  /// StableMemory.storeNat16(offset, value);
+  /// StableMemory.loadNat16(offset) // => 123
+  /// ```
+  public let storeNat16 : (offset : Nat64, value : Nat16) -> () = Prim.multStableMemoryStoreNat16(id, offset, value);
+
+  /// Loads a `Nat64` value from stable memory at the given `offset`.
+  /// Traps on an out-of-bounds access.
+  ///
+  /// Example:
+  /// ```motoko no-repl
+  /// let offset = 0;
+  /// let value = 123;
+  /// StableMemory.storeNat64(offset, value);
+  /// StableMemory.loadNat64(offset) // => 123
+  /// ```
+  public let loadNat64 : (offset : Nat64) -> Nat64 = Prim.multStableMemoryLoadNat64(id, offset);
+
+  /// Stores a `Nat64` value in stable memory at the given `offset`.
+  /// Traps on an out-of-bounds access.
+  ///
+  /// Example:
+  /// ```motoko no-repl
+  /// let offset = 0;
+  /// let value = 123;
+  /// StableMemory.storeNat64(offset, value);
+  /// StableMemory.loadNat64(offset) // => 123
+  /// ```
+  public let storeNat64 : (offset : Nat64, value : Nat64) -> () = Prim.multStableMemoryStoreNat64(id, offset, value);
+
+  /// Loads an `Int32` value from stable memory at the given `offset`.
+  /// Traps on an out-of-bounds access.
+  ///
+  /// Example:
+  /// ```motoko no-repl
+  /// let offset = 0;
+  /// let value = 123;
+  /// StableMemory.storeInt32(offset, value);
+  /// StableMemory.loadInt32(offset) // => 123
+  /// ```
+  public let loadInt32 : (offset : Nat64) -> Int32 = Prim.multStableMemoryLoadInt32(id, offset);
+
+  /// Stores an `Int32` value in stable memory at the given `offset`.
+  /// Traps on an out-of-bounds access.
+  ///
+  /// Example:
+  /// ```motoko no-repl
+  /// let offset = 0;
+  /// let value = 123;
+  /// StableMemory.storeInt32(offset, value);
+  /// StableMemory.loadInt32(offset) // => 123
+  /// ```
+  public let storeInt32 : (offset : Nat64, value : Int32) -> () = Prim.multStableMemoryStoreInt32(id, offset, value);
+
+  /// Loads an `Int8` value from stable memory at the given `offset`.
+  /// Traps on an out-of-bounds access.
+  ///
+  /// Example:
+  /// ```motoko no-repl
+  /// let offset = 0;
+  /// let value = 123;
+  /// StableMemory.storeInt8(offset, value);
+  /// StableMemory.loadInt8(offset) // => 123
+  /// ```
+  public let loadInt8 : (offset : Nat64) -> Int8 = Prim.multStableMemoryLoadInt8(id, offset);
+
+  /// Stores an `Int8` value in stable memory at the given `offset`.
+  /// Traps on an out-of-bounds access.
+  ///
+  /// Example:
+  /// ```motoko no-repl
+  /// let offset = 0;
+  /// let value = 123;
+  /// StableMemory.storeInt8(offset, value);
+  /// StableMemory.loadInt8(offset) // => 123
+  /// ```
+  public let storeInt8 : (offset : Nat64, value : Int8) -> () = Prim.multStableMemoryStoreInt8(id, offset, value);
+
+  /// Loads an `Int16` value from stable memory at the given `offset`.
+  /// Traps on an out-of-bounds access.
+  ///
+  /// Example:
+  /// ```motoko no-repl
+  /// let offset = 0;
+  /// let value = 123;
+  /// StableMemory.storeInt16(offset, value);
+  /// StableMemory.loadInt16(offset) // => 123
+  /// ```
+  public let loadInt16 : (offset : Nat64) -> Int16 = Prim.multStableMemoryLoadInt16(id, offset);
+
+  /// Stores an `Int16` value in stable memory at the given `offset`.
+  /// Traps on an out-of-bounds access.
+  ///
+  /// Example:
+  /// ```motoko no-repl
+  /// let offset = 0;
+  /// let value = 123;
+  /// StableMemory.storeInt16(offset, value);
+  /// StableMemory.loadInt16(offset) // => 123
+  /// ```
+  public let storeInt16 : (offset : Nat64, value : Int16) -> () = Prim.multStableMemoryStoreInt16(id, offset, value);
+
+  /// Loads an `Int64` value from stable memory at the given `offset`.
+  /// Traps on an out-of-bounds access.
+  ///
+  /// Example:
+  /// ```motoko no-repl
+  /// let offset = 0;
+  /// let value = 123;
+  /// StableMemory.storeInt64(offset, value);
+  /// StableMemory.loadInt64(offset) // => 123
+  /// ```
+  public let loadInt64 : (offset : Nat64) -> Int64 = Prim.multStableMemoryLoadInt64(id, offset);
+
+  /// Stores an `Int64` value in stable memory at the given `offset`.
+  /// Traps on an out-of-bounds access.
+  ///
+  /// Example:
+  /// ```motoko no-repl
+  /// let offset = 0;
+  /// let value = 123;
+  /// StableMemory.storeInt64(offset, value);
+  /// StableMemory.loadInt64(offset) // => 123
+  /// ```
+  public let storeInt64 : (offset : Nat64, value : Int64) -> () = Prim.multStableMemoryStoreInt64(id, offset, value);
+
+  /// Loads a `Float` value from stable memory at the given `offset`.
+  /// Traps on an out-of-bounds access.
+  ///
+  /// Example:
+  /// ```motoko no-repl
+  /// let offset = 0;
+  /// let value = 1.25;
+  /// StableMemory.storeFloat(offset, value);
+  /// StableMemory.loadFloat(offset) // => 1.25
+  /// ```
+  public let loadFloat : (offset : Nat64) -> Float = Prim.multStableMemoryLoadFloat(id, offset);
+
+  /// Stores a `Float` value in stable memory at the given `offset`.
+  /// Traps on an out-of-bounds access.
+  ///
+  /// Example:
+  /// ```motoko no-repl
+  /// let offset = 0;
+  /// let value = 1.25;
+  /// StableMemory.storeFloat(offset, value);
+  /// StableMemory.loadFloat(offset) // => 1.25
+  /// ```
+  public let storeFloat : (offset : Nat64, value : Float) -> () = Prim.multStableMemoryStoreFloat(id, offset, value);
+
+  /// Load `size` bytes starting from `offset` as a `Blob`.
+  /// Traps on an out-of-bounds access.
+  ///
+  /// Example:
+  /// ```motoko no-repl
+  /// import Blob "mo:base/Blob";
+  ///
+  /// let offset = 0;
+  /// let value = Blob.fromArray([1, 2, 3]);
+  /// let size = value.size();
+  /// StableMemory.storeBlob(offset, value);
+  /// Blob.toArray(StableMemory.loadBlob(offset, size)) // => [1, 2, 3]
+  /// ```
+  public let loadBlob : (offset : Nat64, size : Nat) -> Blob = Prim.multStableMemoryLoadBlob(id, offset, size);
+
+  /// Write bytes of `blob` beginning at `offset`.
+  /// Traps on an out-of-bounds access.
+  ///
+  /// Example:
+  /// ```motoko no-repl
+  /// import Blob "mo:base/Blob";
+  ///
+  /// let offset = 0;
+  /// let value = Blob.fromArray([1, 2, 3]);
+  /// let size = value.size();
+  /// StableMemory.storeBlob(offset, value);
+  /// Blob.toArray(StableMemory.loadBlob(offset, size)) // => [1, 2, 3]
+  /// ```
+  public let storeBlob : (offset : Nat64, value : Blob) -> () = Prim.multStableMemoryStoreBlob(id, offset, value);
+
+}
+
+}

--- a/src/StableMemory.mo
+++ b/src/StableMemory.mo
@@ -8,14 +8,17 @@
 /// ## Multple memories
 ///
 /// This module provides a generalization over its predecessor (`ExperimentalStableMemory`),
-/// in that it offers a class with _multiple instances_, rather than a module with a single
+/// in that it offers a new _memory instance_ primitive type, 
+/// and the ability to have _multiple, dynamically-created instances_, rather than a 
+/// module with a single
 /// _monolitic_ (_shared, global_) instance, as before.
 ///
 /// The number of these instances may be limited by its implementation, but will provide
 /// up to 256 independent instances, initially 
 /// (matching and reusing a recent Rust library-version of the same feature).
 ///
-/// The API of the `class` provides the same low-level API as before, but where each instance
+/// The API for the memory instance primitive provides 
+/// the same low-level API as before, but where each instance
 /// can be used independently of the others.
 ///
 /// Reclaiming space from one to use in another is
@@ -60,9 +63,7 @@ import Prim "mo:⛔";
 
 module {
 
-  public class StableMemory () {
 
-  var id = Prim.multStableMemoryNew();
 
   /// Current size of the stable memory, in pages.
   /// Each page is 64KiB (65536 bytes).
@@ -77,7 +78,22 @@ module {
   /// let afterSize = StableMemory.size();
   /// afterSize - beforeSize // => 10
   /// ```
-  public let size : () -> (pages : Nat64) = Prim.multStableMemorySize id;
+  public new : () -> Memory = Prim.multStableMemoryNew();
+
+  /// Current size of the stable memory, in pages.
+  /// Each page is 64KiB (65536 bytes).
+  /// Initially `0`.
+  /// Preserved across upgrades, together with contents of allocated
+  /// stable memory.
+  ///
+  /// Example:
+  /// ```motoko no-repl
+  /// let beforeSize = StableMemory.size();
+  /// ignore StableMemory.grow(10);
+  /// let afterSize = StableMemory.size();
+  /// afterSize - beforeSize // => 10
+  /// ```
+  public let size : (m : Memory) -> (pages : Nat64) = Prim.multStableMemorySize m;
 
   /// Grow current `size` of stable memory by the given number of pages.
   /// Each page is 64KiB (65536 bytes).
@@ -98,7 +114,7 @@ module {
   /// let afterSize = StableMemory.size();
   /// afterSize - beforeSize // => 10
   /// ```
-  public let grow : (newPages : Nat64) -> (oldPages : Nat64) = Prim.multStableMemoryGrow(id, newPages);
+  public let grow : (m : Memory, newPages : Nat64) -> (oldPages : Nat64) = Prim.multStableMemoryGrow(m, newPages);
 
   /// Returns a query that, when called, returns the number of bytes of (real) IC stable memory that would be
   /// occupied by persisting its current stable variables before an upgrade.
@@ -132,7 +148,7 @@ module {
   /// StableMemory.storeNat32(offset, value);
   /// StableMemory.loadNat32(offset) // => 123
   /// ```
-  public let loadNat32 : (offset : Nat64) -> Nat32 = Prim.multStableMemoryLoadNat32(id, offset);
+  public let loadNat32 : (m : Memory, offset : Nat64) -> Nat32 = Prim.multStableMemoryLoadNat32(m, offset);
 
   /// Stores a `Nat32` value in stable memory at the given `offset`.
   /// Traps on an out-of-bounds access.
@@ -144,7 +160,7 @@ module {
   /// StableMemory.storeNat32(offset, value);
   /// StableMemory.loadNat32(offset) // => 123
   /// ```
-  public let storeNat32 : (offset : Nat64, value : Nat32) -> () = Prim.multStableMemoryStoreNat32(id, offset, value);
+  public let storeNat32 : (m : Memory, offset : Nat64, value : Nat32) -> () = Prim.multStableMemoryStoreNat32(m, offset, value);
 
   /// Loads a `Nat8` value from stable memory at the given `offset`.
   /// Traps on an out-of-bounds access.
@@ -156,7 +172,7 @@ module {
   /// StableMemory.storeNat8(offset, value);
   /// StableMemory.loadNat8(offset) // => 123
   /// ```
-  public let loadNat8 : (offset : Nat64) -> Nat8 = Prim.multStableMemoryLoadNat8(id, offset);
+  public let loadNat8 : (m : Memory, offset : Nat64) -> Nat8 = Prim.multStableMemoryLoadNat8(m, offset);
 
   /// Stores a `Nat8` value in stable memory at the given `offset`.
   /// Traps on an out-of-bounds access.
@@ -168,7 +184,7 @@ module {
   /// StableMemory.storeNat8(offset, value);
   /// StableMemory.loadNat8(offset) // => 123
   /// ```
-  public let storeNat8 : (offset : Nat64, value : Nat8) -> () = Prim.multStableMemoryStoreNat8(id, offset, value);
+  public let storeNat8 : (m : Memory, offset : Nat64, value : Nat8) -> () = Prim.multStableMemoryStoreNat8(m, offset, value);
 
   /// Loads a `Nat16` value from stable memory at the given `offset`.
   /// Traps on an out-of-bounds access.
@@ -180,7 +196,7 @@ module {
   /// StableMemory.storeNat16(offset, value);
   /// StableMemory.loadNat16(offset) // => 123
   /// ```
-  public let loadNat16 : (offset : Nat64) -> Nat16 = Prim.multStableMemoryLoadNat16(id, offset);
+  public let loadNat16 : (m : Memory, offset : Nat64) -> Nat16 = Prim.multStableMemoryLoadNat16(m, offset);
 
   /// Stores a `Nat16` value in stable memory at the given `offset`.
   /// Traps on an out-of-bounds access.
@@ -192,7 +208,7 @@ module {
   /// StableMemory.storeNat16(offset, value);
   /// StableMemory.loadNat16(offset) // => 123
   /// ```
-  public let storeNat16 : (offset : Nat64, value : Nat16) -> () = Prim.multStableMemoryStoreNat16(id, offset, value);
+  public let storeNat16 : (m : Memory, offset : Nat64, value : Nat16) -> () = Prim.multStableMemoryStoreNat16(m, offset, value);
 
   /// Loads a `Nat64` value from stable memory at the given `offset`.
   /// Traps on an out-of-bounds access.
@@ -204,7 +220,7 @@ module {
   /// StableMemory.storeNat64(offset, value);
   /// StableMemory.loadNat64(offset) // => 123
   /// ```
-  public let loadNat64 : (offset : Nat64) -> Nat64 = Prim.multStableMemoryLoadNat64(id, offset);
+  public let loadNat64 : (m : Memory, offset : Nat64) -> Nat64 = Prim.multStableMemoryLoadNat64(m, offset);
 
   /// Stores a `Nat64` value in stable memory at the given `offset`.
   /// Traps on an out-of-bounds access.
@@ -216,7 +232,7 @@ module {
   /// StableMemory.storeNat64(offset, value);
   /// StableMemory.loadNat64(offset) // => 123
   /// ```
-  public let storeNat64 : (offset : Nat64, value : Nat64) -> () = Prim.multStableMemoryStoreNat64(id, offset, value);
+  public let storeNat64 : (m : Memory, offset : Nat64, value : Nat64) -> () = Prim.multStableMemoryStoreNat64(m, offset, value);
 
   /// Loads an `Int32` value from stable memory at the given `offset`.
   /// Traps on an out-of-bounds access.
@@ -228,7 +244,7 @@ module {
   /// StableMemory.storeInt32(offset, value);
   /// StableMemory.loadInt32(offset) // => 123
   /// ```
-  public let loadInt32 : (offset : Nat64) -> Int32 = Prim.multStableMemoryLoadInt32(id, offset);
+  public let loadInt32 : (m : Memory, offset : Nat64) -> Int32 = Prim.multStableMemoryLoadInt32(m, offset);
 
   /// Stores an `Int32` value in stable memory at the given `offset`.
   /// Traps on an out-of-bounds access.
@@ -240,7 +256,7 @@ module {
   /// StableMemory.storeInt32(offset, value);
   /// StableMemory.loadInt32(offset) // => 123
   /// ```
-  public let storeInt32 : (offset : Nat64, value : Int32) -> () = Prim.multStableMemoryStoreInt32(id, offset, value);
+  public let storeInt32 : (m : Memory, offset : Nat64, value : Int32) -> () = Prim.multStableMemoryStoreInt32(m, offset, value);
 
   /// Loads an `Int8` value from stable memory at the given `offset`.
   /// Traps on an out-of-bounds access.
@@ -252,7 +268,7 @@ module {
   /// StableMemory.storeInt8(offset, value);
   /// StableMemory.loadInt8(offset) // => 123
   /// ```
-  public let loadInt8 : (offset : Nat64) -> Int8 = Prim.multStableMemoryLoadInt8(id, offset);
+  public let loadInt8 : (m : Memory, offset : Nat64) -> Int8 = Prim.multStableMemoryLoadInt8(m, offset);
 
   /// Stores an `Int8` value in stable memory at the given `offset`.
   /// Traps on an out-of-bounds access.
@@ -264,7 +280,7 @@ module {
   /// StableMemory.storeInt8(offset, value);
   /// StableMemory.loadInt8(offset) // => 123
   /// ```
-  public let storeInt8 : (offset : Nat64, value : Int8) -> () = Prim.multStableMemoryStoreInt8(id, offset, value);
+  public let storeInt8 : (m : Memory, offset : Nat64, value : Int8) -> () = Prim.multStableMemoryStoreInt8(m, offset, value);
 
   /// Loads an `Int16` value from stable memory at the given `offset`.
   /// Traps on an out-of-bounds access.
@@ -276,7 +292,7 @@ module {
   /// StableMemory.storeInt16(offset, value);
   /// StableMemory.loadInt16(offset) // => 123
   /// ```
-  public let loadInt16 : (offset : Nat64) -> Int16 = Prim.multStableMemoryLoadInt16(id, offset);
+  public let loadInt16 : (m : Memory, offset : Nat64) -> Int16 = Prim.multStableMemoryLoadInt16(m, offset);
 
   /// Stores an `Int16` value in stable memory at the given `offset`.
   /// Traps on an out-of-bounds access.
@@ -288,7 +304,7 @@ module {
   /// StableMemory.storeInt16(offset, value);
   /// StableMemory.loadInt16(offset) // => 123
   /// ```
-  public let storeInt16 : (offset : Nat64, value : Int16) -> () = Prim.multStableMemoryStoreInt16(id, offset, value);
+  public let storeInt16 : (m : Memory, offset : Nat64, value : Int16) -> () = Prim.multStableMemoryStoreInt16(m, offset, value);
 
   /// Loads an `Int64` value from stable memory at the given `offset`.
   /// Traps on an out-of-bounds access.
@@ -300,7 +316,7 @@ module {
   /// StableMemory.storeInt64(offset, value);
   /// StableMemory.loadInt64(offset) // => 123
   /// ```
-  public let loadInt64 : (offset : Nat64) -> Int64 = Prim.multStableMemoryLoadInt64(id, offset);
+  public let loadInt64 : (m : Memory, offset : Nat64) -> Int64 = Prim.multStableMemoryLoadInt64(m, offset);
 
   /// Stores an `Int64` value in stable memory at the given `offset`.
   /// Traps on an out-of-bounds access.
@@ -312,7 +328,7 @@ module {
   /// StableMemory.storeInt64(offset, value);
   /// StableMemory.loadInt64(offset) // => 123
   /// ```
-  public let storeInt64 : (offset : Nat64, value : Int64) -> () = Prim.multStableMemoryStoreInt64(id, offset, value);
+  public let storeInt64 : (m : Memory, offset : Nat64, value : Int64) -> () = Prim.multStableMemoryStoreInt64(m, offset, value);
 
   /// Loads a `Float` value from stable memory at the given `offset`.
   /// Traps on an out-of-bounds access.
@@ -324,7 +340,7 @@ module {
   /// StableMemory.storeFloat(offset, value);
   /// StableMemory.loadFloat(offset) // => 1.25
   /// ```
-  public let loadFloat : (offset : Nat64) -> Float = Prim.multStableMemoryLoadFloat(id, offset);
+  public let loadFloat : (m : Memory, offset : Nat64) -> Float = Prim.multStableMemoryLoadFloat(m, offset);
 
   /// Stores a `Float` value in stable memory at the given `offset`.
   /// Traps on an out-of-bounds access.
@@ -336,7 +352,7 @@ module {
   /// StableMemory.storeFloat(offset, value);
   /// StableMemory.loadFloat(offset) // => 1.25
   /// ```
-  public let storeFloat : (offset : Nat64, value : Float) -> () = Prim.multStableMemoryStoreFloat(id, offset, value);
+  public let storeFloat : (m : Memory, offset : Nat64, value : Float) -> () = Prim.multStableMemoryStoreFloat(m, offset, value);
 
   /// Load `size` bytes starting from `offset` as a `Blob`.
   /// Traps on an out-of-bounds access.
@@ -351,7 +367,7 @@ module {
   /// StableMemory.storeBlob(offset, value);
   /// Blob.toArray(StableMemory.loadBlob(offset, size)) // => [1, 2, 3]
   /// ```
-  public let loadBlob : (offset : Nat64, size : Nat) -> Blob = Prim.multStableMemoryLoadBlob(id, offset, size);
+  public let loadBlob : (m : Memory, offset : Nat64, size : Nat) -> Blob = Prim.multStableMemoryLoadBlob(m, offset, size);
 
   /// Write bytes of `blob` beginning at `offset`.
   /// Traps on an out-of-bounds access.
@@ -366,8 +382,6 @@ module {
   /// StableMemory.storeBlob(offset, value);
   /// Blob.toArray(StableMemory.loadBlob(offset, size)) // => [1, 2, 3]
   /// ```
-  public let storeBlob : (offset : Nat64, value : Blob) -> () = Prim.multStableMemoryStoreBlob(id, offset, value);
-
-}
+  public let storeBlob : (m : Memory, offset : Nat64, value : Blob) -> () = Prim.multStableMemoryStoreBlob(m, offset, value);
 
 }


### PR DESCRIPTION
Extends #516 with an example stable-region-based data structure, for "stable buffers" that 
 1. grow one blob at a time and 
 2. blob can reappear within a buffer later without taking more space (e.g., for storing elements in a system that recognizes duplicates somehow, which is outside of the scope of this structure for now).
 
 For simplicity, the structure only stores `Blob`s.  It could easily be extended to store other primitive types too.