### PR TITLE
Bump `mo-dev`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "devDependencies": {
         "fast-glob": "^3.2.12",
         "husky": "^8.0.2",
-        "mo-dev": "^0.7.2",
+        "mo-dev": "^0.9.0",
         "prettier": "^2.8.1",
         "prettier-plugin-motoko": "^0.2.3",
         "pretty-quick": "^3.1.3"
@@ -1215,9 +1215,9 @@
       }
     },
     "node_modules/mo-dev": {
-      "version": "0.7.2",
-      "resolved": "https://registry.npmjs.org/mo-dev/-/mo-dev-0.7.2.tgz",
-      "integrity": "sha512-/uGKBZKRbJA8a3CM0iPaiN3wVokCx10j/34JGgw6rrxdt9+6/HvxRgZClb5P3c0/6I2XV7cF/Wez31oMoWb6Lg==",
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/mo-dev/-/mo-dev-0.9.0.tgz",
+      "integrity": "sha512-L0b2hTgxfVrSfADK73KtUkvkiTXLjaQgRF7PF/x2IOIsSrvCfFyXpjXq6vobdsqV6dhZc5080fp8dJTewQ5DYQ==",
       "dev": true,
       "dependencies": {
         "@dfinity/candid": "0.15.4",
@@ -3080,9 +3080,9 @@
       }
     },
     "mo-dev": {
-      "version": "0.7.2",
-      "resolved": "https://registry.npmjs.org/mo-dev/-/mo-dev-0.7.2.tgz",
-      "integrity": "sha512-/uGKBZKRbJA8a3CM0iPaiN3wVokCx10j/34JGgw6rrxdt9+6/HvxRgZClb5P3c0/6I2XV7cF/Wez31oMoWb6Lg==",
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/mo-dev/-/mo-dev-0.9.0.tgz",
+      "integrity": "sha512-L0b2hTgxfVrSfADK73KtUkvkiTXLjaQgRF7PF/x2IOIsSrvCfFyXpjXq6vobdsqV6dhZc5080fp8dJTewQ5DYQ==",
       "dev": true,
       "requires": {
         "@dfinity/candid": "0.15.4",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   "devDependencies": {
     "fast-glob": "^3.2.12",
     "husky": "^8.0.2",
-    "mo-dev": "^0.7.2",
+    "mo-dev": "^0.9.0",
     "prettier": "^2.8.1",
     "prettier-plugin-motoko": "^0.2.3",
     "pretty-quick": "^3.1.3"


### PR DESCRIPTION
This PR updates `mo-dev` to enable running specific unit tests, e.g. `npm test -- -f Nat`. 

Note that this runs all test files starting with the given string, so `RBTrie` would run both `RBTrie.test.mo` and `RBTrieMore.test.mo`. Pass the full name (such as `RBTrie.test.mo`) for an exact match. 

It's also possible to specify multiple tests using multiple `-f` flags (`npm test -- -f Int -f Nat`).

We could eventually simplify this to `npm test Nat` if this ends up being used frequently enough. Currently leaving the unnamed arguments open in case there ends up being a need for subcommands in `mo-test`. 