### PR TITLE
Deprecate `TrieSet.mem()` in favor of `TrieSet.has()`

### DIFF
--- a/src/TrieSet.mo
+++ b/src/TrieSet.mo
@@ -104,8 +104,15 @@ module {
     return true;
   };
 
+  /// @deprecated: use `TrieSet.has()`
+  ///
   /// Test if a set contains a given element.
   public func mem<T>(s : Set<T>, x : T, xh : Hash, eq : (T, T) -> Bool) : Bool {
+    has(s, x, xh, eq)
+  };
+
+  /// Test if a set contains a given element.
+  public func has<T>(s : Set<T>, x : T, xh : Hash, eq : (T, T) -> Bool) : Bool {
     switch (Trie.find<T, ()>(s, { key = x; hash = xh }, eq)) {
       case null { false };
       case (?_) { true }

--- a/test/TrieSet.test.mo
+++ b/test/TrieSet.test.mo
@@ -16,8 +16,8 @@ let simpleTests = do {
     "TrieSet fromArray",
     [
       Suite.test(
-        "mem",
-        TrieSet.mem<Nat>(set1, 1, 1, Nat.equal),
+        "has",
+        TrieSet.has<Nat>(set1, 1, 1, Nat.equal),
         M.equals(T.bool true)
       ),
       Suite.test(


### PR DESCRIPTION
This PR deprecates `TrieSet.mem()` in favor of `TrieSet.has()` for consistency with the [base library design document](https://github.com/dfinity/motoko-base/blob/master/doc/design.md#containers). 

We could update the design document if this makes more sense, although I think `has` would be less ambiguous than `mem`, which could be misunderstood as having something to do with "memory" instead of "membership" for developers familiar with wording such as "has" / "contains" / "includes". 
