### PR TITLE
enable multi-memory, bulk-memory on wasmtime

### DIFF
--- a/test/Makefile
+++ b/test/Makefile
@@ -2,7 +2,7 @@
 
 STDLIB ?= ../src
 MOC ?= moc
-WASMTIME_OPTIONS = --disable-cache --enable-cranelift-nan-canonicalization
+WASMTIME_OPTIONS = --disable-cache --enable-cranelift-nan-canonicalization --wasm-features multi-memory,bulk-memory
 
 OUTDIR=_out
 


### PR DESCRIPTION
moc > 0.10.1 produced binares require additional flags to run on wasmtime, due their use of mutli-memory and bulk-memory instructions to emulate IC stable memory (and Motoko regions).

c.f. https://github.com/dfinity/motoko/pull/4256/
