### PR TITLE
Remove extra space from doc comment in `Blob.mo`

### DIFF
--- a/src/Blob.mo
+++ b/src/Blob.mo
@@ -17,7 +17,7 @@
 /// * `b.size() : Nat` returns the number of bytes in the blob `b`;
 /// * `b.vals() : Iter.Iter<Nat8>` returns an iterator to enumerate the bytes of the blob `b`.
 ///
-///  For example:
+/// For example:
 /// ```motoko include=import
 /// import Debug "mo:base/Debug";
 /// import Nat8 "mo:base/Nat8";


### PR DESCRIPTION
There is a rendering issue on https://mops.one/base/docs/Blob due to this extra space.

<img width="551" alt="image" src="https://github.com/dfinity/motoko-base/assets/21315978/ec036d00-94e5-4948-ae65-1df0bbbc3810">