### PR TITLE
Documentation Typo Fixes for Motoko Base Library Design Guide

### DIFF
--- a/doc/design.md
+++ b/doc/design.md
@@ -96,7 +96,7 @@
 
   - `put`: write to container (overwrites if entry already exists)
 
-    Note: Choosing this instead of `set` since it works better for containers like sets and is visually easier to distinghuish from `get`.
+    Note: Choosing this instead of `set` since it works better for containers like sets and is visually easier to distinguish from `get`.
 
   - `delete`: remove from collection (does nothing if not present)
 
@@ -116,7 +116,7 @@
 
   - `keys`: iterator over keys of collection (same as `vals` for sets)
 
-  - `vals`: iterator over valus of collection
+  - `vals`: iterator over values of collection
 
   - `entries`: iterator over (key, value) pairs
 
@@ -160,7 +160,7 @@
 
 ## Classes
 
-* Abstract data types need to be provided as classes, since that currently is the only means for encapsultion.
+* Abstract data types need to be provided as classes, since that currently is the only means for encapsulation.
   In particular, use classes for any type where it is desirable to maintain the liberty to change its representation in the future --
   a library type that is transparent and happens to be sharable by accident can never again be changed, since clients might already use it in a shared context.
 


### PR DESCRIPTION
#### Overview
This pull request addresses several typographical errors in the Motoko Base Library's design documentation. Ensuring accuracy and clarity in our documentation is vital for effective communication among developers and for maintaining the high standard of our project.

#### Changes Made
- Corrected 'encapsultion' to 'encapsulation' in the Classes section. This change clarifies the intended meaning, emphasizing the importance of encapsulation in abstract data types.
- Updated 'valus' to 'values' in the Containers section under the description of the `keys` iterator. This fix ensures that the documentation accurately represents the functionality of the iterator.
- Fixed 'distinghuish' to 'distinguish' in the Containers section. This modification aids in presenting a clearer rationale for the choice of the `put` method name over `set`, especially in the context of sets and other containers.

#### Impact
These changes, while minor, contribute to the overall readability and professionalism of our documentation. They do not affect the actual functionality of the codebase but are essential for consistent and error-free documentation.

#### Additional Notes
While reviewing the documentation, I've noticed a few areas where further clarification might be beneficial. I plan to propose additional updates in subsequent pull requests to continuously improve the documentation.