### PR TITLE
feat: add Result.toUpper/Result.fromUpper to facilitate interop with common IC canisters using upppercased result variants.

### DIFF
--- a/src/Result.mo
+++ b/src/Result.mo
@@ -206,4 +206,28 @@ module {
     }
   };
 
+  /// Converts an upper cased #Ok, #Err result type into a lowercased #ok, #err result type.
+  /// In Rust, the convention is to use `#Ok` and `#Err` as the variants of the Result type,
+  /// but in Motoko, we use `#ok` and `#err` instead.
+  public func toLowerCasedResult<Ok, Err>(
+    result : { #Ok: Ok; #Err: Err }
+  ) : Result<Ok, Err> {
+    switch result {
+      case (#Ok(ok)) { #ok(ok) };
+      case (#Err(err)) { #err(err) }
+    }
+  };
+
+  /// Converts a lower cased #ok, #err result type into an upper cased #Ok, #Err result type.
+  /// In Rust, the convention is to use `#Ok` and `#Err` as the variants of the Result type,
+  /// but in Motoko, we use `#ok` and `#err` instead.
+  public func toUpperCasedResult<Ok, Err>(
+    result : Result<Ok, Err>
+  ) : { #Ok: Ok; #Err: Err } {
+    switch result {
+      case (#ok(ok)) { #Ok(ok) };
+      case (#err(err)) { #Err(err) }
+    }
+  };
+
 }

--- a/src/Result.mo
+++ b/src/Result.mo
@@ -206,7 +206,7 @@ module {
     }
   };
 
-  /// Converts an upper cased #Ok, #Err result type into a lowercased #ok, #err result type.
+  /// Converts an upper cased `#Ok`, `#Err` result type into a lowercased `#ok`, `#err` result type.
   /// On the IC, a common convention is to use `#Ok` and `#Err` as the variants of a result type,
   /// but in Motoko, we use `#ok` and `#err` instead.
   public func fromUpper<Ok, Err>(

--- a/src/Result.mo
+++ b/src/Result.mo
@@ -207,9 +207,9 @@ module {
   };
 
   /// Converts an upper cased #Ok, #Err result type into a lowercased #ok, #err result type.
-  /// In Rust, the convention is to use `#Ok` and `#Err` as the variants of the Result type,
+  /// On the IC, a common convention is to use `#Ok` and `#Err` as the variants of a result type,
   /// but in Motoko, we use `#ok` and `#err` instead.
-  public func toLowerCasedResult<Ok, Err>(
+  public func fromUpper<Ok, Err>(
     result : { #Ok: Ok; #Err: Err }
   ) : Result<Ok, Err> {
     switch result {
@@ -218,10 +218,10 @@ module {
     }
   };
 
-  /// Converts a lower cased #ok, #err result type into an upper cased #Ok, #Err result type.
-  /// In Rust, the convention is to use `#Ok` and `#Err` as the variants of the Result type,
+  /// Converts a lower cased `#ok`, `#err` result type into an upper cased `#Ok`, `#Err` result type.
+  /// On the IC, a common convention is to use `#Ok` and `#Err` as the variants of a result type,
   /// but in Motoko, we use `#ok` and `#err` instead.
-  public func toUpperCasedResult<Ok, Err>(
+  public func toUpper<Ok, Err>(
     result : Result<Ok, Err>
   ) : { #Ok: Ok; #Err: Err } {
     switch result {


### PR DESCRIPTION
Low hanging solution for https://dx.internetcomputer.org/topic/166

I found myself using this a fair amount when integrating with the new Cycles Ledger, and see it in a fair number of places that integrate with protocol canisters that were built in Rust.