### PR TITLE
feat: add `Array.concat` and CI sanity check for base library compiler warnings

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "hasInstallScript": true,
       "license": "ISC",
       "devDependencies": {
+        "execa": "^4.1.0",
         "fast-glob": "^3.2.12",
         "husky": "^8.0.2",
         "ic-mops": "^0.39.2",

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
   },
   "homepage": "https://github.com/dfinity/motoko-base#readme",
   "devDependencies": {
+    "execa": "^4.1.0",
     "fast-glob": "^3.2.12",
     "husky": "^8.0.2",
     "ic-mops": "^0.39.2",

--- a/src/Array.mo
+++ b/src/Array.mo
@@ -188,7 +188,17 @@ module {
     )
   };
 
-  // @deprecated Please use `Array.concat` or `Buffer.append` in place of `Array.append`.
+  /// Create a new array by appending the values of `array1` and `array2`.
+  /// @deprecated `Array.append` copies its arguments and has linear complexity. To silence this warning, consider using `Array.concat` instead.
+  /// 
+  /// ```motoko include=import
+  /// let array1 = [1, 2, 3];
+  /// let array2 = [4, 5, 6];
+  /// Array.append<Nat>(array1, array2)
+  /// ```
+  /// Runtime: O(size1 + size2)
+  ///
+  /// Space: O(size1 + size2)
   public func append<X>(array1 : [X], array2 : [X]) : [X] {
     concat(array1, array2)
   };

--- a/src/Array.mo
+++ b/src/Array.mo
@@ -162,18 +162,18 @@ module {
   };
 
   /// Create a new array by appending the values of `array1` and `array2`.
-  /// @deprecated `Array.append` copies its arguments and has linear complexity;
+  /// Note that `Array.concat` copies its arguments and has linear complexity;
   /// when used in a loop, consider using a `Buffer`, and `Buffer.append`, instead.
   ///
   /// ```motoko include=import
   /// let array1 = [1, 2, 3];
   /// let array2 = [4, 5, 6];
-  /// Array.append<Nat>(array1, array2)
+  /// Array.concat<Nat>(array1, array2)
   /// ```
   /// Runtime: O(size1 + size2)
   ///
   /// Space: O(size1 + size2)
-  public func append<X>(array1 : [X], array2 : [X]) : [X] {
+  public func concat<X>(array1 : [X], array2 : [X]) : [X] {
     let size1 = array1.size();
     let size2 = array2.size();
     Prim.Array_tabulate<X>(
@@ -186,6 +186,11 @@ module {
         }
       }
     )
+  };
+
+  // @deprecated Please use `Array.concat` or `Buffer.append` in place of `Array.append`.
+  public func append<X>(array1 : [X], array2 : [X]) : [X] {
+    concat(array1, array2)
   };
 
   // FIXME this example stack overflows. Should test with new implementation of sortInPlace

--- a/src/Principal.mo
+++ b/src/Principal.mo
@@ -77,7 +77,7 @@ module {
     // hashBlob is a CRC32 implementation
     let crc32Bytes = nat32ToByteArray(Prim.hashBlob hashSum);
 
-    Blob.fromArray(Array.append(crc32Bytes, Blob.toArray(hashSum)))
+    Blob.fromArray(Array.concat(crc32Bytes, Blob.toArray(hashSum)))
   };
 
   /// Convert a `Principal` to its `Blob` (bytes) representation.

--- a/test/js/importAll.js
+++ b/test/js/importAll.js
@@ -2,26 +2,42 @@
 
 // Generate a test file named `ImportAll.test.mo`
 
-const { resolve } = require("path");
+const { join, resolve } = require("path");
 const { existsSync, writeFileSync, mkdirSync } = require("fs");
 const glob = require("fast-glob");
+const execa = require("execa");
 
 const outDir = resolve(__dirname, "../generated");
 if (!existsSync(outDir)) {
   mkdirSync(outDir);
 }
 
-const outFile = resolve(outDir, "ImportAll.test.mo");
+const baseFilename = "ImportAll.test";
+const outFile = resolve(outDir, `${baseFilename}.mo`);
 
 const moFiles = glob.sync("**/*.mo", { cwd: resolve(__dirname, "../../src") });
 if (moFiles.length === 0) {
   throw new Error("Expected at least one Motoko file in `src` directory");
 }
-const source = moFiles
-  .map((f) => {
-    const name = f.replace(/\.mo$/, "");
-    return `import Import_${name} "../../src/${name}";\n`;
-  })
-  .join("");
+const source =
+  moFiles
+    .map((f) => {
+      const name = f.replace(/\.mo$/, "");
+      return `import _${name} "../../src/${name}";\n`;
+    })
+    .join("") + "\nactor {};";
 
 writeFileSync(outFile, source, "utf8");
+
+(async () => {
+  const mocPath = process.env.DFX_MOC_PATH || "moc";
+  const wasmFile = join(outDir, `${baseFilename}.wasm`);
+  const { stdout, stderr } = await execa(mocPath, [outFile, "-o", wasmFile], {
+    stdio: "pipe",
+    encoding: "utf8",
+  });
+  console.log(stdout);
+  if (stderr.trim()) {
+    throw new Error(`Warning message while importing modules:\n${stderr}`);
+  }
+})();

--- a/test/js/importAll.js
+++ b/test/js/importAll.js
@@ -19,23 +19,26 @@ const moFiles = glob.sync("**/*.mo", { cwd: resolve(__dirname, "../../src") });
 if (moFiles.length === 0) {
   throw new Error("Expected at least one Motoko file in `src` directory");
 }
-const source =
-  moFiles
-    .map((f) => {
-      const name = f.replace(/\.mo$/, "");
-      return `import _${name} "../../src/${name}";\n`;
-    })
-    .join("") + "\nactor {};";
+const source = moFiles
+  .map((f) => {
+    const name = f.replace(/\.mo$/, "");
+    return `import _${name} "../../src/${name}";\n`;
+  })
+  .join("");
 
 writeFileSync(outFile, source, "utf8");
 
 (async () => {
   const mocPath = process.env.DFX_MOC_PATH || "moc";
   const wasmFile = join(outDir, `${baseFilename}.wasm`);
-  const { stdout, stderr } = await execa(mocPath, [outFile, "-o", wasmFile], {
-    stdio: "pipe",
-    encoding: "utf8",
-  });
+  const { stdout, stderr } = await execa(
+    mocPath,
+    [outFile, "-wasi-system-api", "-o", wasmFile],
+    {
+      stdio: "pipe",
+      encoding: "utf8",
+    }
+  );
   console.log(stdout);
   if (stderr.trim()) {
     throw new Error(`Warning message while importing modules:\n${stderr}`);


### PR DESCRIPTION
This PR addresses a compiler warning from using `Array.append` in the `Principal.toLedgerAccount` function. I also updated the CI to detect unintended compiler warnings when importing any base library module.