### PR TITLE
doc: document Trie/TrieSet/TrieMap collision limits

### DIFF
--- a/src/Trie.mo
+++ b/src/Trie.mo
@@ -22,7 +22,7 @@
 /// The `put`, `get` and `remove` operations work over `Key` records,
 /// which group the hash of the key with its non-hash key value.
 ///
-/// LIMITATIONS: this data structure allows at most MAX_LEAF_SIZE=8 hash collisions:
+/// LIMITATIONS: This data structure allows at most MAX_LEAF_SIZE=8 hash collisions:
 /// attempts to insert more than 8 keys (whether directly via `put` or indirectly via other operations) with the same hash value will trap.
 ///
 /// Example:

--- a/src/Trie.mo
+++ b/src/Trie.mo
@@ -23,7 +23,7 @@
 /// which group the hash of the key with its non-hash key value.
 ///
 /// LIMITATIONS: This data structure allows at most MAX_LEAF_SIZE=8 hash collisions:
-/// attempts to insert more than 8 keys (whether directly via `put` or indirectly via other operations) with the same hash value will trap.
+/// attempts to insert more than MAX_LEAF_SIZE keys (whether directly via `put` or indirectly via other operations) with the same hash value will trap.
 ///
 /// Example:
 /// ```motoko

--- a/src/Trie.mo
+++ b/src/Trie.mo
@@ -22,6 +22,9 @@
 /// The `put`, `get` and `remove` operations work over `Key` records,
 /// which group the hash of the key with its non-hash key value.
 ///
+/// LIMITATIONS: this data structure allows at most MAX_LEAF_SIZE=8 hash collisions:
+/// attempts to insert more than 8 keys (whether directly via `put` or indirectly via other operations) with the same hash value will trap.
+///
 /// Example:
 /// ```motoko
 /// import Trie "mo:base/Trie";

--- a/src/Trie.mo
+++ b/src/Trie.mo
@@ -1,14 +1,7 @@
 /// Functional key-value hash maps.
 ///
-/// Functional maps (and sets) whose representation is "canonical", and
-/// independent of operation history (unlike other popular search trees).
-///
-/// The representation we use here comes from Section 6 of ["Incremental computation via function caching", Pugh & Teitelbaum](https://dl.acm.org/citation.cfm?id=75305).
-///
-/// ## <a name="overview"></a>User's overview
-///
-/// This module provides an applicative (functional) hash map.
-/// Notably, each `put` produces a **new trie _and value being replaced, if any_**.
+/// This module provides an applicative (functional) hash map, called a trie.
+/// Notably, each operation produces a new trie rather than destructively updating an existing trie.
 ///
 /// Those looking for a more familiar (imperative,
 /// object-oriented) hash map should consider `TrieMap` or `HashMap` instead.
@@ -24,6 +17,9 @@
 ///
 /// LIMITATIONS: This data structure allows at most MAX_LEAF_SIZE=8 hash collisions:
 /// attempts to insert more than MAX_LEAF_SIZE keys (whether directly via `put` or indirectly via other operations) with the same hash value will trap.
+///
+/// CREDITS: Based on Section 6 of ["Incremental computation via function caching", Pugh & Teitelbaum](https://dl.acm.org/citation.cfm?id=75305).
+///
 ///
 /// Example:
 /// ```motoko
@@ -170,8 +166,8 @@ module {
   };
 
   /// Branch nodes of the trie discriminate on a bit position of the keys' hashes.
-  /// we never store this bitpos; rather,
-  /// we enforce a style where this position is always known from context.
+  /// This bit position is not stored in the branch but determined from
+  /// the context of the branch.
   public type Branch<K, V> = {
     size : Nat;
     left : Trie<K, V>;

--- a/src/TrieMap.mo
+++ b/src/TrieMap.mo
@@ -3,6 +3,11 @@
 /// module. The trie is a binary tree in which the position of elements in the
 /// tree are determined using the hash of the elements.
 ///
+/// LIMITATIONS: this data structure allows at most MAX_LEAF_SIZE=8 hash collisions:
+/// attempts to insert more than MAX_LEAF_SIZE keys (whether directly via `put` or indirectly via other operations) with the same hash value will trap.
+/// This limitation is inherited from the underlying `Trie` data structure.
+///
+///
 /// Note: The `class` `TrieMap` exposes the same interface as `HashMap`.
 ///
 /// Creating a map:

--- a/src/TrieMap.mo
+++ b/src/TrieMap.mo
@@ -3,7 +3,7 @@
 /// module. The trie is a binary tree in which the position of elements in the
 /// tree are determined using the hash of the elements.
 ///
-/// LIMITATIONS: this data structure allows at most MAX_LEAF_SIZE=8 hash collisions:
+/// LIMITATIONS: This data structure allows at most MAX_LEAF_SIZE=8 hash collisions:
 /// attempts to insert more than MAX_LEAF_SIZE keys (whether directly via `put` or indirectly via other operations) with the same hash value will trap.
 /// This limitation is inherited from the underlying `Trie` data structure.
 ///

--- a/src/TrieSet.mo
+++ b/src/TrieSet.mo
@@ -2,6 +2,10 @@
 ///
 /// Sets are partial maps from element type to unit type,
 /// i.e., the partial map represents the set with its domain.
+///
+/// LIMITATIONS: This data structure allows at most MAX_LEAF_SIZE=8 hash collisions:
+/// attempts to insert more than MAX_LEAF_SIZE elements (whether directly via `put` or indirectly via other operations) with the same hash value will trap.
+/// This limitation is inherited from the underlying `Trie` data structure.
 
 // TODO-Matthew:
 // ---------------


### PR DESCRIPTION
Clarify the limits and claims

The claim about trie representation being canonical does not hold if the hash has collisions and requires non-singleton assoc lists at the leaves. I'm also not sure it's preserved by deletion.