### PR TITLE
feat: add `Error.isRetryPossible`, a predicate for non-fatal messaging errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.14.3
+
+* Added `retriable : Error -> Bool` to `Error` (#692).
+
 ## 0.14.2
 
 (nothing)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 0.14.3
 
-* Added `isRetriable : Error -> Bool` to `Error` (#692).
+* Added `isRetryPossible : Error -> Bool` to `Error` (#692).
 
 ## 0.14.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 0.14.3
 
-* Added `retriable : Error -> Bool` to `Error` (#692).
+* Added `isRetriable : Error -> Bool` to `Error` (#692).
 
 ## 0.14.2
 

--- a/src/Error.mo
+++ b/src/Error.mo
@@ -60,11 +60,26 @@ module {
   /// Example:
   /// ```motoko
   /// import Error "mo:base/Error";
-  /// import Debug "mo:base/Debug";
   ///
   /// let error = Error.reject("Example error");
   /// Error.message(error) // "Example error"
   /// ```
   public let message : (error : Error) -> Text = Prim.errorMessage;
+
+  /// Returns whether retrying to send a message may result in success.
+  ///
+  /// Example:
+  /// ```motoko
+  /// import { message; retriable } "mo:base/Error";
+  /// import { print } "mo:base/Debug";
+  ///
+  /// try await (with timeout = 3) Actor.call(arg)
+  /// catch e { if (retriable e) print(message e) }
+  /// ```
+  public func retriable(error : Error) : Bool =
+    switch (code error) {
+      case (#system_unknown or #system_transient) true;
+      case _ false
+    };
 
 }

--- a/src/Error.mo
+++ b/src/Error.mo
@@ -70,13 +70,13 @@ module {
   ///
   /// Example:
   /// ```motoko
-  /// import { message; retriable } "mo:base/Error";
+  /// import { message; isRetriable } "mo:base/Error";
   /// import { print } "mo:base/Debug";
   ///
   /// try await (with timeout = 3) Actor.call(arg)
-  /// catch e { if (retriable e) print(message e) }
+  /// catch e { if (isRetriable e) print(message e) }
   /// ```
-  public func retriable(error : Error) : Bool =
+  public func isRetriable(error : Error) : Bool =
     switch (code error) {
       case (#system_unknown or #system_transient) true;
       case _ false

--- a/src/Error.mo
+++ b/src/Error.mo
@@ -70,13 +70,13 @@ module {
   ///
   /// Example:
   /// ```motoko
-  /// import { message; isRetriable } "mo:base/Error";
+  /// import { message; isRetryPossible } "mo:base/Error";
   /// import { print } "mo:base/Debug";
   ///
   /// try await (with timeout = 3) Actor.call(arg)
-  /// catch e { if (isRetriable e) print(message e) }
+  /// catch e { if (isRetryPossible e) print(message e) }
   /// ```
-  public func isRetriable(error : Error) : Bool =
+  public func isRetryPossible(error : Error) : Bool =
     switch (code error) {
       case (#system_unknown or #system_transient) true;
       case _ false


### PR DESCRIPTION
This predicate categorises `Error`s based on the potential success when resending the message. It _doesn't_ consider semantic issues like idempotence or such.