### PR TITLE
feat: make `replyDeadline` an optional return type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 ## 0.14.3
 
 * Added `isRetryPossible : Error -> Bool` to `Error` (#692).
+* Made `ExperimentalInternetComputer.replyDeadline` to return
+  an optional return type (#693).
 
 ## 0.14.2
 

--- a/src/ExperimentalInternetComputer.mo
+++ b/src/ExperimentalInternetComputer.mo
@@ -84,7 +84,10 @@ module {
 
   /// Returns the time (in nanoseconds from the epoch start) by when the update message should
   /// reply to the best effort message so that it can be received by the requesting canister.
-  /// Queries and non-best-effort update messages return zero.
-  public func replyDeadline() : Nat = Prim.nat64ToNat(Prim.replyDeadline());
+  /// Queries and unbounded-time update messages return null.
+  public func replyDeadline() : ?Nat {
+    let raw = Prim.replyDeadline();
+    if (raw == 0) null else ?Prim.nat64ToNat(raw)
+  };
 
 }


### PR DESCRIPTION
(backported API fix from `new-base` 0.2.0)

This is a mildly breaking change, as the feature is not fully on the subnets yet.