### PR TITLE
Add Iter.slice function

### DIFF
--- a/src/Iter.mo
+++ b/src/Iter.mo
@@ -171,17 +171,45 @@ module {
     object {
       public func next() : ?A {
         if (aEnded) {
-          return b.next();
+          return b.next()
         };
         switch (a.next()) {
           case (?x) ?x;
           case (null) {
             aEnded := true;
-            b.next();
-          };
-        };
-      };
+            b.next()
+          }
+        }
+      }
+    }
+  };
+
+  /// Consumes an iterator and returns a new iterator which produces a part (page) of the given iterator.
+  /// ```motoko
+  /// import Iter "mo:base/Iter";
+  /// let iter = Iter.range(1, 10);
+  /// let page = Iter.slice(iter, 3, 5);
+  /// assert(?6 == page.next());
+  /// assert(?7 == page.next());
+  /// assert(?8 == page.next());
+  /// assert(null == page.next());
+  /// ```
+  public func slice<A>(xs : Iter<A>, limit : Nat, skip : Nat) : Iter<A> {
+    var i = 0;
+    while (i < skip) {
+      let ?_ = xs.next() else return { next = func() = null };
+      i += 1
     };
+    i := 0;
+    object {
+      public func next() : ?A {
+        if (i == limit) {
+          return null
+        };
+        i += 1;
+        xs.next()
+      }
+    }
   };
 
   /// Creates an iterator that produces the elements of an Array in ascending index order.


### PR DESCRIPTION
### Summary
This PR introduces a new utility function `Iter.slice`, which enables extracting a portion (or "page") of items from a given iterator and returning it as a new iterator.

### Use Cases
- Implementing pagination over iterators (e.g., for query interfaces)

- Splitting long iterators into smaller chunks with a specified maximum number of items

### Additional Changes
Minor code formatting improvements for consistency and readability