### PR TITLE
chore: doc and formatting fixes

### DIFF
--- a/src/Array.mo
+++ b/src/Array.mo
@@ -1,24 +1,24 @@
 /// Provides extended utility functions on Arrays.
-/// 
+///
 /// :::warning
-/// 
+///
 /// If you are looking for a list that can grow and shrink in size,
 /// it is recommended you use either the `Buffer` or `List` data structure for
 /// those purposes.
-/// 
+///
 /// :::
-/// 
+///
 /// :::note Assumptions
-/// 
+///
 /// Runtime and space complexity assumes that `generator`, `equal`, and other functions execute in `O(1)` time and space.
 /// :::
-/// 
+///
 /// Import from the base library to use this module.
-/// 
+///
 /// ```motoko name=import
 /// import Array "mo:base/Array";
 /// ```
-/// 
+///
 
 import I "IterType";
 import Option "Option";
@@ -298,7 +298,7 @@ module {
   };
 
   /// Creates a new array by reversing the order of elements in `array`.
-  /// 
+  ///
   /// ```motoko include=import
   /// let array = [10, 11, 12];
   /// Array.reverse(array)
@@ -315,7 +315,7 @@ module {
   /// Creates a new array by applying `f` to each element in `array`. `f` "maps"
   /// each element it is applied to of type `X` to an element of type `Y`.
   /// Retains original ordering of elements.
-  /// 
+  ///
   /// ```motoko include=import
   /// let array = [0, 1, 2, 3];
   /// Array.map<Nat, Nat>(array, func x = x * 3)
@@ -652,7 +652,7 @@ module {
   ///
   /// Alternatively, you can use `array.size()` to achieve the same result. See the example below.
   /// :::
-  /// 
+  ///
   /// ```motoko include=import
   /// let array = [10, 11, 12];
   /// var sum = 0;
@@ -733,7 +733,7 @@ module {
   };
 
   /// Returns the index of the first `element` in the `array`.
-  /// 
+  ///
   /// ```motoko include=import
   /// import Char "mo:base/Char";
   /// let array = ['c', 'o', 'f', 'f', 'e', 'e'];

--- a/src/AssocList.mo
+++ b/src/AssocList.mo
@@ -1,12 +1,12 @@
 /// Map implemented as a linked-list of key-value pairs ("Associations").
-/// 
+///
 /// :::note Usage context
-/// 
+///
 /// This map implementation primarily serves as the underlying bucket structure for other map types. In most cases, those higher-level map implementations are easier to use.
 /// :::
-/// 
+///
 /// :::note Assumptions
-/// 
+///
 /// Runtime and space complexity assumes that `combine`, `equal`, and other functions execute in `O(1)` time and space.
 /// :::
 
@@ -14,15 +14,15 @@ import List "List";
 
 module {
   /// Import from the base library to use this module.
-  /// 
+  ///
   /// ```motoko name=import
   /// import AssocList "mo:base/AssocList";
   /// import List "mo:base/List";
   /// import Nat "mo:base/Nat";
-  /// 
+  ///
   /// type AssocList<K, V> = AssocList.AssocList<K, V>;
   /// ```
-  /// 
+  ///
   /// Initialize an empty map using an empty list.
   /// ```motoko name=initialize include=import
   /// var map : AssocList<Nat, Nat> = List.nil(); // Empty list as an empty map
@@ -33,19 +33,19 @@ module {
 
   /// Find the value associated with key `key`, or `null` if no such key exists.
   /// Compares keys using the provided function `equal`.
-  /// 
+  ///
   /// Example:
-  /// 
+  ///
   /// ```motoko include=import,initialize
   /// // Create map = [(0, 10), (1, 11), (2, 12)]
   /// map := AssocList.replace(map, 0, Nat.equal, ?10).0;
   /// map := AssocList.replace(map, 1, Nat.equal, ?11).0;
   /// map := AssocList.replace(map, 2, Nat.equal, ?12).0;
-  /// 
+  ///
   /// // Find value associated with key 1
   /// AssocList.find(map, 1, Nat.equal)
   /// ```
-  /// 
+  ///
   /// | Runtime   | Space     |
   /// |-----------|-----------|
   /// | `O(size)` | `O(1)` |
@@ -70,9 +70,9 @@ module {
   /// was already present. Returns the old value in an option if it existed and
   /// `null` otherwise, as well as the new map. Compares keys using the provided
   /// function `equal`.
-  /// 
+  ///
   /// Example:
-  /// 
+  ///
   /// ```motoko include=import,initialize
   /// // Add three entries to the map
   /// // map = [(0, 10), (1, 11), (2, 12)]
@@ -81,10 +81,10 @@ module {
   /// map := AssocList.replace(map, 2, Nat.equal, ?12).0;
   /// // Override second entry
   /// map := AssocList.replace(map, 1, Nat.equal, ?21).0;
-  /// 
+  ///
   /// List.toArray(map)
   /// ```
-  /// 
+  ///
   /// | Runtime   | Space     |
   /// |-----------|-----------|
   /// | `O(size)` | `O(size)` |
@@ -124,26 +124,26 @@ module {
   /// Produces a new map containing all entries from `map1` whose keys are not
   /// contained in `map2`. The "extra" entries in `map2` are ignored. Compares
   /// keys using the provided function `equal`.
-  /// 
+  ///
   /// Example:
-  /// 
+  ///
   /// ```motoko include=import,initialize
   /// // Create map1 = [(0, 10), (1, 11), (2, 12)]
   /// var map1 : AssocList<Nat, Nat> = null;
   /// map1 := AssocList.replace(map1, 0, Nat.equal, ?10).0;
   /// map1 := AssocList.replace(map1, 1, Nat.equal, ?11).0;
   /// map1 := AssocList.replace(map1, 2, Nat.equal, ?12).0;
-  /// 
+  ///
   /// // Create map2 = [(2, 12), (3, 13)]
   /// var map2 : AssocList<Nat, Nat> = null;
   /// map2 := AssocList.replace(map2, 2, Nat.equal, ?12).0;
   /// map2 := AssocList.replace(map2, 3, Nat.equal, ?13).0;
-  /// 
+  ///
   /// // Take the difference
   /// let newMap = AssocList.diff(map1, map2, Nat.equal);
   /// List.toArray(newMap)
   /// ```
-  /// 
+  ///
   /// | Runtime   | Space     |
   /// |-----------|-----------|
   /// | `O(size1 * size2)` | `O(1)` |
@@ -166,10 +166,7 @@ module {
     rec(map1)
   };
 
-  /// :::warning Deprecated function
-  /// 
-  /// `mapAppend` is deprecated and may be removed in future versions. Consider using an alternative approach.
-  /// :::
+  /// @deprecated `mapAppend` is deprecated and may be removed in future versions. Consider using an alternative approach.
   public func mapAppend<K, V, W, X>(
     map1 : AssocList<K, V>,
     map2 : AssocList<K, W>,
@@ -188,23 +185,23 @@ module {
   /// Produces a new map by mapping entries in `map1` and `map2` using `f` and
   /// concatenating the results. Assumes that there are no collisions between
   /// keys in `map1` and `map2`.
-  /// 
+  ///
   /// Example:
-  /// 
+  ///
   /// ```motoko include=import,initialize
   /// import { trap } "mo:base/Debug";
-  /// 
+  ///
   /// // Create map1 = [(0, 10), (1, 11), (2, 12)]
   /// var map1 : AssocList<Nat, Nat> = null;
   /// map1 := AssocList.replace(map1, 0, Nat.equal, ?10).0;
   /// map1 := AssocList.replace(map1, 1, Nat.equal, ?11).0;
   /// map1 := AssocList.replace(map1, 2, Nat.equal, ?12).0;
-  /// 
+  ///
   /// // Create map2 = [(4, "14"), (3, "13")]
   /// var map2 : AssocList<Nat, Text> = null;
   /// map2 := AssocList.replace(map2, 4, Nat.equal, ?"14").0;
   /// map2 := AssocList.replace(map2, 3, Nat.equal, ?"13").0;
-  /// 
+  ///
   /// // Map and append the two AssocLists
   /// let newMap =
   ///  AssocList.disjDisjoint<Nat, Nat, Text, Text>(
@@ -224,10 +221,10 @@ module {
   ///      }
   ///    }
   ///  );
-  /// 
+  ///
   /// List.toArray(newMap)
   /// ```
-  /// 
+  ///
   /// | Runtime   | Space     |
   /// |-----------|-----------|
   /// | `O(size1 + size2)` | `O(size1 + size2)` |
@@ -243,29 +240,29 @@ module {
   /// Creates a new map by merging entries from `map1` and `map2`, and mapping
   /// them using `combine`. `combine` is also used to combine the values of colliding keys.
   /// Keys are compared using the given `equal` function.
-  /// 
+  ///
   /// :::note Behavior guarantee
-  /// 
+  ///
   /// `combine` will never be applied to `(null, null)`.
-  /// 
+  ///
   /// :::
-  /// 
+  ///
   /// Example:
-  /// 
+  ///
   /// ```motoko include=import,initialize
   /// import { trap } "mo:base/Debug";
-  /// 
+  ///
   /// // Create map1 = [(0, 10), (1, 11), (2, 12)]
   /// var map1 : AssocList<Nat, Nat> = null;
   /// map1 := AssocList.replace(map1, 0, Nat.equal, ?10).0;
   /// map1 := AssocList.replace(map1, 1, Nat.equal, ?11).0;
   /// map1 := AssocList.replace(map1, 2, Nat.equal, ?12).0;
-  /// 
+  ///
   /// // Create map2 = [(2, 12), (3, 13)]
   /// var map2 : AssocList<Nat, Nat> = null;
   /// map2 := AssocList.replace(map2, 2, Nat.equal, ?12).0;
   /// map2 := AssocList.replace(map2, 3, Nat.equal, ?13).0;
-  /// 
+  ///
   /// // Merge the two maps using `combine`
   /// let newMap =
   ///  AssocList.disj<Nat, Nat, Nat, Nat>(
@@ -289,10 +286,10 @@ module {
   ///      }
   ///    }
   ///  );
-  /// 
+  ///
   /// List.toArray(newMap)
   /// ```
-  /// 
+  ///
   /// | Runtime   | Space     |
   /// |-----------|-----------|
   /// | `O(size1 * size2)` | `O(size1 + size2)` |
@@ -332,27 +329,27 @@ module {
   /// Takes the intersection of `map1` and `map2`, only keeping colliding keys
   /// and combining values using the `combine` function. Keys are compared using
   /// the `equal` function.
-  /// 
+  ///
   /// Example:
-  /// 
+  ///
   /// ```motoko include=import,initialize
   /// // Create map1 = [(0, 10), (1, 11), (2, 12)]
   /// var map1 : AssocList<Nat, Nat> = null;
   /// map1 := AssocList.replace(map1, 0, Nat.equal, ?10).0;
   /// map1 := AssocList.replace(map1, 1, Nat.equal, ?11).0;
   /// map1 := AssocList.replace(map1, 2, Nat.equal, ?12).0;
-  /// 
+  ///
   /// // Create map2 = [(2, 12), (3, 13)]
   /// var map2 : AssocList<Nat, Nat> = null;
   /// map2 := AssocList.replace(map2, 2, Nat.equal, ?12).0;
   /// map2 := AssocList.replace(map2, 3, Nat.equal, ?13).0;
-  /// 
+  ///
   /// // Take the intersection of the two maps, combining values by adding them
   /// let newMap = AssocList.join<Nat, Nat, Nat, Nat>(map1, map2, Nat.equal, Nat.add);
-  /// 
+  ///
   /// List.toArray(newMap)
   /// ```
-  /// 
+  ///
   /// | Runtime   | Space     |
   /// |-----------|-----------|
   /// | `O(size1 * size2)` | `O(size1 + size2)` |
@@ -379,20 +376,20 @@ module {
   /// Collapses the elements in `map` into a single value by starting with `base`
   /// and progessively combining elements into `base` with `combine`. Iteration runs
   /// left to right.
-  /// 
+  ///
   /// Example:
-  /// 
+  ///
   /// ```motoko include=import,initialize
   /// // Create map = [(0, 10), (1, 11), (2, 12)]
   /// var map : AssocList<Nat, Nat> = null;
   /// map := AssocList.replace(map, 0, Nat.equal, ?10).0;
   /// map := AssocList.replace(map, 1, Nat.equal, ?11).0;
   /// map := AssocList.replace(map, 2, Nat.equal, ?12).0;
-  /// 
+  ///
   /// // (0 * 10) + (1 * 11) + (2 * 12)
   /// AssocList.fold<Nat, Nat, Nat>(map, 0, func(k, v, sumSoFar) = (k * v) + sumSoFar)
   /// ```
-  /// 
+  ///
   /// | Runtime   | Space     |
   /// |-----------|-----------|
   /// | `O(size)` | `O(size)` |

--- a/src/Blob.mo
+++ b/src/Blob.mo
@@ -1,28 +1,28 @@
 /// `Blob` is an immutable, iterable sequence of bytes. Unlike `[Nat8]`, which is less compact (using 4 bytes per logical byte), `Blob` provides a more efficient representation.
-/// 
+///
 /// Blobs are not indexable and can be empty. To manipulate a `Blob`, convert it to `[var Nat8]` or `Buffer<Nat8>`, perform your changes, then convert it back.
-/// 
+///
 /// Import from the base library to use this module.
-/// 
+///
 /// ```motoko name=import
 /// import Blob "mo:base/Blob";
 /// ```
-/// 
+///
 /// :::note Additional features
-/// 
+///
 /// Some built-in features are not listed in this module:
-/// 
+///
 /// - You can create a `Blob` literal from a `Text` literal, provided the context expects an expression of type `Blob`.
 /// - `b.size() : Nat` returns the number of bytes in the blob `b`.
 /// - `b.vals() : Iter.Iter<Nat8>` returns an iterator to enumerate the bytes of the blob `b`.
 /// :::
-/// 
+///
 /// For example:
-/// 
+///
 /// ```motoko include=import
 /// import Debug "mo:base/Debug";
 /// import Nat8 "mo:base/Nat8";
-/// 
+///
 /// let blob = "\00\00\00\ff" : Blob; // blob literals, where each byte is delimited by a back-slash and represented in hex
 /// let blob2 = "charsもあり" : Blob; // you can also use characters in the literals
 /// let numBytes = blob.size(); // => 4 (returns the number of bytes in the Blob)
@@ -31,7 +31,7 @@
 /// }
 /// ```
 /// :::note Operator limitation
-/// 
+///
 /// Comparison functions (`equal`, `notEqual`, `less`, `lessOrEqual`, `greater`, `greaterOrEqual`) are defined in this library to allow their use as function values in higher-order functions.
 /// Operators like `==`, `!=`, `<`, `<=`, `>`, and `>=` cannot currently be passed as function values.
 /// :::
@@ -39,7 +39,7 @@ import Prim "mo:⛔";
 module {
   public type Blob = Prim.Types.Blob;
   /// Creates a `Blob` from an array of bytes (`[Nat8]`) by copying each element.
-  /// 
+  ///
   /// Example:
   /// ```motoko include=import
   /// let bytes : [Nat8] = [0, 255, 0];
@@ -48,7 +48,7 @@ module {
   public func fromArray(bytes : [Nat8]) : Blob = Prim.arrayToBlob bytes;
 
   /// Creates a `Blob` from a mutable array of bytes (`[var Nat8]`) by copying each element.
-  /// 
+  ///
   /// Example:
   /// ```motoko include=import
   /// let bytes : [var Nat8] = [var 0, 255, 0];
@@ -57,7 +57,7 @@ module {
   public func fromArrayMut(bytes : [var Nat8]) : Blob = Prim.arrayMutToBlob bytes;
 
   /// Converts a `Blob` to an array of bytes (`[Nat8]`) by copying each element.
-  /// 
+  ///
   /// Example:
   /// ```motoko include=import
   /// let blob = "\00\FF\00" : Blob;
@@ -66,7 +66,7 @@ module {
   public func toArray(blob : Blob) : [Nat8] = Prim.blobToArray blob;
 
   /// Converts a `Blob` to a mutable array of bytes (`[var Nat8]`) by copying each element.
-  /// 
+  ///
   /// Example:
   /// ```motoko include=import
   /// let blob = "\00\FF\00" : Blob;
@@ -75,7 +75,7 @@ module {
   public func toArrayMut(blob : Blob) : [var Nat8] = Prim.blobToArrayMut blob;
 
   /// Returns the (non-cryptographic) hash of `blob`.
-  /// 
+  ///
   /// Example:
   /// ```motoko include=import
   /// let blob = "\00\FF\00" : Blob;
@@ -86,7 +86,7 @@ module {
   /// General purpose comparison function for `Blob` by comparing the value of
   /// the bytes. Returns the `Order` (either `#less`, `#equal`, or `#greater`)
   /// by comparing `blob1` with `blob2`.
-  /// 
+  ///
   /// Example:
   /// ```motoko include=import
   /// let blob1 = "\00\00\00" : Blob;
@@ -100,7 +100,7 @@ module {
 
   /// Equality function for `Blob` types.
   /// This is equivalent to `blob1 == blob2`.
-  /// 
+  ///
   /// Example:
   /// ```motoko include=import
   /// let blob1 = "\00\FF\00" : Blob;
@@ -108,12 +108,12 @@ module {
   /// ignore Blob.equal(blob1, blob2);
   /// blob1 == blob2 // => true
   /// ```
-  /// 
+  ///
   public func equal(blob1 : Blob, blob2 : Blob) : Bool { blob1 == blob2 };
 
   /// Inequality function for `Blob` types.
   /// This is equivalent to `blob1 != blob2`.
-  /// 
+  ///
   /// Example:
   /// ```motoko include=import
   /// let blob1 = "\00\AA\AA" : Blob;
@@ -126,7 +126,7 @@ module {
 
   /// "Less than" function for `Blob` types.
   /// This is equivalent to `blob1 < blob2`.
-  /// 
+  ///
   /// Example:
   /// ```motoko include=import
   /// let blob1 = "\00\AA\AA" : Blob;
@@ -139,7 +139,7 @@ module {
 
   /// "Less than or equal to" function for `Blob` types.
   /// This is equivalent to `blob1 <= blob2`.
-  /// 
+  ///
   /// Example:
   /// ```motoko include=import
   /// let blob1 = "\00\AA\AA" : Blob;
@@ -151,7 +151,7 @@ module {
 
   /// "Greater than" function for `Blob` types.
   /// This is equivalent to `blob1 > blob2`.
-  /// 
+  ///
   /// Example:
   /// ```motoko include=import
   /// let blob1 = "\BB\AA\AA" : Blob;
@@ -163,7 +163,7 @@ module {
 
   /// "Greater than or equal to" function for `Blob` types.
   /// This is equivalent to `blob1 >= blob2`.
-  /// 
+  ///
   /// Example:
   /// ```motoko include=import
   /// let blob1 = "\BB\AA\AA" : Blob;

--- a/src/Bool.mo
+++ b/src/Bool.mo
@@ -1,5 +1,5 @@
 /// Boolean type and operations.
-/// 
+///
 /// While boolean operators `_ and _` and `_ or _` are short-circuiting,
 /// avoiding computation of the right argument when possible, the functions
 /// `logand(_, _)` and `logor(_, _)` are *strict* and will always evaluate *both*

--- a/src/Buffer.mo
+++ b/src/Buffer.mo
@@ -1,47 +1,47 @@
 /// Class `Buffer<X>` provides a mutable list of elements of type `X`.
 /// It wraps a resizable underlying array and is comparable to `ArrayList` or `Vector` in other languages.
-/// 
+///
 /// You can convert a buffer to a fixed-size array using `Buffer.toArray`, which is recommended for storing data in stable variables.
-/// 
+///
 /// Like arrays, buffer elements are indexed from `0` to `size - 1`.
-/// 
+///
 /// :::note Assumptions
-/// 
+///
 /// Runtime and space complexity assumes that `combine`, `equal`, and other functions execute in `O(1)` time and space.
-/// 
+///
 /// :::
-/// 
+///
 /// :::note Size vs capacity
-/// 
+///
 /// - `size`: Number of elements in the buffer.
 /// - `capacity`: Length of the underlying array.
-/// 
+///
 /// The invariant `capacity >= size` always holds.
 /// :::
-/// 
+///
 /// :::warning Performance caveat
-/// 
+///
 /// Operations like `add` are amortized `O(1)` but can take `O(n)` in the worst case.
 /// For large buffers, these worst cases may exceed the cycle limit per message.
 /// Use with care when growing buffers dynamically.
 /// :::
-/// 
+///
 /// :::info Constructor behavior
-/// 
+///
 /// The `initCapacity` argument sets the initial capacity of the underlying array.
-/// 
+///
 /// - When the capacity is exceeded, the array grows by a factor of 1.5.
 /// - When the buffer size drops below 1/4 of the capacity, it shrinks by a factor of 2.
 /// :::
-/// 
+///
 /// Example:
-/// 
+///
 /// ```motoko name=initialize
 /// import Buffer "mo:base/Buffer";
-/// 
+///
 /// let buffer = Buffer.Buffer<Nat>(3); // Creates a new Buffer
 /// ```
-/// 
+///
 /// | Runtime   | Space     |
 /// |-----------|-----------|
 /// | `O(initCapacity)` | `O(initCapacity)` |
@@ -81,13 +81,13 @@ module {
     var elements : [var ?X] = Prim.Array_init(initCapacity, null);
 
     /// Returns the current number of elements in the buffer.
-    /// 
+    ///
     /// Example:
-    /// 
+    ///
     /// ```motoko include=initialize
     /// buffer.size() // => 0
     /// ```
-    /// 
+    ///
     /// | Runtime   | Space     |
     /// |-----------|-----------|
     /// | `O(1)` | `O(1)` |
@@ -95,9 +95,9 @@ module {
 
     /// Adds a single element to the end of the buffer, doubling
     /// the size of the array if capacity is exceeded.
-    /// 
+    ///
     /// Example:
-    /// 
+    ///
     /// ```motoko include=initialize
     /// buffer.add(0); // add 0 to buffer
     /// buffer.add(1);
@@ -105,7 +105,7 @@ module {
     /// buffer.add(3); // causes underlying array to increase in capacity
     /// Buffer.toArray(buffer) // => [0, 1, 2, 3]
     /// ```
-    /// 
+    ///
     /// | Runtime (worst) | Runtime (amortized) | Space (worst) | Space (amortized) |
     /// |------------------|----------------------|----------------|---------------------|
     /// | `O(size)`           | `O(1)`               | `O(size)`         | `O(1)`              |
@@ -118,15 +118,15 @@ module {
     };
 
     /// Returns the element at index `index`. Traps if  `index >= size`. Indexing is zero-based.
-    /// 
+    ///
     /// Example:
-    /// 
+    ///
     /// ```motoko include=initialize
     /// buffer.add(10);
     /// buffer.add(11);
     /// buffer.get(0); // => 10
     /// ```
-    /// 
+    ///
     /// | Runtime   | Space     |
     /// |-----------|-----------|
     /// | `O(1)` | `O(1)` |
@@ -139,21 +139,21 @@ module {
 
     /// Returns the element at index `index` as an option.
     /// Returns `null` when `index >= size`. Indexing is zero-based.
-    /// 
+    ///
     /// Example:
-    /// 
+    ///
     /// ```motoko include=initialize
     /// buffer.add(10);
     /// buffer.add(11);
     /// let x = buffer.getOpt(0); // => ?10
     /// let y = buffer.getOpt(2); // => null
     /// ```
-    /// 
+    ///
     /// | Runtime   | Space     |
     /// |-----------|-----------|
     /// | `O(1)` | `O(1)` |
 
-  
+
     public func getOpt(index : Nat) : ?X {
       if (index < _size) {
         elements[index]
@@ -166,7 +166,7 @@ module {
     /// buffer.put(0, 20); // overwrites 10 at index 0 with 20
     /// Buffer.toArray(buffer) // => [20]
     /// ```
-    /// 
+    ///
     /// | Runtime   | Space     |
     /// |-----------|-----------|
     /// | `O(1)` | `O(1)` |
@@ -180,15 +180,15 @@ module {
 
     /// Removes and returns the last item in the buffer or `null` if
     /// the buffer is empty.
-    /// 
+    ///
     /// Example:
-    /// 
+    ///
     /// ```motoko include=initialize
     /// buffer.add(10);
     /// buffer.add(11);
     /// buffer.removeLast(); // => ?11
     /// ```
-    /// 
+    ///
     /// | Runtime (worst) | Runtime (amortized) | Space (worst) | Space (amortized) |
     /// |------------------|----------------------|----------------|---------------------|
     /// | `O(size)`           | `O(1)`               | `O(size)`         | `O(1)`              |
@@ -214,16 +214,16 @@ module {
     /// Removes and returns the element at `index` from the buffer.
     /// All elements with index > `index` are shifted one position to the left.
     /// This may cause a downsizing of the array.
-    /// 
+    ///
     /// Traps if index >= size.
-    /// 
+    ///
     /// :::warning Inefficient pattern
-    /// 
+    ///
     /// Repeated removal of elements using this method is inefficient and may indicate that a different data structure would better suit your use case.
     /// :::
-    /// 
+    ///
     /// Example:
-    /// 
+    ///
     /// ```motoko include=initialize
     /// buffer.add(10);
     /// buffer.add(11);
@@ -231,7 +231,7 @@ module {
     /// let x = buffer.remove(1); // evaluates to 11. 11 no longer in list.
     /// Buffer.toArray(buffer) // => [10, 12]
     /// ```
-    /// 
+    ///
     /// | Runtime (worst) | Runtime (amortized) | Space (worst) | Space (amortized) |
     /// |------------------|----------------------|----------------|---------------------|
     /// | `O(size)`           |-               | `O(size)`         | `O(1)`              |
@@ -282,9 +282,9 @@ module {
     };
 
     /// Resets the buffer. Capacity is set to 8.
-    /// 
+    ///
     /// Example:
-    /// 
+    ///
     /// ```motoko include=initialize
     /// buffer.add(10);
     /// buffer.add(11);
@@ -292,7 +292,7 @@ module {
     /// buffer.clear(); // buffer is now empty
     /// Buffer.toArray(buffer) // => []
     /// ```
-    /// 
+    ///
     /// | Runtime   | Space     |
     /// |-----------|-----------|
     /// | `O(1)` | `O(1)` |
@@ -304,9 +304,9 @@ module {
     /// Removes all elements from the buffer for which the predicate returns false.
     /// The predicate is given both the index of the element and the element itself.
     /// This may cause a downsizing of the array.
-    /// 
+    ///
     /// Example:
-    /// 
+    ///
     /// ```motoko include=initialize
     /// buffer.add(10);
     /// buffer.add(11);
@@ -314,11 +314,11 @@ module {
     /// buffer.filterEntries(func(_, x) = x % 2 == 0); // only keep even elements
     /// Buffer.toArray(buffer) // => [10, 12]
     /// ```
-    /// 
+    ///
     /// | Runtime (worst) | Runtime (amortized) | Space (worst) | Space (amortized) |
     /// |------------------|----------------------|----------------|---------------------|
     /// | `O(size)`           | -               | `O(size)`         | `O(1)`              |
-    /// 
+    ///
     public func filterEntries(predicate : (Nat, X) -> Bool) {
       var numRemoved = 0;
       let keep = Prim.Array_tabulate<Bool>(
@@ -381,9 +381,9 @@ module {
     };
 
     /// Returns the capacity of the buffer (the length of the underlying array).
-    /// 
+    ///
     /// Example:
-    /// 
+    ///
     /// ```motoko include=initialize
     /// let buffer = Buffer.Buffer<Nat>(2); // underlying array has capacity 2
     /// buffer.add(10);
@@ -392,21 +392,21 @@ module {
     /// buffer.add(12); // causes capacity to increase by factor of 1.5
     /// let c2 = buffer.capacity(); // => 3
     /// ```
-    /// 
+    ///
     /// | Runtime   | Space     |
     /// |-----------|-----------|
     /// | `O(1)` | `O(1)` |
     public func capacity() : Nat = elements.size();
 
     /// Changes the capacity to `capacity`. Traps if `capacity` < `size`.
-    /// 
+    ///
     /// ```motoko include=initialize
     /// buffer.reserve(4);
     /// buffer.add(10);
     /// buffer.add(11);
     /// buffer.capacity(); // => 4
     /// ```
-    /// 
+    ///
     /// | Runtime   | Space     |
     /// |-----------|-----------|
     /// | `O(capacity)` | `O(capacity)` |
@@ -426,7 +426,7 @@ module {
     };
 
     /// Adds all elements in buffer `b` to this buffer.
-    /// 
+    ///
     /// ```motoko include=initialize
     /// let buffer1 = Buffer.Buffer<Nat>(2);
     /// let buffer2 = Buffer.Buffer<Nat>(2);
@@ -437,7 +437,7 @@ module {
     /// buffer1.append(buffer2); // adds elements from buffer2 to buffer1
     /// Buffer.toArray(buffer1) // => [10, 11, 12, 13]
     /// ```
-    /// 
+    ///
     /// | Runtime (worst) | Runtime (amortized) | Space (worst) | Space (amortized) |
     /// |------------------|----------------------|----------------|---------------------|
     /// | `O(size1 + size2)`           | `O(size2)`              | `O(size1 +size2)`         | `O(1)`              |
@@ -460,7 +460,7 @@ module {
 
     /// Inserts `element` at `index`, shifts all elements to the right of
     /// `index` over by one index. Traps if `index` is greater than size.
-    /// 
+    ///
     /// ```motoko include=initialize
     /// let buffer1 = Buffer.Buffer<Nat>(2);
     /// let buffer2 = Buffer.Buffer<Nat>(2);
@@ -469,7 +469,7 @@ module {
     /// buffer.insert(1, 9);
     /// Buffer.toArray(buffer) // => [10, 9, 11]
     /// ```
-    /// 
+    ///
     /// | Runtime (worst) | Runtime (amortized) | Space (worst) | Space (amortized) |
     /// |------------------|----------------------|----------------|---------------------|
     /// | `O(size)`           | -               | `O(size)`         | `O(1)`              |
@@ -509,7 +509,7 @@ module {
 
     /// Inserts `buffer2` at `index`, and shifts all elements to the right of
     /// `index` over by size2. Traps if `index` is greater than size.
-    /// 
+    ///
     /// ```motoko include=initialize
     /// let buffer1 = Buffer.Buffer<Nat>(2);
     /// let buffer2 = Buffer.Buffer<Nat>(2);
@@ -520,7 +520,7 @@ module {
     /// buffer1.insertBuffer(1, buffer2);
     /// Buffer.toArray(buffer1) // => [10, 12, 13, 11]
     /// ```
-    /// 
+    ///
     /// | Runtime (worst) | Runtime (amortized) | Space (worst) | Space (amortized) |
     /// |------------------|----------------------|----------------|---------------------|
     /// | `O(size)`           | -             | `O(size1 +size2)`         | `O(1)`              |
@@ -568,17 +568,17 @@ module {
 
     /// Sorts the elements in the buffer according to `compare`.
     /// Sort is deterministic, stable, and in-place.
-    /// 
+    ///
     /// ```motoko include=initialize
     /// import Nat "mo:base/Nat";
-    /// 
+    ///
     /// buffer.add(11);
     /// buffer.add(12);
     /// buffer.add(10);
     /// buffer.sort(Nat.compare);
     /// Buffer.toArray(buffer) // => [10, 11, 12]
     /// ```
-    /// 
+    ///
     /// | Runtime   | Space     |
     /// |-----------|-----------|
     /// | `O(size * log(size))` | `O(size)` |
@@ -656,19 +656,19 @@ module {
     /// Returns an Iterator (`Iter`) over the elements of this buffer.
     /// Iterator provides a single method `next()`, which returns
     /// elements in order, or `null` when out of elements to iterate over.
-    /// 
+    ///
     /// ```motoko include=initialize
     /// buffer.add(10);
     /// buffer.add(11);
     /// buffer.add(12);
-    /// 
+    ///
     /// var sum = 0;
     /// for (element in buffer.vals()) {
     ///  sum += element;
     /// };
     /// sum // => 33
     /// ```
-    /// 
+    ///
     /// | Runtime   | Space     |
     /// |-----------|-----------|
     /// | `O(1)` | `O(1)` |
@@ -688,10 +688,7 @@ module {
 
     // FOLLOWING METHODS ARE DEPRECATED
 
-    /// :::warning Deprecated function
-    /// 
-    /// Use the static library function instead of this instance method.
-    /// :::
+    /// @deprecated Use the static library function instead of this instance method.
     public func clone() : Buffer<X> {
       let newBuffer = Buffer<X>(elements.size());
       for (element in vals()) {
@@ -700,10 +697,7 @@ module {
       newBuffer
     };
 
-    /// :::warning Deprecated function
-    /// 
-    /// Use the static library function instead of this instance method.
-    /// :::
+    /// @deprecated Use the static library function instead of this instance method.
     public func toArray() : [X] =
     // immutable clone of array
     Prim.Array_tabulate<X>(
@@ -711,10 +705,7 @@ module {
       func(i : Nat) : X { get i }
     );
 
-    /// :::warning Deprecated function
-    /// 
-    /// Use the static library function instead of this instance method.
-    /// :::
+    /// @deprecated Use the static library function instead of this instance method.
     public func toVarArray() : [var X] {
       if (_size == 0) { [var] } else {
         let newArray = Prim.Array_init<X>(_size, get 0);
@@ -729,20 +720,20 @@ module {
   };
 
   /// Returns true if and only if the buffer is empty.
-  /// 
+  ///
   /// Example:
-  /// 
+  ///
   /// ```motoko include=initialize
   /// buffer.add(2);
   /// buffer.add(0);
   /// buffer.add(3);
   /// Buffer.isEmpty(buffer); // => false
   /// ```
-  /// 
+  ///
   /// ```motoko include=initialize
   /// Buffer.isEmpty(buffer); // => true
   /// ```
-  /// 
+  ///
   /// | Runtime   | Space     |
   /// |-----------|-----------|
   /// | `O(1)` | `O(1)` |
@@ -750,18 +741,18 @@ module {
 
   /// Returns true if `buffer` contains `element` with respect to equality
   /// defined by `equal`.
-  /// 
+  ///
   /// Example:
-  /// 
+  ///
   /// ```motoko include=initialize
   /// import Nat "mo:base/Nat";
-  /// 
+  ///
   /// buffer.add(2);
   /// buffer.add(0);
   /// buffer.add(3);
   /// Buffer.contains<Nat>(buffer, 2, Nat.equal); // => true
   /// ```
-  /// 
+  ///
   /// | Runtime   | Space     |
   /// |-----------|-----------|
   /// | `O(size)` | `O(1)` |
@@ -776,16 +767,16 @@ module {
   };
 
   /// Returns a copy of `buffer`, with the same capacity.
-  /// 
+  ///
   /// Example:
-  /// 
+  ///
   /// ```motoko include=initialize
   /// buffer.add(1);
-  /// 
+  ///
   /// let clone = Buffer.clone(buffer);
   /// Buffer.toArray(clone); // => [1]
   /// ```
-  /// 
+  ///
   /// | Runtime   | Space     |
   /// |-----------|-----------|
   /// | `O(size)` | `O(size)` |
@@ -799,18 +790,18 @@ module {
 
   /// Finds the greatest element in `buffer` defined by `compare`.
   /// Returns `null` if `buffer` is empty.
-  /// 
+  ///
   /// Example:
-  /// 
+  ///
   /// ```motoko include=initialize
   /// import Nat "mo:base/Nat";
-  /// 
+  ///
   /// buffer.add(1);
   /// buffer.add(2);
-  /// 
+  ///
   /// Buffer.max(buffer, Nat.compare); // => ?2
   /// ```
-  /// 
+  ///
   /// | Runtime   | Space     |
   /// |-----------|-----------|
   /// | `O(size)` | `O(1)` |
@@ -834,18 +825,18 @@ module {
 
   /// Finds the least element in `buffer` defined by `compare`.
   /// Returns `null` if `buffer` is empty.
-  /// 
+  ///
   /// Example:
-  /// 
+  ///
   /// ```motoko include=initialize
   /// import Nat "mo:base/Nat";
-  /// 
+  ///
   /// buffer.add(1);
   /// buffer.add(2);
-  /// 
+  ///
   /// Buffer.min(buffer, Nat.compare); // => ?1
   /// ```
-  /// 
+  ///
   /// | Runtime   | Space     |
   /// |-----------|-----------|
   /// | `O(size)` | `O(1)` |
@@ -871,23 +862,23 @@ module {
   /// buffers. Returns true if the two buffers are of the same size, and `equal`
   /// evaluates to true for every pair of elements in the two buffers of the same
   /// index.
-  /// 
+  ///
   /// Example:
-  /// 
+  ///
   /// ```motoko include=initialize
   /// import Nat "mo:base/Nat";
-  /// 
+  ///
   /// let buffer1 = Buffer.Buffer<Nat>(2);
   /// buffer1.add(1);
   /// buffer1.add(2);
-  /// 
+  ///
   /// let buffer2 = Buffer.Buffer<Nat>(5);
   /// buffer2.add(1);
   /// buffer2.add(2);
-  /// 
+  ///
   /// Buffer.equal(buffer1, buffer2, Nat.equal); // => true
   /// ```
-  /// 
+  ///
   /// | Runtime   | Space     |
   /// |-----------|-----------|
   /// | `O(size)` | `O(1)` |
@@ -911,23 +902,23 @@ module {
 
   /// Defines comparison for two buffers, using `compare` to recursively compare elements in the
   /// buffers. Comparison is defined lexicographically.
-  /// 
+  ///
   /// Example:
-  /// 
+  ///
   /// ```motoko include=initialize
   /// import Nat "mo:base/Nat";
-  /// 
+  ///
   /// let buffer1 = Buffer.Buffer<Nat>(2);
   /// buffer1.add(1);
   /// buffer1.add(2);
-  /// 
+  ///
   /// let buffer2 = Buffer.Buffer<Nat>(3);
   /// buffer2.add(3);
   /// buffer2.add(4);
-  /// 
+  ///
   /// Buffer.compare<Nat>(buffer1, buffer2, Nat.compare); // => #less
   /// ```
-  /// 
+  ///
   /// | Runtime   | Space     |
   /// |-----------|-----------|
   /// | `O(size)` | `O(1)` |
@@ -961,20 +952,20 @@ module {
 
   /// Creates a textual representation of `buffer`, using `toText` to recursively
   /// convert the elements into Text.
-  /// 
+  ///
   /// Example:
-  /// 
+  ///
   /// ```motoko include=initialize
   /// import Nat "mo:base/Nat";
-  /// 
+  ///
   /// buffer.add(1);
   /// buffer.add(2);
   /// buffer.add(3);
   /// buffer.add(4);
-  /// 
+  ///
   /// Buffer.toText(buffer, Nat.toText); // => "[1, 2, 3, 4]"
   /// ```
-  /// 
+  ///
   /// | Runtime   | Space     |
   /// |-----------|-----------|
   /// | `O(size)` | `O(size)` |
@@ -998,20 +989,20 @@ module {
   /// Hashes `buffer` using `hash` to hash the underlying elements.
   /// The deterministic hash function is a function of the elements in the `buffer`, as well
   /// as their ordering.
-  /// 
+  ///
   /// Example:
-  /// 
+  ///
   /// ```motoko include=initialize
   /// import Hash "mo:base/Hash";
-  /// 
+  ///
   /// buffer.add(1);
   /// buffer.add(2);
   /// buffer.add(3);
   /// buffer.add(1000);
-  /// 
+  ///
   /// Buffer.hash<Nat>(buffer, Hash.hash); // => 2_872_640_342
   /// ```
-  /// 
+  ///
   /// | Runtime   | Space     |
   /// |-----------|-----------|
   /// | `O(size)` | `O(1)` |
@@ -1030,20 +1021,20 @@ module {
 
   /// Finds the first index of `element` in `buffer` using equality of elements defined
   /// by `equal`. Returns `null` if `element` is not found.
-  /// 
+  ///
   /// Example:
-  /// 
+  ///
   /// ```motoko include=initialize
   /// import Nat "mo:base/Nat";
-  /// 
+  ///
   /// buffer.add(1);
   /// buffer.add(2);
   /// buffer.add(3);
   /// buffer.add(4);
-  /// 
+  ///
   /// Buffer.indexOf<Nat>(3, buffer, Nat.equal); // => ?2
   /// ```
-  /// 
+  ///
   /// | Runtime   | Space     |
   /// |-----------|-----------|
   /// | `O(size)` | `O(size)` |
@@ -1062,22 +1053,22 @@ module {
 
   /// Finds the last index of `element` in `buffer` using equality of elements defined
   /// by `equal`. Returns `null` if `element` is not found.
-  /// 
+  ///
   /// Example:
-  /// 
+  ///
   /// ```motoko include=initialize
   /// import Nat "mo:base/Nat";
-  /// 
+  ///
   /// buffer.add(1);
   /// buffer.add(2);
   /// buffer.add(3);
   /// buffer.add(4);
   /// buffer.add(2);
   /// buffer.add(2);
-  /// 
+  ///
   /// Buffer.lastIndexOf<Nat>(2, buffer, Nat.equal); // => ?5
   /// ```
-  /// 
+  ///
   /// | Runtime   | Space     |
   /// |-----------|-----------|
   /// | `O(size)` | `O(size)` |
@@ -1098,27 +1089,27 @@ module {
   };
 
   /// Searches for `subBuffer` in `buffer`, and returns the starting index if it is found.
-  /// 
+  ///
   /// Example:
-  /// 
+  ///
   /// ```motoko include=initialize
   /// import Nat "mo:base/Nat";
-  /// 
+  ///
   /// buffer.add(1);
   /// buffer.add(2);
   /// buffer.add(3);
   /// buffer.add(4);
   /// buffer.add(5);
   /// buffer.add(6);
-  /// 
+  ///
   /// let sub = Buffer.Buffer<Nat>(2);
   /// sub.add(4);
   /// sub.add(5);
   /// sub.add(6);
-  /// 
+  ///
   /// Buffer.indexOfBuffer<Nat>(sub, buffer, Nat.equal); // => ?3
   /// ```
-  /// 
+  ///
   /// | Runtime   | Space     |
   /// |-----------|-----------|
   /// | `O(size of buffer + size of subBuffer)` | `O(size of subBuffer)` |
@@ -1174,20 +1165,20 @@ module {
   /// Similar to `indexOf`, but runs in logarithmic time. Assumes that `buffer` is sorted.
   /// Behavior is undefined if `buffer` is not sorted. Uses `compare` to
   /// perform the search. Returns an index of `element` if it is found.
-  /// 
+  ///
   /// Example:
-  /// 
+  ///
   /// ```motoko include=initialize
   /// import Nat "mo:base/Nat";
-  /// 
+  ///
   /// buffer.add(1);
   /// buffer.add(4);
   /// buffer.add(5);
   /// buffer.add(6);
-  /// 
+  ///
   /// Buffer.binarySearch<Nat>(5, buffer, Nat.compare); // => ?2
   /// ```
-  /// 
+  ///
   /// | Runtime   | Space     |
   /// |-----------|-----------|
   /// | `O(log(size))` | `O(1)` |
@@ -1217,23 +1208,23 @@ module {
   /// Returns the sub-buffer of `buffer` starting at index `start`
   /// of length `length`. Traps if `start` is out of bounds, or `start + length`
   /// is greater than the size of `buffer`.
-  /// 
+  ///
   /// Example:
-  /// 
+  ///
   /// ```motoko include=initialize
   /// import Nat "mo:base/Nat";
-  /// 
+  ///
   /// buffer.add(1);
   /// buffer.add(2);
   /// buffer.add(3);
   /// buffer.add(4);
   /// buffer.add(5);
   /// buffer.add(6);
-  /// 
+  ///
   /// let sub = Buffer.subBuffer(buffer, 3, 2);
   /// Buffer.toText(sub, Nat.toText); // => [4, 5]
   /// ```
-  /// 
+  ///
   /// | Runtime   | Space     |
   /// |-----------|-----------|
   /// | `O(length)` | `O(length)` |
@@ -1258,25 +1249,25 @@ module {
 
   /// Checks if `subBuffer` is a sub-Buffer of `buffer`. Uses `equal` to
   /// compare elements.
-  /// 
+  ///
   /// Example:
-  /// 
+  ///
   /// ```motoko include=initialize
   /// import Nat "mo:base/Nat";
-  /// 
+  ///
   /// buffer.add(1);
   /// buffer.add(2);
   /// buffer.add(3);
   /// buffer.add(4);
   /// buffer.add(5);
   /// buffer.add(6);
-  /// 
+  ///
   /// let sub = Buffer.Buffer<Nat>(2);
   /// sub.add(2);
   /// sub.add(3);
   /// Buffer.isSubBufferOf(sub, buffer, Nat.equal); // => true
   /// ```
-  /// 
+  ///
   /// | Runtime   | Space     |
   /// |-----------|-----------|
   /// | `O(size of subBuffer + size of buffer)` | `O(size of subBuffer)` |
@@ -1290,23 +1281,23 @@ module {
   /// Checks if `subBuffer` is a strict subBuffer of `buffer`, i.e. `subBuffer` must be
   /// strictly contained inside both the first and last indices of `buffer`.
   /// Uses `equal` to compare elements.
-  /// 
+  ///
   /// Example:
-  /// 
+  ///
   /// ```motoko include=initialize
   /// import Nat "mo:base/Nat";
-  /// 
+  ///
   /// buffer.add(1);
   /// buffer.add(2);
   /// buffer.add(3);
   /// buffer.add(4);
-  /// 
+  ///
   /// let sub = Buffer.Buffer<Nat>(2);
   /// sub.add(2);
   /// sub.add(3);
   /// Buffer.isStrictSubBufferOf(sub, buffer, Nat.equal); // => true
   /// ```
-  /// 
+  ///
   /// | Runtime   | Space     |
   /// |-----------|-----------|
   /// | `O(size of subBuffer + size of buffer)` | `O(size of subBuffer)` |
@@ -1325,25 +1316,25 @@ module {
 
   /// Returns the prefix of `buffer` of length `length`. Traps if `length`
   /// is greater than the size of `buffer`.
-  /// 
+  ///
   /// Example:
-  /// 
+  ///
   /// ```motoko include=initialize
   /// import Nat "mo:base/Nat";
-  /// 
+  ///
   /// buffer.add(1);
   /// buffer.add(2);
   /// buffer.add(3);
   /// buffer.add(4);
-  /// 
+  ///
   /// let pre = Buffer.prefix(buffer, 3); // => [1, 2, 3]
   /// Buffer.toText(pre, Nat.toText);
   /// ```
-  /// 
+  ///
   /// | Runtime   | Space     |
   /// |-----------|-----------|
   /// | `O(length)` | `O(length)` |
-  /// 
+  ///
   public func prefix<X>(buffer : Buffer<X>, length : Nat) : Buffer<X> {
     let size = buffer.size();
     if (length > size) {
@@ -1363,23 +1354,23 @@ module {
 
   /// Checks if `prefix` is a prefix of `buffer`. Uses `equal` to
   /// compare elements.
-  /// 
+  ///
   /// Example:
-  /// 
+  ///
   /// ```motoko include=initialize
   /// import Nat "mo:base/Nat";
-  /// 
+  ///
   /// buffer.add(1);
   /// buffer.add(2);
   /// buffer.add(3);
   /// buffer.add(4);
-  /// 
+  ///
   /// let pre = Buffer.Buffer<Nat>(2);
   /// pre.add(1);
   /// pre.add(2);
   /// Buffer.isPrefixOf(pre, buffer, Nat.equal); // => true
   /// ```
-  /// 
+  ///
   /// | Runtime   | Space     |
   /// |-----------|-----------|
   /// | `O(size of prefix)` | `O(size of prefix)` |
@@ -1403,24 +1394,24 @@ module {
 
   /// Checks if `prefix` is a strict prefix of `buffer`. Uses `equal` to
   /// compare elements.
-  /// 
+  ///
   /// Example:
-  /// 
+  ///
   /// ```motoko include=initialize
   /// import Nat "mo:base/Nat";
-  /// 
+  ///
   /// buffer.add(1);
   /// buffer.add(2);
   /// buffer.add(3);
   /// buffer.add(4);
-  /// 
+  ///
   /// let pre = Buffer.Buffer<Nat>(3);
   /// pre.add(1);
   /// pre.add(2);
   /// pre.add(3);
   /// Buffer.isStrictPrefixOf(pre, buffer, Nat.equal); // => true
   /// ```
-  /// 
+  ///
   /// | Runtime   | Space     |
   /// |-----------|-----------|
   /// | `O(size of prefix)` | `O(size of prefix)` |
@@ -1433,21 +1424,21 @@ module {
 
   /// Returns the suffix of `buffer` of length `length`.
   /// Traps if `length`is greater than the size of `buffer`.
-  /// 
+  ///
   /// Example:
-  /// 
+  ///
   /// ```motoko include=initialize
   /// import Nat "mo:base/Nat";
-  /// 
+  ///
   /// buffer.add(1);
   /// buffer.add(2);
   /// buffer.add(3);
   /// buffer.add(4);
-  /// 
+  ///
   /// let suf = Buffer.suffix(buffer, 3); // => [2, 3, 4]
   /// Buffer.toText(suf, Nat.toText);
   /// ```
-  /// 
+  ///
   /// | Runtime   | Space     |
   /// |-----------|-----------|
   /// | `O(length)` | `O(length)` |
@@ -1472,24 +1463,24 @@ module {
 
   /// Checks if `suffix` is a suffix of `buffer`. Uses `equal` to compare
   /// elements.
-  /// 
+  ///
   /// Example:
-  /// 
+  ///
   /// ```motoko include=initialize
   /// import Nat "mo:base/Nat";
-  /// 
+  ///
   /// buffer.add(1);
   /// buffer.add(2);
   /// buffer.add(3);
   /// buffer.add(4);
-  /// 
+  ///
   /// let suf = Buffer.Buffer<Nat>(3);
   /// suf.add(2);
   /// suf.add(3);
   /// suf.add(4);
   /// Buffer.isSuffixOf(suf, buffer, Nat.equal); // => true
   /// ```
-  /// 
+  ///
   /// | Runtime   | Space     |
   /// |-----------|-----------|
   /// | `O(length of suffix)` | `O(length of suffix)` |
@@ -1515,23 +1506,23 @@ module {
 
   /// Checks if `suffix` is a strict suffix of `buffer`. Uses `equal` to compare
   /// elements.
-  /// 
+  ///
   /// Example:
   /// ```motoko include=initialize
   /// import Nat "mo:base/Nat";
-  /// 
+  ///
   /// buffer.add(1);
   /// buffer.add(2);
   /// buffer.add(3);
   /// buffer.add(4);
-  /// 
+  ///
   /// let suf = Buffer.Buffer<Nat>(3);
   /// suf.add(2);
   /// suf.add(3);
   /// suf.add(4);
   /// Buffer.isStrictSuffixOf(suf, buffer, Nat.equal); // => true
   /// ```
-  /// 
+  ///
 /// | Runtime   | Space     |
   /// |-----------|-----------|
   /// | `O(length)` | `O(length)` |
@@ -1543,17 +1534,17 @@ module {
   };
 
   /// Returns true if every element in `buffer` satisfies `predicate`.
-  /// 
+  ///
   /// Example:
-  /// 
+  ///
   /// ```motoko include=initialize
   /// buffer.add(2);
   /// buffer.add(3);
   /// buffer.add(4);
-  /// 
+  ///
   /// Buffer.forAll<Nat>(buffer, func x { x > 1 }); // => true
   /// ```
-  /// 
+  ///
   /// | Runtime   | Space     |
   /// |-----------|-----------|
   /// | `O(size)` | `O(1)` |
@@ -1568,17 +1559,17 @@ module {
   };
 
   /// Returns true if some element in `buffer` satisfies `predicate`.
-  /// 
+  ///
   /// Example:
-  /// 
+  ///
   /// ```motoko include=initialize
   /// buffer.add(2);
   /// buffer.add(3);
   /// buffer.add(4);
-  /// 
+  ///
   /// Buffer.forSome<Nat>(buffer, func x { x > 3 }); // => true
   /// ```
-  /// 
+  ///
   /// | Runtime   | Space     |
   /// |-----------|-----------|
   /// | `O(size)` | `O(1)` |
@@ -1593,17 +1584,17 @@ module {
   };
 
   /// Returns true if no element in `buffer` satisfies `predicate`.
-  /// 
+  ///
   /// Example:
-  /// 
+  ///
   /// ```motoko include=initialize
   /// buffer.add(2);
   /// buffer.add(3);
   /// buffer.add(4);
-  /// 
+  ///
   /// Buffer.forNone<Nat>(buffer, func x { x == 0 }); // => true
   /// ```
-  /// 
+  ///
   /// | Runtime   | Space     |
   /// |-----------|-----------|
   /// | `O(size)` | `O(1)` |
@@ -1618,17 +1609,17 @@ module {
   };
 
   /// Creates an `array` containing elements from `buffer`.
-  /// 
+  ///
   /// Example:
-  /// 
+  ///
   /// ```motoko include=initialize
   /// buffer.add(1);
   /// buffer.add(2);
   /// buffer.add(3);
-  /// 
+  ///
   /// Buffer.toArray<Nat>(buffer); // => [1, 2, 3]
   /// ```
-  /// 
+  ///
   /// | Runtime   | Space     |
   /// |-----------|-----------|
   /// | `O(size)` | `O(size)` |
@@ -1638,22 +1629,19 @@ module {
     buffer.size(),
     func(i : Nat) : X { buffer.get(i) }
   );
-  ///``` motoko include=initialize
-  /// func toVarArray<X>(buffer : Buffer<X>) : [var X]
-  /// ```
-  /// 
+
   /// Creates a mutable array containing elements from `buffer`.
-  /// 
+  ///
   /// Example:
-  /// 
+  ///
   /// ```motoko include=initialize
   /// buffer.add(1);
   /// buffer.add(2);
   /// buffer.add(3);
-  /// 
+  ///
   /// Buffer.toVarArray<Nat>(buffer); // => [1, 2, 3]
   /// ```
-  /// 
+  ///
   /// | Runtime   | Space     |
   /// |-----------|-----------|
   /// | `O(size)` | `O(size)` |
@@ -1671,18 +1659,18 @@ module {
   };
 
   /// Creates a `buffer` containing elements from `array`.
-  /// 
+  ///
   /// Example:
-  /// 
+  ///
   /// ```motoko include=initialize
   /// import Nat "mo:base/Nat";
-  /// 
+  ///
   /// let array = [2, 3];
-  /// 
+  ///
   /// let buf = Buffer.fromArray<Nat>(array); // => [2, 3]
   /// Buffer.toText(buf, Nat.toText);
   /// ```
-  /// 
+  ///
   /// | Runtime   | Space     |
   /// |-----------|-----------|
   /// | `O(size)` | `O(size)` |
@@ -1704,18 +1692,18 @@ module {
   };
 
   /// Creates a `buffer` containing elements from `array`.
-  /// 
+  ///
   /// Example:
-  /// 
+  ///
   /// ```motoko include=initialize
   /// import Nat "mo:base/Nat";
-  /// 
+  ///
   /// let array = [var 1, 2, 3];
-  /// 
+  ///
   /// let buf = Buffer.fromVarArray<Nat>(array); // => [1, 2, 3]
   /// Buffer.toText(buf, Nat.toText);
   /// ```
-  /// 
+  ///
   /// | Runtime   | Space     |
   /// |-----------|-----------|
   /// | `O(size)` | `O(size)` |
@@ -1730,19 +1718,19 @@ module {
   };
 
   /// Creates a `buffer` containing elements from `iter`.
-  /// 
+  ///
   /// Example:
-  /// 
+  ///
   /// ```motoko include=initialize
   /// import Nat "mo:base/Nat";
-  /// 
+  ///
   /// let array = [1, 1, 1];
   /// let iter = array.vals();
-  /// 
+  ///
   /// let buf = Buffer.fromIter<Nat>(iter); // => [1, 1, 1]
   /// Buffer.toText(buf, Nat.toText);
   /// ```
-  /// 
+  ///
   /// | Runtime   | Space     |
   /// |-----------|-----------|
   /// | `O(size)` | `O(size)` |
@@ -1757,19 +1745,19 @@ module {
   };
 
   /// Reallocates the array underlying `buffer` such that capacity == size.
-  /// 
+  ///
   /// Example:
-  /// 
+  ///
   /// ```motoko include=initialize
   /// let buffer = Buffer.Buffer<Nat>(10);
   /// buffer.add(1);
   /// buffer.add(2);
   /// buffer.add(3);
-  /// 
+  ///
   /// Buffer.trimToSize<Nat>(buffer);
   /// buffer.capacity(); // => 3
   /// ```
-  /// 
+  ///
   /// | Runtime   | Space     |
   /// |-----------|-----------|
   /// | `O(size)` | `O(size)` |
@@ -1781,20 +1769,20 @@ module {
   };
 
   /// Creates a new `buffer` by applying `f` to each element in `buffer`.
-  /// 
+  ///
   /// Example:
-  /// 
+  ///
   /// ```motoko include=initialize
   /// import Nat "mo:base/Nat";
-  /// 
+  ///
   /// buffer.add(1);
   /// buffer.add(2);
   /// buffer.add(3);
-  /// 
+  ///
   /// let newBuf = Buffer.map<Nat, Nat>(buffer, func (x) { x + 1 });
   /// Buffer.toText(newBuf, Nat.toText); // => [2, 3, 4]
   /// ```
-  /// 
+  ///
   /// | Runtime   | Space     |
   /// |-----------|-----------|
   /// | `O(size)` | `O(size)` |
@@ -1809,26 +1797,26 @@ module {
   };
 
   /// Applies `f` to each element in `buffer`.
-  /// 
+  ///
   /// Example:
-  /// 
+  ///
   /// ```motoko include=initialize
   /// import Nat "mo:base/Nat";
   /// import Debug "mo:base/Debug";
-  /// 
+  ///
   /// buffer.add(1);
   /// buffer.add(2);
   /// buffer.add(3);
-  /// 
+  ///
   /// Buffer.iterate<Nat>(buffer, func (x) {
   ///   Debug.print(Nat.toText(x)); // prints each element in buffer
   /// });
   /// ```
-  /// 
+  ///
   /// | Runtime   | Space     |
   /// |-----------|-----------|
   /// | `O(size)` | `O(size)` |
-  /// 
+  ///
   public func iterate<X>(buffer : Buffer<X>, f : X -> ()) {
     for (element in buffer.vals()) {
       f element
@@ -1836,19 +1824,19 @@ module {
   };
 
   /// Applies `f` to each element in `buffer` and its index.
-  /// 
+  ///
   /// Example:
-  /// 
+  ///
   /// ```motoko include=initialize
   /// import Nat "mo:base/Nat";
   /// buffer.add(1);
   /// buffer.add(2);
   /// buffer.add(3);
-  /// 
+  ///
   /// let newBuf = Buffer.mapEntries<Nat, Nat>(buffer, func (x, i) { x + i + 1 });
   /// Buffer.toText(newBuf, Nat.toText); // => [2, 4, 6]
   /// ```
-  /// 
+  ///
   /// | Runtime   | Space     |
   /// |-----------|-----------|
   /// | `O(size)` | `O(size)` |
@@ -1867,15 +1855,15 @@ module {
 
   /// Creates a new buffer by applying `f` to each element in `buffer`,
   /// and keeping all non-null elements.
-  /// 
+  ///
   /// Example:
-  /// 
+  ///
   /// ```motoko include=initialize
   /// import Nat "mo:base/Nat";
   /// buffer.add(1);
   /// buffer.add(2);
   /// buffer.add(3);
-  /// 
+  ///
   /// let newBuf = Buffer.mapFilter<Nat, Nat>(buffer, func (x) {
   ///  if (x > 1) {
   ///    ?(x * 2);
@@ -1885,7 +1873,7 @@ module {
   /// });
   /// Buffer.toText(newBuf, Nat.toText); // => [4, 6]
   /// ```
-  /// 
+  ///
   /// | Runtime   | Space     |
   /// |-----------|-----------|
   /// | `O(size)` | `O(size)` |
@@ -1907,15 +1895,15 @@ module {
   /// Creates a new buffer by applying `f` to each element in `buffer`.
   /// If any invocation of `f` produces an `#err`, returns an `#err`. Otherwise
   /// Returns an `#ok` containing the new buffer.
-  /// 
+  ///
   /// Example:
-  /// 
+  ///
   /// ```motoko include=initialize
   /// import Result "mo:base/Result";
   /// buffer.add(1);
   /// buffer.add(2);
   /// buffer.add(3);
-  /// 
+  ///
   /// let result = Buffer.mapResult<Nat, Nat, Text>(buffer, func (k) {
   ///  if (k > 0) {
   ///    #ok(k);
@@ -1923,10 +1911,10 @@ module {
   ///    #err("One or more elements are zero.");
   ///  }
   /// });
-  /// 
+  ///
   /// Result.mapOk<Buffer.Buffer<Nat>, [Nat], Text>(result, func buffer = Buffer.toArray(buffer)) // => #ok([1, 2, 3])
   /// ```
-  /// 
+  ///
   /// | Runtime   | Space     |
   /// |-----------|-----------|
   /// | `O(size)` | `O(size)` |
@@ -1950,15 +1938,15 @@ module {
   /// Creates a new `buffer` by applying `k` to each element in `buffer`,
   /// and concatenating the resulting buffers in order. This operation
   /// is similar to what in other functional languages is known as monadic bind.
-  /// 
+  ///
   /// Example:
-  /// 
+  ///
   /// ```motoko include=initialize
   /// import Nat "mo:base/Nat";
   /// buffer.add(1);
   /// buffer.add(2);
   /// buffer.add(3);
-  /// 
+  ///
   /// let chain = Buffer.chain<Nat, Nat>(buffer, func (x) {
   /// let b = Buffer.Buffer<Nat>(2);
   /// b.add(x);
@@ -1967,7 +1955,7 @@ module {
   /// });
   /// Buffer.toText(chain, Nat.toText); // => [1, 2, 2, 4, 3, 6]
   /// ```
-  /// 
+  ///
   /// | Runtime   | Space     |
   /// |-----------|-----------|
   /// | `O(size)` | `O(size)` |
@@ -1984,18 +1972,18 @@ module {
   /// Collapses the elements in `buffer` into a single value by starting with `base`
   /// and progessively combining elements into `base` with `combine`. Iteration runs
   /// left to right.
-  /// 
+  ///
   /// Example:
-  /// 
+  ///
   /// ```motoko include=initialize
   /// import Nat "mo:base/Nat";
   /// buffer.add(1);
   /// buffer.add(2);
   /// buffer.add(3);
-  /// 
+  ///
   /// Buffer.foldLeft<Text, Nat>(buffer, "", func (acc, x) { acc # Nat.toText(x)}); // => "123"
   /// ```
-  /// 
+  ///
   /// | Runtime   | Space     |
   /// |-----------|-----------|
   /// | `O(size)` | `O(1)` |
@@ -2012,18 +2000,18 @@ module {
   /// Collapses the elements in `buffer` into a single value by starting with `base`
   /// and progessively combining elements into `base` with `combine`. Iteration runs
   /// right to left.
-  /// 
+  ///
   /// Example:
-  /// 
+  ///
   /// ```motoko include=initialize
   /// import Nat "mo:base/Nat";
   /// buffer.add(1);
   /// buffer.add(2);
   /// buffer.add(3);
-  /// 
+  ///
   /// Buffer.foldRight<Nat, Text>(buffer, "", func (x, acc) { Nat.toText(x) # acc }); // => "123"
   /// ```
-  /// 
+  ///
   /// | Runtime   | Space     |
   /// |-----------|-----------|
   /// | `O(size)` | `O(1)` |
@@ -2044,49 +2032,49 @@ module {
   };
 
   /// Returns the first element of `buffer`. Traps if `buffer` is empty.
-  /// 
+  ///
   /// Example:
-  /// 
+  ///
   /// ```motoko include=initialize
   /// buffer.add(1);
   /// buffer.add(2);
   /// buffer.add(3);
-  /// 
+  ///
   /// Buffer.first(buffer); // => 1
   /// ```
-  /// 
+  ///
   /// | Runtime   | Space     |
   /// |-----------|-----------|
   /// | `O(1)` | `O(1)` |
   public func first<X>(buffer : Buffer<X>) : X = buffer.get(0);
 
   /// Returns the last element of `buffer`. Traps if `buffer` is empty.
-  /// 
+  ///
   /// Example:
   /// ```motoko include=initialize
   /// buffer.add(1);
   /// buffer.add(2);
   /// buffer.add(3);
-  /// 
+  ///
   /// Buffer.last(buffer); // => 3
   /// ```
-  /// 
+  ///
   /// | Runtime   | Space     |
   /// |-----------|-----------|
   /// | `O(1)` | `O(1)` |
   public func last<X>(buffer : Buffer<X>) : X = buffer.get(buffer.size() - 1);
 
   /// Returns a new `buffer` with capacity and size 1, containing `element`.
-  /// 
+  ///
   /// Example:
-  /// 
+  ///
   /// ```motoko include=initialize
   /// import Nat "mo:base/Nat";
-  /// 
+  ///
   /// let buffer = Buffer.make<Nat>(1);
   /// Buffer.toText(buffer, Nat.toText); // => [1]
   /// ```
-  /// 
+  ///
   /// | Runtime   | Space     |
   /// |-----------|-----------|
   /// | `O(1)` | `O(1)` |
@@ -2097,19 +2085,19 @@ module {
   };
 
   /// Reverses the order of elements in `buffer`.
-  /// 
+  ///
   /// Example:
   /// ```motoko include=initialize
   /// import Nat "mo:base/Nat";
-  /// 
+  ///
   /// buffer.add(1);
   /// buffer.add(2);
   /// buffer.add(3);
-  /// 
+  ///
   /// Buffer.reverse(buffer);
   /// Buffer.toText(buffer, Nat.toText); // => [3, 2, 1]
   /// ```
-  /// 
+  ///
   /// | Runtime   | Space     |
   /// |-----------|-----------|
   /// | `O(size)` | `O(1)` |
@@ -2134,26 +2122,26 @@ module {
   /// Merges two sorted buffers into a single sorted `buffer`, using `compare` to define
   /// the ordering. The final ordering is stable. Behavior is undefined if either
   /// `buffer1` or `buffer2` is not sorted.
-  /// 
+  ///
   /// Example:
-  /// 
+  ///
   /// ```motoko include=initialize
   /// import Nat "mo:base/Nat";
-  /// 
+  ///
   /// let buffer1 = Buffer.Buffer<Nat>(2);
   /// buffer1.add(1);
   /// buffer1.add(2);
   /// buffer1.add(4);
-  /// 
+  ///
   /// let buffer2 = Buffer.Buffer<Nat>(2);
   /// buffer2.add(2);
   /// buffer2.add(4);
   /// buffer2.add(6);
-  /// 
+  ///
   /// let merged = Buffer.merge<Nat>(buffer1, buffer2, Nat.compare);
   /// Buffer.toText(merged, Nat.toText); // => [1, 2, 2, 4, 4, 6]
   /// ```
-  /// 
+  ///
   /// | Runtime   | Space     |
   /// |-----------|-----------|
   /// | `O(size1 + size2)` | `O(size1 + size2)` |
@@ -2197,23 +2185,23 @@ module {
 
   /// Eliminates all duplicate elements in `buffer` as defined by `compare`.
   /// Elimination is stable with respect to the original ordering of the elements.
-  /// 
+  ///
   /// Example:
-  /// 
+  ///
   /// ```motoko include=initialize
   /// import Nat "mo:base/Nat";
-  /// 
+  ///
   /// buffer.add(1);
   /// buffer.add(2);
   /// buffer.add(3);
   /// buffer.add(1);
   /// buffer.add(2);
   /// buffer.add(3);
-  /// 
+  ///
   /// Buffer.removeDuplicates<Nat>(buffer, Nat.compare);
   /// Buffer.toText(buffer, Nat.toText); // => [1, 2, 3]
   /// ```
-  /// 
+  ///
   /// | Runtime   | Space     |
   /// |-----------|-----------|
   /// | `O(size * log(size))` | `O(size)` |
@@ -2273,23 +2261,23 @@ module {
 
   /// Splits `buffer` into a pair of buffers where all elements in the left
   /// `buffer` satisfy `predicate` and all elements in the right `buffer` do not.
-  /// 
+  ///
   /// Example:
-  /// 
+  ///
   /// ```motoko include=initialize
   /// import Nat "mo:base/Nat";
-  /// 
+  ///
   /// buffer.add(1);
   /// buffer.add(2);
   /// buffer.add(3);
   /// buffer.add(4);
   /// buffer.add(5);
   /// buffer.add(6);
-  /// 
+  ///
   /// let partitions = Buffer.partition<Nat>(buffer, func (x) { x % 2 == 0 });
   /// (Buffer.toArray(partitions.0), Buffer.toArray(partitions.1)) // => ([2, 4, 6], [1, 3, 5])
   /// ```
-  /// 
+  ///
   /// | Runtime   | Space     |
   /// |-----------|-----------|
   /// | `O(size)` | `O(size)` |
@@ -2313,23 +2301,23 @@ module {
   /// all elements with indices less than `index`, and the right buffer contains all
   /// elements with indices greater than or equal to `index`. Traps if `index` is out
   /// of bounds.
-  /// 
+  ///
   /// Example:
-  /// 
+  ///
   /// ```motoko include=initialize
   /// import Nat "mo:base/Nat";
-  /// 
+  ///
   /// buffer.add(1);
   /// buffer.add(2);
   /// buffer.add(3);
   /// buffer.add(4);
   /// buffer.add(5);
   /// buffer.add(6);
-  /// 
+  ///
   /// let split = Buffer.split<Nat>(buffer, 3);
   /// (Buffer.toArray(split.0), Buffer.toArray(split.1)) // => ([1, 2, 3], [4, 5, 6])
   /// ```
-  /// 
+  ///
   /// | Runtime   | Space     |
   /// |-----------|-----------|
   /// | `O(size)` | `O(size)` |
@@ -2360,27 +2348,27 @@ module {
   /// Breaks up `buffer` into buffers of size `size`. The last chunk may
   /// have less than `size` elements if the number of elements is not divisible
   /// by the chunk size.
-  /// 
+  ///
   /// Example:
-  /// 
+  ///
   /// ```motoko include=initialize
   /// import Nat "mo:base/Nat";
-  /// 
+  ///
   /// buffer.add(1);
   /// buffer.add(2);
   /// buffer.add(3);
   /// buffer.add(4);
   /// buffer.add(5);
   /// buffer.add(6);
-  /// 
+  ///
   /// let chunks = Buffer.chunk<Nat>(buffer, 3);
   /// Buffer.toText<Buffer.Buffer<Nat>>(chunks, func buf = Buffer.toText(buf, Nat.toText)); // => [[1, 2, 3], [4, 5, 6]]
   /// ```
-  /// 
+  ///
   /// | Runtime   | Space     |
   /// |-----------|-----------|
   /// | `O(number of elements in buffer)` | `O(number of elements in buffer)` |
-  /// 
+  ///
   public func chunk<X>(buffer : Buffer<X>, size : Nat) : Buffer<Buffer<X>> {
     if (size == 0) {
       Prim.trap "Chunk size must be non-zero in chunk"
@@ -2408,23 +2396,23 @@ module {
   };
 
   /// Groups equal and adjacent elements in the list into sub lists.
-  /// 
+  ///
   /// Example:
-  /// 
+  ///
   /// ```motoko include=initialize
   /// import Nat "mo:base/Nat";
-  /// 
+  ///
   /// buffer.add(1);
   /// buffer.add(2);
   /// buffer.add(2);
   /// buffer.add(4);
   /// buffer.add(5);
   /// buffer.add(5);
-  /// 
+  ///
   /// let grouped = Buffer.groupBy<Nat>(buffer, func (x, y) { x == y });
   /// Buffer.toText<Buffer.Buffer<Nat>>(grouped, func buf = Buffer.toText(buf, Nat.toText)); // => [[1], [2, 2], [4], [5, 5]]
   /// ```
-  /// 
+  ///
   /// | Runtime   | Space     |
   /// |-----------|-----------|
   /// | `O(size)` | `O(size)` |
@@ -2459,30 +2447,30 @@ module {
   };
 
   /// Flattens the `buffer` of buffers into a single `buffer`.
-  /// 
+  ///
   /// Example:
-  /// 
+  ///
   /// ```motoko include=initialize
   /// import Nat "mo:base/Nat";
-  /// 
+  ///
   /// let buffer = Buffer.Buffer<Buffer.Buffer<Nat>>(1);
-  /// 
+  ///
   /// let inner1 = Buffer.Buffer<Nat>(2);
   /// inner1.add(1);
   /// inner1.add(2);
-  /// 
+  ///
   /// let inner2 = Buffer.Buffer<Nat>(2);
   /// inner2.add(3);
   /// inner2.add(4);
-  /// 
+  ///
   /// buffer.add(inner1);
   /// buffer.add(inner2);
   /// // buffer = [[1, 2], [3, 4]]
-  /// 
+  ///
   /// let flat = Buffer.flatten<Nat>(buffer);
   /// Buffer.toText<Nat>(flat, Nat.toText); // => [1, 2, 3, 4]
   /// ```
-  /// 
+  ///
   /// | Runtime   | Space     |
   /// |-----------|-----------|
   /// | `O(number of elements in buffer)` | `O(number of elements in buffer)` |
@@ -2512,24 +2500,24 @@ module {
   /// Combines the two buffers into a single buffer of pairs, pairing together
   /// elements with the same index. If one buffer is longer than the other, the
   /// remaining elements from the longer buffer are not included.
-  /// 
+  ///
   /// Example:
-  /// 
+  ///
   /// ```motoko include=initialize
-  /// 
+  ///
   /// let buffer1 = Buffer.Buffer<Nat>(2);
   /// buffer1.add(1);
   /// buffer1.add(2);
   /// buffer1.add(3);
-  /// 
+  ///
   /// let buffer2 = Buffer.Buffer<Nat>(2);
   /// buffer2.add(4);
   /// buffer2.add(5);
-  /// 
+  ///
   /// let zipped = Buffer.zip(buffer1, buffer2);
   /// Buffer.toArray(zipped); // => [(1, 4), (2, 5)]
   /// ```
-  /// 
+  ///
   /// | Runtime   | Space     |
   /// |-----------|-----------|
   /// | `O(min(size1, size2))` | `O(min(size1, size2))` |
@@ -2542,29 +2530,29 @@ module {
   /// elements with the same index and combining them using `zip`. If
   /// one buffer is longer than the other, the remaining elements from
   /// the longer buffer are not included.
-  /// 
+  ///
   /// Example:
-  /// 
+  ///
   /// ```motoko include=initialize
-  /// 
+  ///
   /// let buffer1 = Buffer.Buffer<Nat>(2);
   /// buffer1.add(1);
   /// buffer1.add(2);
   /// buffer1.add(3);
-  /// 
+  ///
   /// let buffer2 = Buffer.Buffer<Nat>(2);
   /// buffer2.add(4);
   /// buffer2.add(5);
   /// buffer2.add(6);
-  /// 
+  ///
   /// let zipped = Buffer.zipWith<Nat, Nat, Nat>(buffer1, buffer2, func (x, y) { x + y });
   /// Buffer.toArray(zipped) // => [5, 7, 9]
   /// ```
-  /// 
+  ///
   /// | Runtime   | Space     |
   /// |-----------|-----------|
   /// | `O(min(size1, size2))` | `O(min(size1, size2))` |
-  /// 
+  ///
   public func zipWith<X, Y, Z>(buffer1 : Buffer<X>, buffer2 : Buffer<Y>, zip : (X, Y) -> Z) : Buffer<Z> {
     let size1 = buffer1.size();
     let size2 = buffer2.size();
@@ -2581,20 +2569,20 @@ module {
 
   /// Creates a new buffer taking elements in order from `buffer` until predicate
   /// returns false.
-  /// 
+  ///
   /// Example:
-  /// 
+  ///
   /// ```motoko include=initialize
   /// import Nat "mo:base/Nat";
-  /// 
+  ///
   /// buffer.add(1);
   /// buffer.add(2);
   /// buffer.add(3);
-  /// 
+  ///
   /// let newBuf = Buffer.takeWhile<Nat>(buffer, func (x) { x < 3 });
   /// Buffer.toText(newBuf, Nat.toText); // => [1, 2]
   /// ```
-  /// 
+  ///
   /// | Runtime   | Space     |
   /// |-----------|-----------|
   /// | `O(size)` | `O(size)` |
@@ -2613,20 +2601,20 @@ module {
 
   /// Creates a new buffer excluding elements in order from `buffer` until predicate
   /// returns false.
-  /// 
+  ///
   /// Example:
-  /// 
+  ///
   /// ```motoko include=initialize
   /// import Nat "mo:base/Nat";
-  /// 
+  ///
   /// buffer.add(1);
   /// buffer.add(2);
   /// buffer.add(3);
-  /// 
+  ///
   /// let newBuf = Buffer.dropWhile<Nat>(buffer, func x { x < 3 }); // => [3]
   /// Buffer.toText(newBuf, Nat.toText);
   /// ```
-  /// 
+  ///
   /// | Runtime   | Space     |
   /// |-----------|-----------|
   /// | `O(size)` | `O(size)` |

--- a/src/CertifiedData.mo
+++ b/src/CertifiedData.mo
@@ -1,22 +1,22 @@
 /// The Internet Computer allows canister smart contracts to store a small amount of data during
 /// update method processing so that during query call processing, the canister can obtain
 /// a certificate about that data.
-/// 
+///
 /// :::info Intended audience
-/// 
+///
 /// This module provides a _low-level_ interface to this API, aimed at advanced
 /// users and library implementors. See the Internet Computer interface
 /// specification and corresponding documentation for how to use this to make query
 /// calls to your canister tamperproof.
 /// :::
-/// 
+///
 
 import Prim "mo:⛔";
 
 module {
 
   /// Set the certified data.
-  /// 
+  ///
   /// :::note Usage constraints
   ///
   /// Must be called from an update method, else traps.
@@ -35,15 +35,15 @@ module {
   /// let blob = Blob.fromArray(array);
   /// CertifiedData.set(blob);
   /// ```
-  /// 
+  ///
   /// :::info
   /// [See a full example on how to use certified variables](https://github.com/dfinity/examples/tree/master/motoko/cert-var).
   /// :::
-  /// 
+  ///
   public let set : (data : Blob) -> () = Prim.setCertifiedData;
 
   /// Gets a certificate.
-  /// 
+  ///
   /// :::note When available
   ///
   /// Returns `null` if no certificate is available, e.g. when processing an

--- a/src/Debug.mo
+++ b/src/Debug.mo
@@ -1,5 +1,5 @@
 /// Utility functions for debugging.
-/// 
+///
 /// Import from the base library to use this module.
 /// ```motoko name=import
 /// import Debug "mo:base/Debug";
@@ -8,13 +8,13 @@
 import Prim "mo:⛔";
 module {
   /// Prints `text` to output stream.
-  /// 
+  ///
   /// :::note
   /// When running on ICP, all output is written to the [canister log](https://internetcomputer.org/docs/current/developer-docs/smart-contracts/maintain/logs) with the exclusion of any output
   /// produced during the execution of non-replicated queries and composite queries.
   /// In other environments, like the interpreter and stand-alone Wasm engines, the output is written to standard out.
   /// :::
-  /// 
+  ///
   /// ```motoko include=import
   /// Debug.print "Hello New World!";
   /// Debug.print(debug_show(4)) // Often used with `debug_show` to convert values to Text
@@ -24,28 +24,28 @@ module {
   };
 
   /// `trap(t)` traps execution with a user-provided diagnostic message.
-  /// 
+  ///
   /// The caller of a future whose execution called `trap(t)` will
   /// observe the trap as an `Error` value, thrown at `await`, with code
   /// `#canister_error` and message `m`. Here `m` is a more descriptive `Text`
   /// message derived from the provided `t`. See example for more details.
-  /// 
+  ///
   /// :::note
 
   /// Other execution environments that cannot handle traps may only
   /// propagate the trap and terminate execution, with or without some
   /// descriptive message.
   /// :::
-  /// 
+  ///
   /// ```motoko
   /// import Debug "mo:base/Debug";
   /// import Error "mo:base/Error";
-  /// 
+  ///
   /// actor {
   ///   func fail() : async () {
   ///     Debug.trap("user provided error message");
   ///   };
-  /// 
+  ///
   ///   public func foo() : async () {
   ///     try {
   ///       await fail();

--- a/src/Deque.mo
+++ b/src/Deque.mo
@@ -1,19 +1,19 @@
 /// Double-ended queue (deque) of a generic element type `T`.
-/// 
+///
 /// The interface of deques is purely functional, not imperative, and deques are immutable values.
 /// In particular, deque operations such as push and pop do not update their input deque but instead return the value of the modified deque, alongside any other data.
 /// The input deque is left unchanged.
-/// 
+///
 /// Examples of use-cases:
 /// Queue (FIFO) by using `pushBack()` and `popFront()`.
 /// Stack (LIFO) by using `pushFront()` and `popFront()`.
-/// 
+///
 /// A deque is internally implemented as two lists, a head access list and a (reversed) tail access list, that are dynamically size-balanced by splitting.
-/// 
+///
 /// Construction: Create a new deque with the `empty<T>()` function.
-/// 
+///
 /// :::note Performance characteristics
-/// 
+///
 /// Push and pop operations have `O(1)` amortized cost and `O(n)` worst-case cost per call.
 /// Space usage follows the same pattern.
 /// `n` denotes the number of elements stored in the deque.
@@ -29,14 +29,14 @@ module {
   public type Deque<T> = (List<T>, List<T>);
 
   /// Create a new empty deque.
-  /// 
+  ///
   /// Example:
   /// ```motoko
   /// import Deque "mo:base/Deque";
-  /// 
+  ///
   /// Deque.empty<Nat>()
   /// ```
-  /// 
+  ///
   /// | Runtime | Space |
   /// |---------|--------|
   /// | `O(1)`  | `O(1)` |
@@ -45,15 +45,15 @@ module {
 
   /// Determine whether a deque is empty.
   /// Returns true if `deque` is empty, otherwise `false`.
-  /// 
+  ///
   /// Example:
   /// ```motoko
   /// import Deque "mo:base/Deque";
-  /// 
+  ///
   /// let deque = Deque.empty<Nat>();
   /// Deque.isEmpty(deque) // => true
   /// ```
-  /// 
+  ///
   /// | Runtime | Space |
   /// |---------|--------|
   /// | `O(1)`  | `O(1)` |
@@ -79,20 +79,20 @@ module {
 
   /// Insert a new element on the front end of a deque.
   /// Returns the new deque with `element` in the front followed by the elements of `deque`.
-  /// 
+  ///
   /// This may involve dynamic rebalancing of the two, internally used lists.
-  /// 
+  ///
   /// Example:
   /// ```motoko
   /// import Deque "mo:base/Deque";
-  /// 
+  ///
   /// Deque.pushFront(Deque.pushFront(Deque.empty<Nat>(), 2), 1) // deque with elements [1, 2]
   /// ```
-  /// 
+  ///
   /// | Runtime (worst) | Runtime (amortized) | Space (worst) | Space (amortized) |
   /// |------------------|----------------------|----------------|---------------------|
   /// | `O(n)`           | `O(1)`               | `O(n)`         | `O(1)`              |
-  /// 
+  ///
   /// `n` denotes the number of elements stored in the deque.
   public func pushFront<T>(deque : Deque<T>, element : T) : Deque<T> {
     check(List.push(element, deque.0), deque.1)
@@ -100,19 +100,19 @@ module {
 
   /// Inspect the optional element on the front end of a deque.
   /// Returns `null` if `deque` is empty. Otherwise, the front element of `deque`.
-  /// 
+  ///
   /// Example:
   /// ```motoko
   /// import Deque "mo:base/Deque";
-  /// 
+  ///
   /// let deque = Deque.pushFront(Deque.pushFront(Deque.empty<Nat>(), 2), 1);
   /// Deque.peekFront(deque) // => ?1
   /// ```
-  /// 
+  ///
   /// | Runtime | Space |
   /// |---------|--------|
   /// | `O(1)`  | `O(1)` |
-  /// 
+  ///
   public func peekFront<T>(deque : Deque<T>) : ?T {
     switch deque {
       case (?(x, _f), _r) { ?x };
@@ -124,9 +124,9 @@ module {
   /// Remove the element on the front end of a deque.
   /// Returns `null` if `deque` is empty. Otherwise, it returns a pair of
   /// the first element and a new deque that contains all the remaining elements of `deque`.
-  /// 
+  ///
   /// This may involve dynamic rebalancing of the two, internally used lists.
-  /// 
+  ///
   /// Example:
   /// ```motoko
   /// import Deque "mo:base/Deque";
@@ -144,7 +144,7 @@ module {
   ///   }
   /// }
   /// ```
-  /// 
+  ///
   /// | Runtime (worst) | Runtime (amortized) | Space (worst) | Space (amortized) |
   /// |------------------|----------------------|----------------|---------------------|
   /// | `O(n)`           | `O(1)`               | `O(n)`         | `O(1)`              |
@@ -158,20 +158,20 @@ module {
 
   /// Insert a new element on the back end of a deque.
   /// Returns the new deque with all the elements of `deque`, followed by `element` on the back.
-  /// 
+  ///
   /// This may involve dynamic rebalancing of the two, internally used lists.
-  /// 
+  ///
   /// Example:
   /// ```motoko
   /// import Deque "mo:base/Deque";
-  /// 
+  ///
   /// Deque.pushBack(Deque.pushBack(Deque.empty<Nat>(), 1), 2) // deque with elements [1, 2]
   /// ```
-  /// 
+  ///
   /// | Runtime (worst) | Runtime (amortized) | Space (worst) | Space (amortized) |
   /// |------------------|----------------------|----------------|---------------------|
   /// | `O(n)`           | `O(1)`               | `O(n)`         | `O(1)`              |
-  /// 
+  ///
   /// `n` denotes the number of elements stored in the deque.
   public func pushBack<T>(deque : Deque<T>, element : T) : Deque<T> {
     check(deque.0, List.push(element, deque.1))
@@ -179,20 +179,20 @@ module {
 
   /// Inspect the optional element on the back end of a deque.
   /// Returns `null` if `deque` is empty. Otherwise, the back element of `deque`.
-  /// 
+  ///
   /// Example:
   /// ```motoko
   /// import Deque "mo:base/Deque";
-  /// 
+  ///
   /// let deque = Deque.pushBack(Deque.pushBack(Deque.empty<Nat>(), 1), 2);
   /// Deque.peekBack(deque) // => ?2
   /// ```
-  /// 
+  ///
   /// | Runtime | Space |
   /// |---------|--------|
   /// | `O(1)`  | `O(1)` |
-  /// 
-  /// 
+  ///
+  ///
   public func peekBack<T>(deque : Deque<T>) : ?T {
     switch deque {
       case (_f, ?(x, _r)) { ?x };
@@ -205,14 +205,14 @@ module {
   /// Returns `null` if `deque` is empty. Otherwise, it returns a pair of
   /// a new deque that contains the remaining elements of `deque`
   /// and, as the second pair item, the removed back element.
-  /// 
+  ///
   /// This may involve dynamic rebalancing of the two, internally used lists.
-  /// 
+  ///
   /// Example:
   /// ```motoko
   /// import Deque "mo:base/Deque";
   /// import Debug "mo:base/Debug";
-  /// 
+  ///
   /// let initial = Deque.pushBack(Deque.pushBack(Deque.empty<Nat>(), 1), 2);
   /// // initial deque with elements [1, 2]
   /// let reduced = Deque.popBack(initial);
@@ -226,7 +226,7 @@ module {
   ///   }
   /// }
   /// ```
-  /// 
+  ///
   /// | Runtime (worst) | Runtime (amortized) | Space (worst) | Space (amortized) |
   /// |------------------|----------------------|----------------|---------------------|
   /// | `O(n)`           | `O(1)`               | `O(n)`         | `O(1)`              |

--- a/src/Error.mo
+++ b/src/Error.mo
@@ -1,5 +1,5 @@
 /// Error values and inspection.
-/// 
+///
 /// The `Error` type is the argument to `throw`, parameter of `catch`.
 /// The `Error` type is opaque.
 
@@ -35,44 +35,44 @@ module {
   public type ErrorCode = Prim.ErrorCode;
 
   /// Create an error from the message with the code `#canister_reject`.
-  /// 
+  ///
   /// Example:
   /// ```motoko
   /// import Error "mo:base/Error";
-  /// 
+  ///
   /// Error.reject("Example error") // can be used as throw argument
   /// ```
   public let reject : (message : Text) -> Error = Prim.error;
 
   /// Returns the code of an error.
-  /// 
+  ///
   /// Example:
   /// ```motoko
   /// import Error "mo:base/Error";
-  /// 
+  ///
   /// let error = Error.reject("Example error");
   /// Error.code(error) // #canister_reject
   /// ```
   public let code : (error : Error) -> ErrorCode = Prim.errorCode;
 
   /// Returns the message of an error.
-  /// 
+  ///
   /// Example:
   /// ```motoko
   /// import Error "mo:base/Error";
-  /// 
+  ///
   /// let error = Error.reject("Example error");
   /// Error.message(error) // "Example error"
   /// ```
   public let message : (error : Error) -> Text = Prim.errorMessage;
 
   /// Returns whether retrying to send a message may result in success.
-  /// 
+  ///
   /// Example:
   /// ```motoko
   /// import { message; isRetryPossible } "mo:base/Error";
   /// import { print } "mo:base/Debug";
-  /// 
+  ///
   /// try await (with timeout = 3) Actor.call(arg)
   /// catch e { if (isRetryPossible e) print(message e) }
   /// ```

--- a/src/ExperimentalCycles.mo
+++ b/src/ExperimentalCycles.mo
@@ -1,25 +1,25 @@
 /// Managing cycles within actors on the Internet Computer (ICP).
-/// 
+///
 /// The usage of the Internet Computer is measured, and paid for, in _cycles_.
 /// This library provides imperative operations for observing cycles, transferring cycles, and observing refunds of cycles.
-/// 
+///
 /// :::warning Experimental API
-/// 
+///
 /// This low-level API is experimental and may change or be removed in the future.
 /// Dedicated syntactic support for manipulating cycles may be added to the language, which would make this library obsolete.
 /// :::
-/// 
+///
 /// :::note Volatile cycle balance
-/// 
+///
 /// Since cycles measure computational resources, the value of `balance()` can change from one call to the next.
 /// :::
-/// 
+///
 /// Example:
-/// 
+///
 /// ```motoko no-repl
 /// import Cycles "mo:base/ExperimentalCycles";
 /// import Debug "mo:base/Debug";
-/// 
+///
 /// actor {
 ///  public func main() : async() {
 ///    Debug.print("Main balance: " # debug_show(Cycles.balance()));
@@ -28,7 +28,7 @@
 ///    Debug.print("Main refunded: " # debug_show(Cycles.refunded())); // 5_000_000
 ///    Debug.print("Main balance: " # debug_show(Cycles.balance())); // decreased by around 10_000_000
 ///  };
-/// 
+///
 ///  func operation() : async() {
 ///    Debug.print("Operation balance: " # debug_show(Cycles.balance()));
 ///    Debug.print("Operation available: " # debug_show(Cycles.available()));
@@ -43,12 +43,12 @@ import Prim "mo:⛔";
 module {
 
   /// Returns the actor's current balance of cycles as `amount`.
-  /// 
+  ///
   /// Example:
   /// ```motoko no-repl
   /// import Cycles "mo:base/ExperimentalCycles";
   /// import Debug "mo:base/Debug";
-  /// 
+  ///
   /// actor {
   ///   public func main() : async() {
   ///     let balance = Cycles.balance();
@@ -63,12 +63,12 @@ module {
   /// minus the cumulative amount `accept`ed by this call.
   /// On exit from the current shared function or async expression via `return` or `throw`,
   /// any remaining available amount is automatically refunded to the caller/context.
-  /// 
+  ///
   /// Example:
   /// ```motoko no-repl
   /// import Cycles "mo:base/ExperimentalCycles";
   /// import Debug "mo:base/Debug";
-  /// 
+  ///
   /// actor {
   ///   public func main() : async() {
   ///     let available = Cycles.available();
@@ -81,18 +81,18 @@ module {
   /// Transfers up to `amount` from `available()` to `balance()`.
   /// Returns the amount actually transferred, which may be less than
   /// requested, for example, if less is available, or if canister balance limits are reached.
-  /// 
+  ///
   /// Example (for simplicity, only transferring cycles to itself):
   /// ```motoko no-repl
   /// import Cycles "mo:base/ExperimentalCycles";
   /// import Debug "mo:base/Debug";
-  /// 
+  ///
   /// actor {
   ///   public func main() : async() {
   ///     Cycles.add<system>(15_000_000);
   ///     await operation(); // accepts 10_000_000 cycles
   ///   };
-  /// 
+  ///
   ///   func operation() : async() {
   ///     let obtained = Cycles.accept<system>(10_000_000);
   ///     Debug.print("Obtained: " # debug_show(obtained)); // => 10_000_000
@@ -108,21 +108,21 @@ module {
   /// Upon the call, but not before, the total amount of cycles ``add``ed since
   /// the last call is deducted from `balance()`.
   /// If this total exceeds `balance()`, the caller traps, aborting the call.
-  /// 
+  ///
   /// :::note Reset behavior
-  /// 
+  ///
   /// The implicit register of added amounts is reset to zero on entry to a shared function and after each shared function call or resume from an await.
   /// :::
-  /// 
+  ///
   /// Example (for simplicity, only transferring cycles to itself):
   /// ```motoko no-repl
   /// import Cycles "mo:base/ExperimentalCycles";
-  /// 
+  ///
   /// actor {
   ///   func operation() : async() {
   ///     ignore Cycles.accept<system>(10_000_000);
   ///   };
-  /// 
+  ///
   ///   public func main() : async() {
   ///     Cycles.add<system>(15_000_000);
   ///     await operation();
@@ -137,17 +137,17 @@ module {
   /// Calling `refunded()` is solely informational and does not affect `balance()`.
   /// Instead, refunds are automatically added to the current balance,
   /// whether or not `refunded` is used to observe them.
-  /// 
+  ///
   /// Example (for simplicity, only transferring cycles to itself):
   /// ```motoko no-repl
   /// import Cycles "mo:base/ExperimentalCycles";
   /// import Debug "mo:base/Debug";
-  /// 
+  ///
   /// actor {
   ///   func operation() : async() {
   ///     ignore Cycles.accept<system>(10_000_000);
   ///   };
-  /// 
+  ///
   ///   public func main() : async() {
   ///     Cycles.add<system>(15_000_000);
   ///     await operation(); // accepts 10_000_000 cycles
@@ -160,12 +160,12 @@ module {
   /// Attempts to burn `amount` of cycles, deducting `burned` from the canister's
   /// cycle balance. The burned cycles are irrevocably lost and not available to any
   /// other principal either.
-  /// 
+  ///
   /// Example:
   /// ```motoko no-repl
   /// import Cycles "mo:base/ExperimentalCycles";
   /// import Debug "mo:base/Debug";
-  /// 
+  ///
   /// actor {
   ///   public func main() : async() {
   ///     let burnt = Cycles.burn<system>(10_000_000);

--- a/src/ExperimentalInternetComputer.mo
+++ b/src/ExperimentalInternetComputer.mo
@@ -1,5 +1,5 @@
 /// Low-level interface to the Internet Computer.
-/// 
+///
 /// :::warning Experimental API
 /// This low-level API is **experimental** and likely to change or even disappear.
 /// :::
@@ -9,26 +9,26 @@ module {
 
   /// Calls ``canister``'s update or query function, `name`, with the binary contents of `data` as IC argument.
   /// Returns the response to the call, an IC _reply_ or _reject_, as a Motoko future:
-  /// 
+  ///
   /// * The message data of an IC reply determines the binary contents of `reply`.
   /// * The error code and textual message data of an IC reject determines the future's `Error` value.
-  /// 
+  ///
   /// Asynchronous context required: `call` is an asynchronous function and can only be applied in an asynchronous context.
-  
+
   /// Example:
   /// ```motoko no-repl
   /// import IC "mo:base/ExperimentalInternetComputer";
   /// import Principal "mo:base/Principal";
-  /// 
+  ///
   /// let ledger = Principal.fromText("ryjl3-tyaaa-aaaaa-aaaba-cai");
   /// let method = "decimals";
   /// let input = ();
   /// type OutputType = { decimals : Nat32 };
-  /// 
+  ///
   /// let rawReply = await IC.call(ledger, method, to_candid(input)); // serialized Candid
   /// let output : ?OutputType = from_candid(rawReply); // { decimals = 8 }
   /// ```
-  /// 
+  ///
   /// [Learn more about Candid serialization](https://internetcomputer.org/docs/current/motoko/main/reference/language-manual#candid-serialization)
   public let call : (canister : Principal, name : Text, data : Blob) -> async (reply : Blob) = Prim.call_raw;
 
@@ -50,7 +50,7 @@ module {
 
   /// ```motoko no-repl
   /// import IC "mo:base/ExperimentalInternetComputer";
-  /// 
+  ///
   /// let count = IC.countInstructions(func() {
   // ...
   /// });
@@ -66,24 +66,24 @@ module {
   };
 
   /// Returns the current value of IC _performance counter_ `counter`.
-  /// 
+  ///
   /// * Counter `0` is the _current execution instruction counter_, counting instructions only since the beginning of the current IC message.
   ///   This counter is reset to value `0` on shared function entry and every `await`.
   ///   It is therefore only suitable for measuring the cost of synchronous code.
-  /// 
+  ///
   /// * Counter `1` is the _call context instruction counter_  for the current shared function call.
   ///   For replicated message executing, this excludes the cost of nested IC calls (even to the current canister).
   ///   For non-replicated messages, such as composite queries, it includes the cost of nested calls.
   ///   The current value of this counter is preserved across `awaits` (unlike counter `0`).
-  /// 
+  ///
   /// * The function (currently) traps if `counter` >= 2.
-  /// 
+  ///
   /// Consult [Performance Counter](https://internetcomputer.org/docs/current/references/ic-interface-spec#system-api-performance-counter) for details.
-  /// 
+  ///
   /// Example:
   /// ```motoko no-repl
   /// import IC "mo:base/ExperimentalInternetComputer";
-  /// 
+  ///
   /// let c1 = IC.performanceCounter(1);
   /// work();
   /// let diff : Nat64 = IC.performanceCounter(1) - c1;
@@ -100,11 +100,11 @@ module {
 
   /// Returns the subnet's principal for the running actor.
   /// Note: Due to canister migration the hosting subnet can vary with time.
-  /// 
+  ///
   /// Example:
   /// ```motoko no-repl
   /// import IC "mo:base/ExperimentalInternetComputer";
-  /// 
+  ///
   /// let subnetPrincipal = IC.subnet();
   /// ```
   public let subnet : () -> Principal = Prim.canisterSubnet;

--- a/src/ExperimentalStableMemory.mo
+++ b/src/ExperimentalStableMemory.mo
@@ -1,45 +1,45 @@
 /// Byte-level access to (virtual) _stable memory_.
-/// 
+///
 /// :::warning Experimental module
-/// 
+///
 /// As the name suggests, this library is experimental, subject to change, and may be replaced by safer alternatives in later versions of Motoko.
 /// Use at your own risk and discretion.
 /// :::
-/// 
+///
 /// :::warning Deprecation notice
-/// 
+///
 /// Use of `ExperimentalStableMemory` may be deprecated in the future.
 /// Consider using `Region.mo` for isolated memory regions.
 /// Isolated regions ensure that writing to one region does not affect unrelated state elsewhere.
 /// :::
-/// 
+///
 /// This is a lightweight abstraction over IC _stable memory_ and supports persisting raw binary data across Motoko upgrades.
 /// It is fully compatible with Motoko's _stable variables_, which also use IC stable memory internally, but do not interfere with this API.
-/// 
+///
 /// Memory is allocated using `grow(pages)`, sequentially and on demand, in units of 64KiB pages, starting with 0 allocated pages.
 /// New pages are zero-initialized.
 /// Growth is capped by a soft page limit set with the compile-time flag `--max-stable-pages <n>` (default: 65536, or 4GiB).
-/// 
+///
 /// Each `load` reads from byte address `offset` in little-endian format using the natural bit-width of the type.
 /// Traps if reading beyond the allocated size.
-/// 
+///
 /// Each `store` writes to byte address `offset` in little-endian format using the natural bit-width of the type.
 /// Traps if writing beyond the allocated size.
-/// 
+///
 /// Text can be handled using `Text.decodeUtf8` and `Text.encodeUtf8` in combination with `loadBlob` and `storeBlob`.
-/// 
+///
 /// The current page allocation and contents are preserved across upgrades.
-/// 
+///
 /// :::note IC stable memory discrepancy
-/// 
+///
 /// The IC’s reported stable memory size (`ic0.stable_size`) may exceed what Motoko’s `size()` returns.
 /// This and the growth cap exist to protect Motoko’s internal use of stable variables.
 /// If you're not using stable variables (or using them sparingly), you may increase `--max-stable-pages` toward the IC maximum (currently 64GiB).
 /// Even if not using stable variables, always reserve at least one page.
 /// :::
-/// 
+///
 /// Usage:
-/// 
+///
 /// ```motoko no-repl
 /// import StableMemory "mo:base/ExperimentalStableMemory";
 /// ```
@@ -53,7 +53,7 @@ module {
   /// Initially `0`.
   /// Preserved across upgrades, together with contents of allocated
   /// stable memory.
-  /// 
+  ///
   /// Example:
   /// ```motoko no-repl
   /// let beforeSize = StableMemory.size();
@@ -70,11 +70,11 @@ module {
   /// Every new page is zero-initialized, containing byte 0x00 at every offset.
   /// Function `grow` is capped by a soft limit on `size` controlled by compile-time flag
   ///  `--max-stable-pages <n>` (the default is 65536, or 4GiB).
-  /// 
+  ///
   /// Example:
   /// ```motoko no-repl
   /// import Error "mo:base/Error";
-  /// 
+  ///
   /// let beforeSize = StableMemory.grow(10);
   /// if (beforeSize == 0xFFFF_FFFF_FFFF_FFFF) {
   ///   throw Error.reject("Out of memory");
@@ -90,7 +90,7 @@ module {
   /// The query computes the estimate by running the first half of an upgrade, including any `preupgrade` system method.
   /// Like any other query, its state changes are discarded so no actual upgrade (or other state change) takes place.
   /// The query can only be called by the enclosing actor and will trap for other callers.
-  /// 
+  ///
   /// Example:
   /// ```motoko no-repl
   /// actor {
@@ -108,7 +108,7 @@ module {
 
   /// Loads a `Nat32` value from stable memory at the given `offset`.
   /// Traps on an out-of-bounds access.
-  /// 
+  ///
   /// Example:
   /// ```motoko no-repl
   /// let offset = 0;
@@ -120,7 +120,7 @@ module {
 
   /// Stores a `Nat32` value in stable memory at the given `offset`.
   /// Traps on an out-of-bounds access.
-  /// 
+  ///
   /// Example:
   /// ```motoko no-repl
   /// let offset = 0;
@@ -132,7 +132,7 @@ module {
 
   /// Loads a `Nat8` value from stable memory at the given `offset`.
   /// Traps on an out-of-bounds access.
-  /// 
+  ///
   /// Example:
   /// ```motoko no-repl
   /// let offset = 0;
@@ -144,7 +144,7 @@ module {
 
   /// Stores a `Nat8` value in stable memory at the given `offset`.
   /// Traps on an out-of-bounds access.
-  /// 
+  ///
   /// Example:
   /// ```motoko no-repl
   /// let offset = 0;
@@ -156,7 +156,7 @@ module {
 
   /// Loads a `Nat16` value from stable memory at the given `offset`.
   /// Traps on an out-of-bounds access.
-  /// 
+  ///
   /// Example:
   /// ```motoko no-repl
   /// let offset = 0;
@@ -168,7 +168,7 @@ module {
 
   /// Stores a `Nat16` value in stable memory at the given `offset`.
   /// Traps on an out-of-bounds access.
-  /// 
+  ///
   /// Example:
   /// ```motoko no-repl
   /// let offset = 0;
@@ -180,7 +180,7 @@ module {
 
   /// Loads a `Nat64` value from stable memory at the given `offset`.
   /// Traps on an out-of-bounds access.
-  /// 
+  ///
   /// Example:
   /// ```motoko no-repl
   /// let offset = 0;
@@ -192,7 +192,7 @@ module {
 
   /// Stores a `Nat64` value in stable memory at the given `offset`.
   /// Traps on an out-of-bounds access.
-  /// 
+  ///
   /// Example:
   /// ```motoko no-repl
   /// let offset = 0;
@@ -204,7 +204,7 @@ module {
 
   /// Loads an `Int32` value from stable memory at the given `offset`.
   /// Traps on an out-of-bounds access.
-  /// 
+  ///
   /// Example:
   /// ```motoko no-repl
   /// let offset = 0;
@@ -216,7 +216,7 @@ module {
 
   /// Stores an `Int32` value in stable memory at the given `offset`.
   /// Traps on an out-of-bounds access.
-  /// 
+  ///
   /// Example:
   /// ```motoko no-repl
   /// let offset = 0;
@@ -228,7 +228,7 @@ module {
 
   /// Loads an `Int8` value from stable memory at the given `offset`.
   /// Traps on an out-of-bounds access.
-  /// 
+  ///
   /// Example:
   /// ```motoko no-repl
   /// let offset = 0;
@@ -240,7 +240,7 @@ module {
 
   /// Stores an `Int8` value in stable memory at the given `offset`.
   /// Traps on an out-of-bounds access.
-  /// 
+  ///
   /// Example:
   /// ```motoko no-repl
   /// let offset = 0;
@@ -252,7 +252,7 @@ module {
 
   /// Loads an `Int16` value from stable memory at the given `offset`.
   /// Traps on an out-of-bounds access.
-  /// 
+  ///
   /// Example:
   /// ```motoko no-repl
   /// let offset = 0;
@@ -264,7 +264,7 @@ module {
 
   /// Stores an `Int16` value in stable memory at the given `offset`.
   /// Traps on an out-of-bounds access.
-  /// 
+  ///
   /// Example:
   /// ```motoko no-repl
   /// let offset = 0;
@@ -276,7 +276,7 @@ module {
 
   /// Loads an `Int64` value from stable memory at the given `offset`.
   /// Traps on an out-of-bounds access.
-  /// 
+  ///
   /// Example:
   /// ```motoko no-repl
   /// let offset = 0;
@@ -288,7 +288,7 @@ module {
 
   /// Stores an `Int64` value in stable memory at the given `offset`.
   /// Traps on an out-of-bounds access.
-  /// 
+  ///
   /// Example:
   /// ```motoko no-repl
   /// let offset = 0;
@@ -300,7 +300,7 @@ module {
 
   /// Loads a `Float` value from stable memory at the given `offset`.
   /// Traps on an out-of-bounds access.
-  /// 
+  ///
   /// Example:
   /// ```motoko no-repl
   /// let offset = 0;
@@ -312,7 +312,7 @@ module {
 
   /// Stores a `Float` value in stable memory at the given `offset`.
   /// Traps on an out-of-bounds access.
-  /// 
+  ///
   /// Example:
   /// ```motoko no-repl
   /// let offset = 0;
@@ -324,11 +324,11 @@ module {
 
   /// Load `size` bytes starting from `offset` as a `Blob`.
   /// Traps on an out-of-bounds access.
-  /// 
+  ///
   /// Example:
   /// ```motoko no-repl
   /// import Blob "mo:base/Blob";
-  /// 
+  ///
   /// let offset = 0;
   /// let value = Blob.fromArray([1, 2, 3]);
   /// let size = value.size();
@@ -339,11 +339,11 @@ module {
 
   /// Write bytes of `blob` beginning at `offset`.
   /// Traps on an out-of-bounds access.
-  /// 
+  ///
   /// Example:
   /// ```motoko no-repl
   /// import Blob "mo:base/Blob";
-  /// 
+  ///
   /// let offset = 0;
   /// let value = Blob.fromArray([1, 2, 3]);
   /// let size = value.size();

--- a/src/Float.mo
+++ b/src/Float.mo
@@ -1,15 +1,15 @@
 /// Double precision (64-bit) floating-point numbers in IEEE 754 representation.
-/// 
+///
 /// This module contains common floating-point constants and utility functions.
-/// 
+///
 /// Notation for special values in the documentation below:
-/// 
+///
 /// `+inf`: Positive infinity
-/// 
+///
 /// `-inf`: Negative infinity
-/// 
+///
 /// `NaN`: "not a number" (can have different sign bit values, but `NaN != NaN` regardless of the sign).
-/// 
+///
 /// :::note
 /// Floating point numbers have limited precision and operations may inherently result in numerical errors.
 /// :::
@@ -18,29 +18,29 @@
 ///   ```motoko
 ///   0.1 + 0.1 + 0.1 == 0.3 // => false
 ///   ```
-/// 
+///
 ///   ```motoko
 ///  1e16 + 1.0 != 1e16 // => false
 ///   ```
-/// 
-/// 
+///
+///
 /// Advice:
 /// * Floating point number comparisons by `==` or `!=` are discouraged. Instead, it is better to compare
 ///   floating-point numbers with a numerical tolerance, called epsilon.
-/// 
+///
 ///   Example:
 ///   ```motoko
 ///   import Float "mo:base/Float";
 ///   let x = 0.1 + 0.1 + 0.1;
 ///   let y = 0.3;
-/// 
+///
 ///   let epsilon = 1e-6; // This depends on the application case (needs a numerical error analysis).
 ///   Float.equalWithin(x, y, epsilon) // => true
 ///   ```
-/// 
+///
 /// * For absolute precision, it is recommend to encode the fraction number as a pair of a `Nat` for the base
 ///   and a `Nat` for the exponent (decimal point).
-/// 
+///
 /// `NaN` sign:
 /// * The `NaN` sign is only applied by `abs`, `neg`, and `copySign`. Other operations can have an arbitrary
 ///   sign bit for `NaN` results.
@@ -66,11 +66,11 @@ module {
   /// * Equality test of `NaN` with itself or another number is always `false`.
   /// * There exist many internal `NaN` value representations, such as positive and negative `NaN`,
   ///   signalling and quiet `NaN`s, each with many different bit representations.
-  /// 
+  ///
   /// Example:
   /// ```motoko
   /// import Float "mo:base/Float";
-  /// 
+  ///
   /// Float.isNaN(0.0/0.0) // => true
   /// ```
   public func isNaN(number : Float) : Bool {
@@ -78,7 +78,7 @@ module {
   };
 
   /// Returns the absolute value of `x`.
-  /// 
+  ///
   /// Special cases:
   /// ```
   /// abs(+inf) => +inf
@@ -86,17 +86,17 @@ module {
   /// abs(-NaN)  => +NaN
   /// abs(-0.0) => 0.0
   /// ```
-  /// 
+  ///
   /// Example:
   /// ```motoko
   /// import Float "mo:base/Float";
-  /// 
+  ///
   /// Float.abs(-1.2) // => 1.2
   /// ```
   public let abs : (x : Float) -> Float = Prim.floatAbs;
 
   /// Returns the square root of `x`.
-  /// 
+  ///
   /// Special cases:
   /// ```
   /// sqrt(+inf) => +inf
@@ -104,17 +104,17 @@ module {
   /// sqrt(x)    => NaN if x < 0.0
   /// sqrt(NaN)  => NaN
   /// ```
-  /// 
+  ///
   /// Example:
   /// ```motoko
   /// import Float "mo:base/Float";
-  /// 
+  ///
   /// Float.sqrt(6.25) // => 2.5
   /// ```
   public let sqrt : (x : Float) -> Float = Prim.floatSqrt;
 
   /// Returns the smallest integral float greater than or equal to `x`.
-  /// 
+  ///
   /// Special cases:
   /// ```
   /// ceil(+inf) => +inf
@@ -123,17 +123,17 @@ module {
   /// ceil(0.0)  => 0.0
   /// ceil(-0.0) => -0.0
   /// ```
-  /// 
+  ///
   /// Example:
   /// ```motoko
   /// import Float "mo:base/Float";
-  /// 
+  ///
   /// Float.ceil(1.2) // => 2.0
   /// ```
   public let ceil : (x : Float) -> Float = Prim.floatCeil;
 
   /// Returns the largest integral float less than or equal to `x`.
-  /// 
+  ///
   /// Special cases:
   /// ```
   /// floor(+inf) => +inf
@@ -142,18 +142,18 @@ module {
   /// floor(0.0)  => 0.0
   /// floor(-0.0) => -0.0
   /// ```
-  /// 
+  ///
   /// Example:
   /// ```motoko
   /// import Float "mo:base/Float";
-  /// 
+  ///
   /// Float.floor(1.2) // => 1.0
   /// ```
   public let floor : (x : Float) -> Float = Prim.floatFloor;
 
   /// Returns the nearest integral float not greater in magnitude than `x`.
   /// This is equivalent to returning `x` with truncating its decimal places.
-  /// 
+  ///
   /// Special cases:
   /// ```
   /// trunc(+inf) => +inf
@@ -162,11 +162,11 @@ module {
   /// trunc(0.0)  => 0.0
   /// trunc(-0.0) => -0.0
   /// ```
-  /// 
+  ///
   /// Example:
   /// ```motoko
   /// import Float "mo:base/Float";
-  /// 
+  ///
   /// Float.trunc(2.75) // => 2.0
   /// ```
   public let trunc : (x : Float) -> Float = Prim.floatTrunc;
@@ -174,7 +174,7 @@ module {
   /// Returns the nearest integral float to `x`.
   /// A decimal place of exactly .5 is rounded up for `x > 0`
   /// and rounded down for `x < 0`
-  /// 
+  ///
   /// Special cases:
   /// ```
   /// nearest(+inf) => +inf
@@ -183,163 +183,163 @@ module {
   /// nearest(0.0)  => 0.0
   /// nearest(-0.0) => -0.0
   /// ```
-  /// 
+  ///
   /// Example:
   /// ```motoko
   /// import Float "mo:base/Float";
-  /// 
+  ///
   /// Float.nearest(2.75) // => 3.0
   /// ```
   public let nearest : (x : Float) -> Float = Prim.floatNearest;
 
   /// Returns `x` if `x` and `y` have same sign, otherwise `x` with negated sign.
-  /// 
+  ///
   /// The sign bit of zero, infinity, and `NaN` is considered.
-  /// 
+  ///
   /// Example:
   /// ```motoko
   /// import Float "mo:base/Float";
-  /// 
+  ///
   /// Float.copySign(1.2, -2.3) // => -1.2
   /// ```
   public let copySign : (x : Float, y : Float) -> Float = Prim.floatCopySign;
 
   /// Returns the smaller value of `x` and `y`.
-  /// 
+  ///
   /// Special cases:
   /// ```
   /// min(NaN, y) => NaN for any Float y
   /// min(x, NaN) => NaN for any Float x
   /// ```
-  /// 
+  ///
   /// Example:
   /// ```motoko
   /// import Float "mo:base/Float";
-  /// 
+  ///
   /// Float.min(1.2, -2.3) // => -2.3 (with numerical imprecision)
   /// ```
   public let min : (x : Float, y : Float) -> Float = Prim.floatMin;
 
   /// Returns the larger value of `x` and `y`.
-  /// 
+  ///
   /// Special cases:
   /// ```
   /// max(NaN, y) => NaN for any Float y
   /// max(x, NaN) => NaN for any Float x
   /// ```
-  /// 
+  ///
   /// Example:
   /// ```motoko
   /// import Float "mo:base/Float";
-  /// 
+  ///
   /// Float.max(1.2, -2.3) // => 1.2
   /// ```
   public let max : (x : Float, y : Float) -> Float = Prim.floatMax;
 
   /// Returns the sine of the radian angle `x`.
-  /// 
+  ///
   /// Special cases:
   /// ```
   /// sin(+inf) => NaN
   /// sin(-inf) => NaN
   /// sin(NaN) => NaN
   /// ```
-  /// 
+  ///
   /// Example:
   /// ```motoko
   /// import Float "mo:base/Float";
-  /// 
+  ///
   /// Float.sin(Float.pi / 2) // => 1.0
   /// ```
   public let sin : (x : Float) -> Float = Prim.sin;
 
   /// Returns the cosine of the radian angle `x`.
-  /// 
+  ///
   /// Special cases:
   /// ```
   /// cos(+inf) => NaN
   /// cos(-inf) => NaN
   /// cos(NaN)  => NaN
   /// ```
-  /// 
+  ///
   /// Example:
   /// ```motoko
   /// import Float "mo:base/Float";
-  /// 
+  ///
   /// Float.cos(Float.pi / 2) // => 0.0 (with numerical imprecision)
   /// ```
   public let cos : (x : Float) -> Float = Prim.cos;
 
   /// Returns the tangent of the radian angle `x`.
-  /// 
+  ///
   /// Special cases:
   /// ```
   /// tan(+inf) => NaN
   /// tan(-inf) => NaN
   /// tan(NaN)  => NaN
   /// ```
-  /// 
+  ///
   /// Example:
   /// ```motoko
   /// import Float "mo:base/Float";
-  /// 
+  ///
   /// Float.tan(Float.pi / 4) // => 1.0 (with numerical imprecision)
   /// ```
   public let tan : (x : Float) -> Float = Prim.tan;
 
   /// Returns the arc sine of `x` in radians.
-  /// 
+  ///
   /// Special cases:
   /// ```
   /// arcsin(x)   => NaN if x > 1.0
   /// arcsin(x)   => NaN if x < -1.0
   /// arcsin(NaN) => NaN
   /// ```
-  /// 
+  ///
   /// Example:
   /// ```motoko
   /// import Float "mo:base/Float";
-  /// 
+  ///
   /// Float.arcsin(1.0) // => Float.pi / 2
   /// ```
   public let arcsin : (x : Float) -> Float = Prim.arcsin;
 
   /// Returns the arc cosine of `x` in radians.
-  /// 
+  ///
   /// Special cases:
   /// ```
   /// arccos(x)  => NaN if x > 1.0
   /// arccos(x)  => NaN if x < -1.0
   /// arcos(NaN) => NaN
   /// ```
-  /// 
+  ///
   /// Example:
   /// ```motoko
   /// import Float "mo:base/Float";
-  /// 
+  ///
   /// Float.arccos(1.0) // => 0.0
   /// ```
   public let arccos : (x : Float) -> Float = Prim.arccos;
 
   /// Returns the arc tangent of `x` in radians.
-  /// 
+  ///
   /// Special cases:
   /// ```
   /// arctan(+inf) => pi / 2
   /// arctan(-inf) => -pi / 2
   /// arctan(NaN)  => NaN
   /// ```
-  /// 
+  ///
   /// Example:
   /// ```motoko
   /// import Float "mo:base/Float";
-  /// 
+  ///
   /// Float.arctan(1.0) // => Float.pi / 4
   /// ```
   public let arctan : (x : Float) -> Float = Prim.arctan;
 
   /// Given `(y,x)`, returns the arc tangent in radians of `y/x` based on the signs of both values to determine the correct quadrant.
-  /// 
+  ///
   /// Special cases:
   /// ```
   /// arctan2(0.0, 0.0)   => 0.0
@@ -353,35 +353,35 @@ module {
   /// arctan2(NaN, x)     => NaN for any Float x
   /// arctan2(y, NaN)     => NaN for any Float y
   /// ```
-  /// 
+  ///
   /// Example:
   /// ```motoko
   /// import Float "mo:base/Float";
-  /// 
+  ///
   /// let sqrt2over2 = Float.sqrt(2) / 2;
   /// Float.arctan2(sqrt2over2, sqrt2over2) // => Float.pi / 4
   /// ```
   public let arctan2 : (y : Float, x : Float) -> Float = Prim.arctan2;
 
   /// Returns the value of `e` raised to the `x`-th power.
-  /// 
+  ///
   /// Special cases:
   /// ```
   /// exp(+inf) => +inf
   /// exp(-inf) => 0.0
   /// exp(NaN)  => NaN
   /// ```
-  /// 
+  ///
   /// Example:
   /// ```motoko
   /// import Float "mo:base/Float";
-  /// 
+  ///
   /// Float.exp(1.0) // => Float.e
   /// ```
   public let exp : (x : Float) -> Float = Prim.exp;
 
   /// Returns the natural logarithm (base-`e`) of `x`.
-  /// 
+  ///
   /// Special cases:
   /// ```
   /// log(0.0)  => -inf
@@ -390,36 +390,36 @@ module {
   /// log(+inf) => +inf
   /// log(NaN)  => NaN
   /// ```
-  /// 
+  ///
   /// Example:
   /// ```motoko
   /// import Float "mo:base/Float";
-  /// 
+  ///
   /// Float.log(Float.e) // => 1.0
   /// ```
   public let log : (x : Float) -> Float = Prim.log;
 
   /// Formatting. `format(fmt, x)` formats `x` to `Text` according to the
   /// formatting directive `fmt`, which can take one of the following forms:
-  /// 
+  ///
   /// * `#fix prec` as fixed-point format with `prec` digits
   /// * `#exp prec` as exponential format with `prec` digits
   /// * `#gen prec` as generic format with `prec` digits
   /// * `#exact` as exact format that can be decoded without loss.
-  /// 
+  ///
   /// `-0.0` is formatted with negative sign bit.
   /// Positive infinity is formatted as "inf".
   /// Negative infinity is formatted as "-inf".
-  /// 
+  ///
   /// :::info
   /// The numerical precision and the text format can vary between
   /// Motoko versions and runtime configuration. Moreover, `NaN` can be printed
   /// differently, i.e. "NaN" or "nan", potentially omitting the `NaN` sign.
-  /// 
+  ///
   /// Example:
   /// ```motoko
   /// import Float "mo:base/Float";
-  /// 
+  ///
   /// Float.format(#exp 3, 123.0) // => "1.230e+02"
   /// ```
   public func format(fmt : { #fix : Nat8; #exp : Nat8; #gen : Nat8; #exact }, x : Float) : Text = switch fmt {
@@ -430,93 +430,89 @@ module {
   };
 
   /// Conversion to `Text`. Use `format(fmt, x)` for more detailed control.
-  /// 
+  ///
   /// `-0.0` is formatted with negative sign bit.
   /// Positive infinity is formatted as `inf`.
   /// Negative infinity is formatted as `-inf`.
   /// `NaN` is formatted as `NaN` or `-NaN` depending on its sign bit.
-  /// 
+  ///
   /// Example:
   /// ```motoko
   /// import Float "mo:base/Float";
-  /// 
+  ///
   /// Float.toText(0.12) // => "0.12"
   /// ```
   public let toText : Float -> Text = Prim.floatToText;
 
   /// Conversion to `Int64` by truncating Float, equivalent to `toInt64(trunc(f))`
-  /// 
+  ///
   /// Traps if the floating point number is larger or smaller than the representable Int64.
   /// Also traps for `inf`, `-inf`, and `NaN`.
-  /// 
+  ///
   /// Example:
   /// ```motoko
   /// import Float "mo:base/Float";
-  /// 
+  ///
   /// Float.toInt64(-12.3) // => -12
   /// ```
   public let toInt64 : Float -> Int64 = Prim.floatToInt64;
 
   /// Conversion from `Int64`.
-  /// 
+  ///
   /// :::note
   /// The floating point number may be imprecise for large or small `Int64`.
   /// :::
-  /// 
+  ///
   /// Example:
   /// ```motoko
   /// import Float "mo:base/Float";
-  /// 
+  ///
   /// Float.fromInt64(-42) // => -42.0
   /// ```
   public let fromInt64 : Int64 -> Float = Prim.int64ToFloat;
 
   /// Conversion to `Int`.
-  /// 
+  ///
   /// Traps for `inf`, `-inf`, and `NaN`.
-  /// 
+  ///
   /// Example:
   /// ```motoko
   /// import Float "mo:base/Float";
-  /// 
+  ///
   /// Float.toInt(1.2e6) // => +1_200_000
   /// ```
   public let toInt : Float -> Int = Prim.floatToInt;
 
   /// Conversion from `Int`. May result in `Inf`.
-  /// 
-  /// :::note 
+  ///
+  /// :::note
   /// The floating point number may be imprecise for large or small Int values.
   /// Returns `inf` if the integer is greater than the maximum floating point number.
   /// Returns `-inf` if the integer is less than the minimum floating point number.
   /// :::
-  /// 
+  ///
   /// Example:
   /// ```motoko
   /// import Float "mo:base/Float";
-  /// 
+  ///
   /// Float.fromInt(-123) // => -123.0
   /// ```
   public let fromInt : Int -> Float = Prim.intToFloat;
 
   /// Returns `x == y`.
-  /// :::warning Deprecated function
-  /// Use `Float.equalWithin()` as this function does not consider numerical errors.
-  /// :::
+  /// @deprecated `Float.equalWithin()` as this function does not consider numerical errors.
   public func equal(x : Float, y : Float) : Bool { x == y };
 
   /// Returns `x != y`.
-  /// :::warning Deprecated function
-  /// Use `Float.notEqualWithin()` as this function does not consider numerical errors.
-  /// :::
+  /// @deprecated Use `Float.notEqualWithin()` as this function does not consider numerical errors.
   public func notEqual(x : Float, y : Float) : Bool { x != y };
 
   /// Determines whether `x` is equal to `y` within the defined tolerance of `epsilon`.
   /// The `epsilon` considers numerical errors, see comment above.
   /// Equivalent to `Float.abs(x - y) <= epsilon` for a non-negative epsilon.
-  /// 
+  ///
   /// Traps if `epsilon` is negative or `NaN`.
-  /// 
+  ///
   /// Special cases:
   /// ```
   /// equalWithin(+0.0, -0.0, epsilon) => true for any `epsilon >= 0.0`
@@ -526,11 +522,11 @@ module {
   /// equalWithin(x, NaN, epsilon)     => false for any x and `epsilon >= 0.0`
   /// equalWithin(NaN, y, epsilon)     => false for any y and `epsilon >= 0.0`
   /// ```
-  /// 
+  ///
   /// Example:
   /// ```motoko
   /// import Float "mo:base/Float";
-  /// 
+  ///
   /// let epsilon = 1e-6;
   /// Float.equalWithin(-12.3, -1.23e1, epsilon) // => true
   /// ```
@@ -545,9 +541,9 @@ module {
   /// Determines whether `x` is not equal to `y` within the defined tolerance of `epsilon`.
   /// The `epsilon` considers numerical errors, see comment above.
   /// Equivalent to `not equal(x, y, epsilon)`.
-  /// 
+  ///
   /// Traps if `epsilon` is negative or `NaN`.
-  /// 
+  ///
   /// Special cases:
   /// ```
   /// notEqualWithin(+0.0, -0.0, epsilon) => false for any `epsilon >= 0.0`
@@ -557,11 +553,11 @@ module {
   /// notEqualWithin(x, NaN, epsilon)     => true for any x and `epsilon >= 0.0`
   /// notEqualWithin(NaN, y, epsilon)     => true for any y and `epsilon >= 0.0`
   /// ```
-  /// 
+  ///
   /// Example:
   /// ```motoko
   /// import Float "mo:base/Float";
-  /// 
+  ///
   /// let epsilon = 1e-6;
   /// Float.notEqualWithin(-12.3, -1.23e1, epsilon) // => false
   /// ```
@@ -570,7 +566,7 @@ module {
   };
 
   /// Returns `x < y`.
-  /// 
+  ///
   /// Special cases:
   /// ```
   /// less(+0.0, -0.0) => false
@@ -578,17 +574,17 @@ module {
   /// less(NaN, y)     => false for any Float y
   /// less(x, NaN)     => false for any Float x
   /// ```
-  /// 
+  ///
   /// Example:
   /// ```motoko
   /// import Float "mo:base/Float";
-  /// 
+  ///
   /// Float.less(Float.e, Float.pi) // => true
   /// ```
   public func less(x : Float, y : Float) : Bool { x < y };
 
   /// Returns `x <= y`.
-  /// 
+  ///
   /// Special cases:
   /// ```
   /// lessOrEqual(+0.0, -0.0) => true
@@ -596,17 +592,17 @@ module {
   /// lessOrEqual(NaN, y)     => false for any Float y
   /// lessOrEqual(x, NaN)     => false for any Float x
   /// ```
-  /// 
+  ///
   /// Example:
   /// ```motoko
   /// import Float "mo:base/Float";
-  /// 
+  ///
   /// Float.lessOrEqual(0.123, 0.1234) // => true
   /// ```
   public func lessOrEqual(x : Float, y : Float) : Bool { x <= y };
 
   /// Returns `x > y`.
-  /// 
+  ///
   /// Special cases:
   /// ```
   /// greater(+0.0, -0.0) => false
@@ -614,17 +610,17 @@ module {
   /// greater(NaN, y)     => false for any Float y
   /// greater(x, NaN)     => false for any Float x
   /// ```
-  /// 
+  ///
   /// Example:
   /// ```motoko
   /// import Float "mo:base/Float";
-  /// 
+  ///
   /// Float.greater(Float.pi, Float.e) // => true
   /// ```
   public func greater(x : Float, y : Float) : Bool { x > y };
 
   /// Returns `x >= y`.
-  /// 
+  ///
   /// Special cases:
   /// ```
   /// greaterOrEqual(+0.0, -0.0) => true
@@ -632,18 +628,18 @@ module {
   /// greaterOrEqual(NaN, y)     => false for any Float y
   /// greaterOrEqual(x, NaN)     => false for any Float x
   /// ```
-  /// 
+  ///
   /// Example:
   /// ```motoko
   /// import Float "mo:base/Float";
-  /// 
+  ///
   /// Float.greaterOrEqual(0.1234, 0.123) // => true
   /// ```
   public func greaterOrEqual(x : Float, y : Float) : Bool { x >= y };
 
   /// Defines a total order of `x` and `y` for use in sorting.
-  /// 
-  /// :::note 
+  ///
+  /// :::note
   /// Using this operation to determine equality or inequality is discouraged for two reasons:
   /// * It does not consider numerical errors, see comment above. Use `equalWithin(x, y, espilon)` or
   ///   `notEqualWithin(x, y, epsilon)` to test for equality or inequality, respectively.
@@ -660,11 +656,11 @@ module {
   /// * positive numbers (including positive subnormal numbers in standard order)
   /// * positive infinity
   /// * positive `NaN` (no distinction between signalling and quiet positive `NaN`)
-  /// 
+  ///
   /// Example:
   /// ```motoko
   /// import Float "mo:base/Float";
-  /// 
+  ///
   /// Float.compare(0.123, 0.1234) // => #less
   /// ```
   public func compare(x : Float, y : Float) : { #less; #equal; #greater } {
@@ -690,9 +686,9 @@ module {
   };
 
   /// Returns the negation of `x`, `-x` .
-  /// 
+  ///
   /// Changes the sign bit for infinity.
-  /// 
+  ///
   /// Special cases:
   /// ```
   /// neg(+inf) => -inf
@@ -702,21 +698,21 @@ module {
   /// neg(+0.0) => -0.0
   /// neg(-0.0) => +0.0
   /// ```
-  /// 
+  ///
   /// Example:
   /// ```motoko
   /// import Float "mo:base/Float";
-  /// 
+  ///
   /// Float.neg(1.23) // => -1.23
   /// ```
   public func neg(x : Float) : Float { -x };
 
   /// Returns the sum of `x` and `y`, `x + y`.
-  /// 
+  ///
   /// :::info
   /// Numerical errors may occur, see comment above.
   /// :::
-  /// 
+  ///
   /// Special cases:
   /// ```
   /// add(+inf, y)    => +inf if y is any Float except -inf and NaN
@@ -725,19 +721,19 @@ module {
   /// add(NaN, y)     => NaN for any Float y
   /// ```
   /// The same cases apply commutatively, i.e. for `add(y, x)`.
-  /// 
+  ///
   /// Example:
   /// ```motoko
   /// import Float "mo:base/Float";
-  /// 
+  ///
   /// Float.add(1.23, 0.123) // => 1.353
   /// ```
   public func add(x : Float, y : Float) : Float { x + y };
 
   /// Returns the difference of `x` and `y`, `x - y`.
-  /// 
+  ///
   /// Note: Numerical errors may occur, see comment above.
-  /// 
+  ///
   /// Special cases:
   /// ```
   /// sub(+inf, y)    => +inf if y is any Float except +inf or NaN
@@ -749,21 +745,21 @@ module {
   /// sub(NaN, y)     => NaN for any Float y
   /// sub(x, NaN)     => NaN for any Float x
   /// ```
-  /// 
+  ///
   /// Example:
   /// ```motoko
   /// import Float "mo:base/Float";
-  /// 
+  ///
   /// Float.sub(1.23, 0.123) // => 1.107
   /// ```
   public func sub(x : Float, y : Float) : Float { x - y };
 
   /// Returns the product of `x` and `y`, `x * y`.
-  /// 
-  /// :::info 
+  ///
+  /// :::info
   /// Numerical errors may occur, see comment above.
   /// :::
-  /// 
+  ///
   /// Special cases:
   /// ```
   /// mul(+inf, y) => +inf if y > 0.0
@@ -775,21 +771,21 @@ module {
   /// mul(NaN, y) => NaN for any Float y
   /// ```
   /// The same cases apply commutatively, i.e. for `mul(y, x)`.
-  /// 
+  ///
   /// Example:
   /// ```motoko
   /// import Float "mo:base/Float";
-  /// 
+  ///
   /// Float.mul(1.23, 1e2) // => 123.0
   /// ```
   public func mul(x : Float, y : Float) : Float { x * y };
 
   /// Returns the division of `x` by `y`, `x / y`.
-  /// 
-  /// :::info 
+  ///
+  /// :::info
   /// Numerical errors may occur, see comment above.
   /// :::
-  /// 
+  ///
   /// Special cases:
   /// ```
   /// div(0.0, 0.0) => NaN
@@ -804,22 +800,22 @@ module {
   /// div(NaN, y)   => NaN for any Float y
   /// div(x, NaN)   => NaN for any Float x
   /// ```
-  /// 
+  ///
   /// Example:
   /// ```motoko
   /// import Float "mo:base/Float";
-  /// 
+  ///
   /// Float.div(1.23, 1e2) // => 0.0123
   /// ```
   public func div(x : Float, y : Float) : Float { x / y };
 
   /// Returns the floating point division remainder `x % y`,
   /// which is defined as `x - trunc(x / y) * y`.
-  /// 
-  /// :::info 
+  ///
+  /// :::info
   /// Numerical errors may occur, see comment above.
   /// :::
-  /// 
+  ///
   /// Special cases:
   /// ```
   /// rem(0.0, 0.0) => NaN
@@ -832,21 +828,21 @@ module {
   /// rem(NaN, y)   => NaN for any Float y
   /// rem(x, NaN)   => NaN for any Float x
   /// ```
-  /// 
+  ///
   /// Example:
   /// ```motoko
   /// import Float "mo:base/Float";
-  /// 
+  ///
   /// Float.rem(7.2, 2.3) // => 0.3 (with numerical imprecision)
   /// ```
   public func rem(x : Float, y : Float) : Float { x % y };
 
   /// Returns `x` to the power of `y`, `x ** y`.
-  /// 
-  /// :::info 
+  ///
+  /// :::info
   /// Numerical errors may occur, see comment above.
   /// :::
-  /// 
+  ///
   /// Special cases:
   /// ```
   /// pow(+inf, y)    => +inf for any y > 0.0 including +inf
@@ -867,11 +863,11 @@ module {
   /// pow(NaN, 0.0)   => 1.0
   /// pow(x, NaN)     => NaN for any Float x
   /// ```
-  /// 
+  ///
   /// Example:
   /// ```motoko
   /// import Float "mo:base/Float";
-  /// 
+  ///
   /// Float.pow(2.5, 2.0) // => 6.25
   /// ```
   public func pow(x : Float, y : Float) : Float { x ** y };

--- a/src/Func.mo
+++ b/src/Func.mo
@@ -2,7 +2,7 @@
 
 module {
   /// Import from the base library to use this module.
-  /// 
+  ///
   /// ```motoko name=import
   /// import { compose; const; identity } = "mo:base/Func";
   /// import Text = "mo:base/Text";
@@ -10,7 +10,7 @@ module {
   /// ```
 
   /// The composition of two functions `f` and `g` is a function that applies `g` and then `f`.
-  /// 
+  ///
   /// Example:
   /// ```motoko include=import
   /// let textFromNat32 = compose(Text.fromChar, Char.fromNat32);
@@ -33,7 +33,7 @@ module {
   /// The const function is a _curried_ function that accepts an argument `x`,
   /// and then returns a function that discards its argument and always returns
   /// the `x`.
-  /// 
+  ///
   /// Example:
   /// ```motoko include=import
   /// assert const<Nat, Text>(10)("hello") == 10;

--- a/src/Hash.mo
+++ b/src/Hash.mo
@@ -21,10 +21,8 @@ module {
     ha == hb
   };
 
-  /// :::warning Deprecated function
-  /// This function computes a hash from the least significant 32 bits of `n`, ignoring other bits.
-  /// For large `Nat` values, consider using a bespoke hash function that considers all of the argument's bits.
-  /// :::
+  /// Computes a hash from the least significant 32-bits of `n`, ignoring other bits.
+  /// @deprecated For large `Nat` values consider using a bespoke hash function that considers all of the argument's bits.
   public func hash(n : Nat) : Hash {
     let j = Prim.intToNat32Wrap(n);
     hashNat8([
@@ -35,10 +33,7 @@ module {
     ])
   };
 
-  /// :::warning Deprecated function
-
-  /// This function will be removed in a future version.
-  /// :::
+  /// @deprecated This function will be removed in future.
   public func debugPrintBits(bits : Hash) {
     for (j in Iter.range(0, length - 1)) {
       if (bit(bits, j)) {
@@ -49,10 +44,8 @@ module {
     }
   };
 
-  /// :::warning Deprecated function
 
-  /// This function will be removed in a future version.
-  /// :::
+  /// @deprecated This function will be removed in future.
   public func debugPrintBitsRev(bits : Hash) {
     for (j in Iter.revRange(length - 1, 0)) {
       if (bit(bits, Prim.abs(j))) {
@@ -64,15 +57,13 @@ module {
   };
 
   /// [View Jenkin's one at a time](https://en.wikipedia.org/wiki/Jenkins_hash_function#one_at_a_time).
-  /// 
+  ///
   /// :::note
   /// The input type should actually be `[Nat8]`.
   /// Be sure to explode each `Nat8` of a `Nat32` into its own `Nat32`, and shift into the lower 8 bits.
   /// :::
   /// :::warning Deprecated function
-
-  /// This function may be removed or changed in a future version.
-  /// :::
+  /// @deprecated This function may be removed or changed in future.
   public func hashNat8(key : [Hash]) : Hash {
     var hash : Nat32 = 0;
     for (natOfKey in key.vals()) {

--- a/src/Heap.mo
+++ b/src/Heap.mo
@@ -1,20 +1,20 @@
 /// Class `Heap<X>` provides a priority queue of elements of type `X`.
-/// 
+///
 /// The class wraps a purely-functional implementation based on a leftist heap.
-/// 
+///
 /// :::note Constructor details
 /// The constructor takes in a comparison function `compare` that defines the ordering between elements of type `X`. Most primitive types have a default version of this comparison function defined in their modules (e.g. `Nat.compare`). The runtime analysis in this documentation assumes that the `compare` function runs in `O(1)` time and space.
 /// :::
-/// 
+///
 /// Example:
-/// 
+///
 /// ```motoko name=initialize
 /// import Heap "mo:base/Heap";
 /// import Text "mo:base/Text";
-/// 
+///
 /// let heap = Heap.Heap<Text>(Text.compare);
 /// ```
-/// 
+///
 /// | Runtime   | Space     |
 /// |-----------|-----------|
 /// | `O(1)`    | `O(1)`    |
@@ -32,13 +32,13 @@ module {
     var heap : Tree<X> = null;
 
     /// Inserts an element into the heap.
-    /// 
+    ///
     /// Example:
     /// ```motoko include=initialize
     /// heap.put("apple");
     /// heap.peekMin() // => ?"apple"
     /// ```
-    /// 
+    ///
     /// | Runtime   | Space     |
     /// |-----------|-----------|
     /// | `O(1)`    | `O(1)`    |
@@ -47,7 +47,7 @@ module {
     };
 
     /// Return the minimal element in the heap, or `null` if the heap is empty.
-    /// 
+    ///
     /// Example:
     /// ```motoko include=initialize
     /// heap.put("apple");
@@ -55,7 +55,7 @@ module {
     /// heap.put("cantaloupe");
     /// heap.peekMin() // => ?"apple"
     /// ```
-    /// 
+    ///
     /// | Runtime   | Space     |
     /// |-----------|-----------|
     /// | `O(1)`    | `O(1)`    |
@@ -67,7 +67,7 @@ module {
     };
 
     /// Delete the minimal element in the heap, if it exists.
-    /// 
+    ///
     /// Example:
     /// ```motoko include=initialize
     /// heap.put("apple");
@@ -76,7 +76,7 @@ module {
     /// heap.deleteMin();
     /// heap.peekMin(); // => ?"banana"
     /// ```
-    /// 
+    ///
     /// | Runtime      | Space       |
     /// |--------------|-------------|
     /// | `O(log(n))`  | `O(log(n))` |
@@ -88,7 +88,7 @@ module {
     };
 
     /// Delete and return the minimal element in the heap, if it exists.
-    /// 
+    ///
     /// Example:
     /// ```motoko include=initialize
     /// heap.put("apple");
@@ -96,7 +96,7 @@ module {
     /// heap.put("cantaloupe");
     /// heap.removeMin(); // => ?"apple"
     /// ```
-    /// 
+    ///
     /// | Runtime      | Space       |
     /// |--------------|-------------|
     /// | `O(log(n))`  | `O(log(n))` |
@@ -112,16 +112,16 @@ module {
 
     /// Return a snapshot of the internal functional tree representation as sharable data.
     /// The returned tree representation is not affected by subsequent changes of the `Heap` instance.
-    /// 
+    ///
     /// Example:
     /// ```motoko include=initialize
     /// heap.put("banana");
     /// heap.share();
     /// ```
-    /// 
+    ///
     /// Useful for storing the heap as a stable variable, pretty-printing, and sharing it across async function calls,
     /// i.e. passing it in async arguments or async results.
-    /// 
+    ///
     /// | Runtime   | Space     |
     /// |-----------|-----------|
     /// | `O(1)`    | `O(1)`    |
@@ -132,7 +132,7 @@ module {
     /// Rewraps a snapshot of a heap (obtained by `share()`) in a `Heap` instance.
     /// The wrapping instance must be initialized with the same `compare`
     /// function that created the snapshot.
-    /// 
+    ///
     /// Example:
     /// ```motoko include=initialize
     /// heap.put("apple");
@@ -142,10 +142,10 @@ module {
     /// heapCopy.unsafeUnshare(snapshot);
     /// heapCopy.peekMin() // => ?"apple"
     /// ```
-    /// 
+    ///
     /// Useful for loading a stored heap from a stable variable or accesing a heap
     /// snapshot passed from an async function call.
-    /// 
+    ///
     /// | Runtime   | Space     |
     /// |-----------|-----------|
     /// | `O(1)`    | `O(1)`    |
@@ -185,16 +185,16 @@ module {
 
   /// Returns a new `Heap`, containing all entries given by the iterator `iter`.
   /// The new map is initialized with the provided `compare` function.
-  /// 
+  ///
   /// Example:
   /// ```motoko include=initialize
   /// let entries = ["banana", "apple", "cantaloupe"];
   /// let iter = entries.vals();
-  /// 
+  ///
   /// let newHeap = Heap.fromIter<Text>(iter, Text.compare);
   /// newHeap.peekMin() // => ?"apple"
   /// ```
-  /// 
+  ///
   /// | Runtime   | Space     |
   /// |-----------|-----------|
   /// | `O(size)` | `O(size)` |

--- a/src/Int.mo
+++ b/src/Int.mo
@@ -1,21 +1,21 @@
 /// Signed integer numbers with infinite precision (also called big integers).
-/// 
+///
 /// :::note
 /// Most operations on integer numbers (e.g. addition) are available as built-in operators (e.g. `-1 + 1`).
 /// This module provides equivalent functions and `Text` conversion.
 /// :::
-/// 
+///
 /// :::info Function form for higher-order use
-/// 
+///
 /// Several arithmetic and comparison functions (e.g. `add`, `sub`, `equal`, `less`, `pow`) are defined in this module to enable their use as first-class function values, which is not possible with operators like `+`, `-`, `==`, etc., in Motoko. This allows you to pass these operations to higher-order functions such as `map`, `foldLeft`, or `sort`.
 /// :::
-/// 
+///
 /// Import from the base library to use this module.
-/// 
+///
 /// ```motoko name=import
 /// import Int "mo:base/Int";
 /// ```
-/// 
+///
 
 import Prim "mo:⛔";
 import Prelude "Prelude";
@@ -27,7 +27,7 @@ module {
   public type Int = Prim.Types.Int;
 
   /// Returns the absolute value of `x`.
-  /// 
+  ///
   /// Example:
   /// ```motoko include=import
   /// Int.abs(-12) // => 12
@@ -38,7 +38,7 @@ module {
 
   /// Converts an integer number to its textual representation. Textual
   /// representation _do not_ contain underscores to represent commas.
-  /// 
+  ///
   /// Example:
   /// ```motoko include=import
   /// Int.toText(-1234) // => "-1234"
@@ -78,7 +78,7 @@ module {
   };
 
   /// Returns the minimum of `x` and `y`.
-  /// 
+  ///
   /// Example:
   /// ```motoko include=import
   /// Int.min(2, -3) // => -3
@@ -88,7 +88,7 @@ module {
   };
 
   /// Returns the maximum of `x` and `y`.
-  /// 
+  ///
   /// Example:
   /// ```motoko include=import
   /// Int.max(2, -3) // => 2
@@ -111,11 +111,8 @@ module {
     return hash
   };
 
-  /// :::warning Deprecated function
-  /// 
-  /// The function `hash` is deprecated. It computes a hash using only the least significant 32 bits of the `Int`, ignoring the rest.
-  /// For large integers, this may lead to hash collisions. Use a bespoke hash function that considers all bits of the value instead.
-  /// :::
+  /// Computes a hash from the least significant 32-bits of `i`, ignoring other bits.
+  /// @deprecated For large `Int` values consider using a bespoke hash function that considers all of the argument's bits.
   public func hash(i : Int) : Hash.Hash {
     // CAUTION: This removes the high bits!
     let j = Prim.int32ToNat32(Prim.intToInt32Wrap(i));
@@ -127,11 +124,8 @@ module {
     ])
   };
 
-  /// :::warning Deprecated function
-  /// 
-  /// The function `hashAcc` is deprecated. It accumulates a hash using only the least significant 32 bits of the `Int`, ignoring other bits.
-  /// This limits its effectiveness for large integers. Prefer using a custom hash function that processes the full integer input.
-  /// :::
+  /// Computes an accumulated hash from `h1` and the least significant 32-bits of `i`, ignoring other bits in `i`.
+  /// @deprecated For large `Int` values consider using a bespoke hash function that considers all of the argument's bits.
   public func hashAcc(h1 : Hash.Hash, i : Int) : Hash.Hash {
     // CAUTION: This removes the high bits!
     let j = Prim.int32ToNat32(Prim.intToInt32Wrap(i));
@@ -146,17 +140,17 @@ module {
 
   /// Equality function for Int types.
   /// This is equivalent to `x == y`.
-  /// 
+  ///
   /// Example:
   /// ```motoko include=import
   /// Int.equal(-1, -1); // => true
   /// ```
-  /// 
-  /// 
+  ///
+  ///
   /// Example:
   /// ```motoko include=import
   /// import Buffer "mo:base/Buffer";
-  /// 
+  ///
   /// let buffer1 = Buffer.Buffer<Int>(1);
   /// buffer1.add(-3);
   /// let buffer2 = Buffer.Buffer<Int>(1);
@@ -167,69 +161,69 @@ module {
 
   /// Inequality function for Int types.
   /// This is equivalent to `x != y`.
-  /// 
+  ///
   /// Example:
   /// ```motoko include=import
   /// Int.notEqual(-1, -2); // => true
   /// ```
-  /// 
+  ///
 
   public func notEqual(x : Int, y : Int) : Bool { x != y };
 
   /// "Less than" function for Int types.
   /// This is equivalent to `x < y`.
-  /// 
+  ///
   /// Example:
   /// ```motoko include=import
   /// Int.less(-2, 1); // => true
   /// ```
-  /// 
+  ///
 
   public func less(x : Int, y : Int) : Bool { x < y };
 
   /// "Less than or equal" function for Int types.
   /// This is equivalent to `x <= y`.
-  /// 
+  ///
   /// Example:
   /// ```motoko include=import
   /// Int.lessOrEqual(-2, 1); // => true
   /// ```
-  /// 
+  ///
 
   public func lessOrEqual(x : Int, y : Int) : Bool { x <= y };
 
   /// "Greater than" function for Int types.
   /// This is equivalent to `x > y`.
-  /// 
+  ///
   /// Example:
   /// ```motoko include=import
   /// Int.greater(1, -2); // => true
   /// ```
-  /// 
+  ///
 
   public func greater(x : Int, y : Int) : Bool { x > y };
 
   /// "Greater than or equal" function for Int types.
   /// This is equivalent to `x >= y`.
-  /// 
+  ///
   /// Example:
   /// ```motoko include=import
   /// Int.greaterOrEqual(1, -2); // => true
   /// ```
-  /// 
+  ///
 
   public func greaterOrEqual(x : Int, y : Int) : Bool { x >= y };
 
   /// General-purpose comparison function for `Int`. Returns the `Order` (
   /// either `#less`, `#equal`, or `#greater`) of comparing `x` with `y`.
-  /// 
+  ///
   /// Example:
   /// ```motoko include=import
   /// Int.compare(-3, 2) // => #less
   /// ```
-  /// 
+  ///
   /// This function can be used as value for a high order function, such as a sort function.
-  /// 
+  ///
   /// Example:
   /// ```motoko include=import
   /// import Array "mo:base/Array";
@@ -240,26 +234,26 @@ module {
   };
 
   /// Returns the negation of `x`, `-x` .
-  /// 
+  ///
   /// Example:
   /// ```motoko include=import
   /// Int.neg(123) // => -123
   /// ```
-  /// 
+  ///
 
   public func neg(x : Int) : Int { -x };
 
   /// Returns the sum of `x` and `y`, `x + y`.
-  /// 
+  ///
   /// No overflow since `Int` has infinite precision.
-  /// 
+  ///
   /// Example:
   /// ```motoko include=import
   /// Int.add(1, -2); // => -1
   /// ```
-  /// 
+  ///
 
-  /// 
+  ///
   /// Example:
   /// ```motoko include=import
   /// import Array "mo:base/Array";
@@ -268,16 +262,16 @@ module {
   public func add(x : Int, y : Int) : Int { x + y };
 
   /// Returns the difference of `x` and `y`, `x - y`.
-  /// 
+  ///
   /// No overflow since `Int` has infinite precision.
-  /// 
+  ///
   /// Example:
   /// ```motoko include=import
   /// Int.sub(1, 2); // => -1
   /// ```
-  /// 
+  ///
 
-  /// 
+  ///
   /// Example:
   /// ```motoko include=import
   /// import Array "mo:base/Array";
@@ -286,16 +280,16 @@ module {
   public func sub(x : Int, y : Int) : Int { x - y };
 
   /// Returns the product of `x` and `y`, `x * y`.
-  /// 
+  ///
   /// No overflow since `Int` has infinite precision.
-  /// 
+  ///
   /// Example:
   /// ```motoko include=import
   /// Int.mul(-2, 3); // => -6
   /// ```
-  /// 
+  ///
 
-  /// 
+  ///
   /// Example:
   /// ```motoko include=import
   /// import Array "mo:base/Array";
@@ -305,40 +299,40 @@ module {
 
   /// Returns the signed integer division of `x` by `y`,  `x / y`.
   /// Rounds the quotient towards zero, which is the same as truncating the decimal places of the quotient.
-  /// 
+  ///
   /// Traps when `y` is zero.
-  /// 
+  ///
   /// Example:
   /// ```motoko include=import
   /// Int.div(6, -2); // => -3
   /// ```
-  /// 
+  ///
 
   public func div(x : Int, y : Int) : Int { x / y };
 
   /// Returns the remainder of the signed integer division of `x` by `y`, `x % y`,
   /// which is defined as `x - x / y * y`.
-  /// 
+  ///
   /// Traps when `y` is zero.
-  /// 
+  ///
   /// Example:
   /// ```motoko include=import
   /// Int.rem(6, -4); // => 2
   /// ```
-  /// 
+  ///
 
   public func rem(x : Int, y : Int) : Int { x % y };
 
   /// Returns `x` to the power of `y`, `x ** y`.
-  /// 
+  ///
   /// Traps when `y` is negative or `y > 2 ** 32 - 1`.
   /// No overflow since `Int` has infinite precision.
-  /// 
+  ///
   /// Example:
   /// ```motoko include=import
   /// Int.pow(-2, 3); // => -8
   /// ```
-  /// 
+  ///
   public func pow(x : Int, y : Int) : Int { x ** y };
 
 }

--- a/src/Int16.mo
+++ b/src/Int16.mo
@@ -1,16 +1,16 @@
 /// Provides utility functions on 16-bit signed integers.
-/// 
+///
 /// :::note
 /// Most operations are available as built-in operators (e.g. `1 + 1`).
 /// :::
-/// 
+///
 /// :::info Function form for higher-order use
-/// 
+///
 /// Several arithmetic and comparison functions (e.g. `add`, `sub`, `bitor`, `bitand`, `pow`) are defined in this module to enable their use as first-class function values, which is not possible with operators like `+`, `-`, `==`, etc., in Motoko. This allows you to pass these operations to higher-order functions such as `map`, `foldLeft`, or `sort`.
 /// :::
-/// 
+///
 /// Import from the base library to use this module.
-/// 
+///
 /// ```motoko name=import
 /// import Int16 "mo:base/Int16";
 /// ```
@@ -23,7 +23,7 @@ module {
   public type Int16 = Prim.Types.Int16;
 
   /// Minimum 16-bit integer value, `-2 ** 15`.
-  /// 
+  ///
   /// Example:
   /// ```motoko include=import
   /// Int16.minimumValue // => -32_768 : Int16
@@ -31,7 +31,7 @@ module {
   public let minimumValue = -32_768 : Int16;
 
   /// Maximum 16-bit integer value, `+2 ** 15 - 1`.
-  /// 
+  ///
   /// Example:
   /// ```motoko include=import
   /// Int16.maximumValue // => +32_767 : Int16
@@ -39,7 +39,7 @@ module {
   public let maximumValue = 32_767 : Int16;
 
   /// Converts a 16-bit signed integer to a signed integer with infinite precision.
-  /// 
+  ///
   /// Example:
   /// ```motoko include=import
   /// Int16.toInt(12_345) // => 12_345 : Int
@@ -47,9 +47,9 @@ module {
   public let toInt : Int16 -> Int = Prim.int16ToInt;
 
   /// Converts a signed integer with infinite precision to a 16-bit signed integer.
-  /// 
+  ///
   /// Traps on overflow/underflow.
-  /// 
+  ///
   /// Example:
   /// ```motoko include=import
   /// Int16.fromInt(12_345) // => +12_345 : Int16
@@ -57,9 +57,9 @@ module {
   public let fromInt : Int -> Int16 = Prim.intToInt16;
 
   /// Converts a signed integer with infinite precision to a 16-bit signed integer.
-  /// 
+  ///
   /// Wraps on overflow/underflow.
-  /// 
+  ///
   /// Example:
   /// ```motoko include=import
   /// Int16.fromIntWrap(-12_345) // => -12_345 : Int
@@ -67,7 +67,7 @@ module {
   public let fromIntWrap : Int -> Int16 = Prim.intToInt16Wrap;
 
   /// Converts a 8-bit signed integer to a 16-bit signed integer.
-  /// 
+  ///
   /// Example:
   /// ```motoko include=import
   /// Int16.fromInt8(-123) // => -123 : Int16
@@ -75,9 +75,9 @@ module {
   public let fromInt8 : Int8 -> Int16 = Prim.int8ToInt16;
 
   /// Converts a 16-bit signed integer to a 8-bit signed integer.
-  /// 
+  ///
   /// Traps on overflow/underflow.
-  /// 
+  ///
   /// Example:
   /// ```motoko include=import
   /// Int16.toInt8(-123) // => -123 : Int8
@@ -85,9 +85,9 @@ module {
   public let toInt8 : Int16 -> Int8 = Prim.int16ToInt8;
 
   /// Converts a 32-bit signed integer to a 16-bit signed integer.
-  /// 
+  ///
   /// Traps on overflow/underflow.
-  /// 
+  ///
   /// Example:
   /// ```motoko include=import
   /// Int16.fromInt32(-12_345) // => -12_345 : Int16
@@ -95,7 +95,7 @@ module {
   public let fromInt32 : Int32 -> Int16 = Prim.int32ToInt16;
 
   /// Converts a 16-bit signed integer to a 32-bit signed integer.
-  /// 
+  ///
   /// Example:
   /// ```motoko include=import
   /// Int16.toInt32(-12_345) // => -12_345 : Int32
@@ -103,9 +103,9 @@ module {
   public let toInt32 : Int16 -> Int32 = Prim.int16ToInt32;
 
   /// Converts an unsigned 16-bit integer to a signed 16-bit integer.
-  /// 
+  ///
   /// Wraps on overflow/underflow.
-  /// 
+  ///
   /// Example:
   /// ```motoko include=import
   /// Int16.fromNat16(12_345) // => +12_345 : Int16
@@ -113,9 +113,9 @@ module {
   public let fromNat16 : Nat16 -> Int16 = Prim.nat16ToInt16;
 
   /// Converts a signed 16-bit integer to an unsigned 16-bit integer.
-  /// 
+  ///
   /// Wraps on overflow/underflow.
-  /// 
+  ///
   /// Example:
   /// ```motoko include=import
   /// Int16.toNat16(-1) // => 65_535 : Nat16 // underflow
@@ -124,7 +124,7 @@ module {
 
   /// Returns the Text representation of `x`. Textual representation _do not_
   /// contain underscores to represent commas.
-  /// 
+  ///
   /// Example:
   /// ```motoko include=import
   /// Int16.toText(-12345) // => "-12345"
@@ -134,9 +134,9 @@ module {
   };
 
   /// Returns the absolute value of `x`.
-  /// 
+  ///
   /// Traps when `x == -2 ** 15` (the minimum `Int16` value).
-  /// 
+  ///
   /// Example:
   /// ```motoko include=import
   /// Int16.abs(-12345) // => +12_345
@@ -146,7 +146,7 @@ module {
   };
 
   /// Returns the minimum of `x` and `y`.
-  /// 
+  ///
   /// Example:
   /// ```motoko include=import
   /// Int16.min(+2, -3) // => -3
@@ -156,7 +156,7 @@ module {
   };
 
   /// Returns the maximum of `x` and `y`.
-  /// 
+  ///
   /// Example:
   /// ```motoko include=import
   /// Int16.max(+2, -3) // => +2
@@ -167,18 +167,18 @@ module {
 
   /// Equality function for Int16 types.
   /// This is equivalent to `x == y`.
-  /// 
+  ///
   /// Example:
   /// ```motoko include=import
   /// Int16.equal(-1, -1); // => true
   /// ```
-  /// 
+  ///
 
-  /// 
+  ///
   /// Example:
   /// ```motoko include=import
   /// import Buffer "mo:base/Buffer";
-  /// 
+  ///
   /// let buffer1 = Buffer.Buffer<Int16>(1);
   /// buffer1.add(-3);
   /// let buffer2 = Buffer.Buffer<Int16>(1);
@@ -189,40 +189,40 @@ module {
 
   /// Inequality function for Int16 types.
   /// This is equivalent to `x != y`.
-  /// 
+  ///
   /// Example:
   /// ```motoko include=import
   /// Int16.notEqual(-1, -2); // => true
   /// ```
-  /// 
+  ///
 
   public func notEqual(x : Int16, y : Int16) : Bool { x != y };
 
   /// "Less than" function for Int16 types.
   /// This is equivalent to `x < y`.
-  /// 
+  ///
   /// Example:
   /// ```motoko include=import
   /// Int16.less(-2, 1); // => true
   /// ```
-  /// 
+  ///
 
   public func less(x : Int16, y : Int16) : Bool { x < y };
 
   /// "Less than or equal" function for Int16 types.
   /// This is equivalent to `x <= y`.
-  /// 
+  ///
   /// Example:
   /// ```motoko include=import
   /// Int16.lessOrEqual(-2, -2); // => true
   /// ```
-  /// 
+  ///
 
   public func lessOrEqual(x : Int16, y : Int16) : Bool { x <= y };
 
   /// "Greater than" function for Int16 types.
   /// This is equivalent to `x > y`.
-  /// 
+  ///
   /// Example:
   /// ```motoko include=import
   /// Int16.greater(-2, 1); // => false
@@ -231,7 +231,7 @@ module {
 
   /// "Greater than or equal" function for Int16 types.
   /// This is equivalent to `x >= y`.
-  /// 
+  ///
   /// Example:
   /// ```motoko include=import
   /// Int16.greaterOrEqual(-2, -2); // => true
@@ -240,14 +240,14 @@ module {
 
   /// General-purpose comparison function for `Int16`. Returns the `Order` (
   /// either `#less`, `#equal`, or `#greater`) of comparing `x` with `y`.
-  /// 
+  ///
   /// Example:
   /// ```motoko include=import
   /// Int16.compare(-3, 2) // => #less
   /// ```
-  /// 
+  ///
   /// This function can be used as value for a high order function, such as a sort function.
-  /// 
+  ///
   /// Example:
   /// ```motoko include=import
   /// import Array "mo:base/Array";
@@ -258,28 +258,28 @@ module {
   };
 
   /// Returns the negation of `x`, `-x`.
-  /// 
+  ///
   /// Traps on overflow, i.e. for `neg(-2 ** 15)`.
-  /// 
+  ///
   /// Example:
   /// ```motoko include=import
   /// Int16.neg(123) // => -123
   /// ```
-  /// 
+  ///
 
   public func neg(x : Int16) : Int16 { -x };
 
   /// Returns the sum of `x` and `y`, `x + y`.
-  /// 
+  ///
   /// Traps on overflow/underflow.
-  /// 
+  ///
   /// Example:
   /// ```motoko include=import
   /// Int16.add(100, 23) // => +123
   /// ```
-  /// 
+  ///
 
-  /// 
+  ///
   /// Example:
   /// ```motoko include=import
   /// import Array "mo:base/Array";
@@ -288,16 +288,16 @@ module {
   public func add(x : Int16, y : Int16) : Int16 { x + y };
 
   /// Returns the difference of `x` and `y`, `x - y`.
-  /// 
+  ///
   /// Traps on overflow/underflow.
-  /// 
+  ///
   /// Example:
   /// ```motoko include=import
   /// Int16.sub(123, 100) // => +23
   /// ```
-  /// 
+  ///
 
-  /// 
+  ///
   /// Example:
   /// ```motoko include=import
   /// import Array "mo:base/Array";
@@ -306,16 +306,16 @@ module {
   public func sub(x : Int16, y : Int16) : Int16 { x - y };
 
   /// Returns the product of `x` and `y`, `x * y`.
-  /// 
+  ///
   /// Traps on overflow/underflow.
-  /// 
+  ///
   /// Example:
   /// ```motoko include=import
   /// Int16.mul(12, 10) // => +120
   /// ```
-  /// 
+  ///
 
-  /// 
+  ///
   /// Example:
   /// ```motoko include=import
   /// import Array "mo:base/Array";
@@ -325,64 +325,64 @@ module {
 
   /// Returns the signed integer division of `x` by `y`, `x / y`.
   /// Rounds the quotient towards zero, which is the same as truncating the decimal places of the quotient.
-  /// 
+  ///
   /// Traps when `y` is zero.
-  /// 
+  ///
   /// Example:
   /// ```motoko include=import
   /// Int16.div(123, 10) // => +12
   /// ```
-  /// 
+  ///
 
   public func div(x : Int16, y : Int16) : Int16 { x / y };
 
   /// Returns the remainder of the signed integer division of `x` by `y`, `x % y`,
   /// which is defined as `x - x / y * y`.
-  /// 
+  ///
   /// Traps when `y` is zero.
-  /// 
+  ///
   /// Example:
   /// ```motoko include=import
   /// Int16.rem(123, 10) // => +3
   /// ```
-  /// 
+  ///
 
   public func rem(x : Int16, y : Int16) : Int16 { x % y };
 
   /// Returns `x` to the power of `y`, `x ** y`.
-  /// 
+  ///
   /// Traps on overflow/underflow and when `y < 0 or y >= 16`.
-  /// 
+  ///
   /// Example:
   /// ```motoko include=import
   /// Int16.pow(2, 10) // => +1_024
   /// ```
-  /// 
+  ///
 
   public func pow(x : Int16, y : Int16) : Int16 { x ** y };
 
   /// Returns the bitwise negation of `x`, `^x`.
-  /// 
+  ///
   /// Example:
   /// ```motoko include=import
   /// Int16.bitnot(-256 /* 0xff00 */) // => +255 // 0xff
   /// ```
-  /// 
+  ///
 
   public func bitnot(x : Int16) : Int16 { ^x };
 
   /// Returns the bitwise "and" of `x` and `y`, `x & y`.
-  /// 
+  ///
   /// Example:
   /// ```motoko include=import
   /// Int16.bitand(0x0fff, 0x00f0) // => +240 // 0xf0
   /// ```
-  /// 
+  ///
 
   public func bitand(x : Int16, y : Int16) : Int16 { x & y };
 
   /// Returns the bitwise "or" of `x` and `y`, `x | y`.
-  /// 
+  ///
   /// Example:
   /// ```motoko include=import
   /// Int16.bitor(0x0f0f, 0x00f0) // => +4_095 // 0x0fff
@@ -391,7 +391,7 @@ module {
   public func bitor(x : Int16, y : Int16) : Int16 { x | y };
 
   /// Returns the bitwise "exclusive or" of `x` and `y`, `x ^ y`.
-  /// 
+  ///
   /// Example:
   /// ```motoko include=import
   /// Int16.bitxor(0x0fff, 0x00f0) // => +3_855 // 0x0f0f
@@ -402,67 +402,67 @@ module {
   /// Returns the bitwise left shift of `x` by `y`, `x << y`.
   /// The right bits of the shift filled with zeros.
   /// Left-overflowing bits, including the sign bit, are discarded.
-  /// 
+  ///
   /// For `y >= 16`, the semantics is the same as for `bitshiftLeft(x, y % 16)`.
   /// For `y < 0`,  the semantics is the same as for `bitshiftLeft(x, y + y % 16)`.
-  /// 
+  ///
   /// Example:
   /// ```motoko include=import
   /// Int16.bitshiftLeft(1, 8) // => +256 // 0x100 equivalent to `2 ** 8`.
   /// ```
-  /// 
+  ///
 
   public func bitshiftLeft(x : Int16, y : Int16) : Int16 { x << y };
 
   /// Returns the signed bitwise right shift of `x` by `y`, `x >> y`.
   /// The sign bit is retained and the left side is filled with the sign bit.
   /// Right-underflowing bits are discarded, i.e. not rotated to the left side.
-  /// 
+  ///
   /// For `y >= 16`, the semantics is the same as for `bitshiftRight(x, y % 16)`.
   /// For `y < 0`,  the semantics is the same as for `bitshiftRight (x, y + y % 16)`.
-  /// 
+  ///
   /// Example:
   /// ```motoko include=import
   /// Int16.bitshiftRight(1024, 8) // => +4 // equivalent to `1024 / (2 ** 8)`
   /// ```
-  /// 
+  ///
 
   public func bitshiftRight(x : Int16, y : Int16) : Int16 { x >> y };
 
   /// Returns the bitwise left rotatation of `x` by `y`, `x <<> y`.
   /// Each left-overflowing bit is inserted again on the right side.
   /// The sign bit is rotated like other bits, i.e. the rotation interprets the number as unsigned.
-  /// 
+  ///
   /// Changes the direction of rotation for negative `y`.
   /// For `y >= 16`, the semantics is the same as for `bitrotLeft(x, y % 16)`.
-  /// 
+  ///
   /// Example:
   /// ```motoko include=import
   /// Int16.bitrotLeft(0x2001, 4) // => +18 // 0x12.
   /// ```
-  /// 
+  ///
 
   public func bitrotLeft(x : Int16, y : Int16) : Int16 { x <<> y };
 
   /// Returns the bitwise right rotation of `x` by `y`, `x <>> y`.
   /// Each right-underflowing bit is inserted again on the right side.
   /// The sign bit is rotated like other bits, i.e. the rotation interprets the number as unsigned.
-  /// 
+  ///
   /// Changes the direction of rotation for negative `y`.
   /// For `y >= 16`, the semantics is the same as for `bitrotRight(x, y % 16)`.
-  /// 
+  ///
   /// Example:
   /// ```motoko include=import
   /// Int16.bitrotRight(0x2010, 8) // => +4_128 // 0x01020.
   /// ```
-  /// 
+  ///
 
   public func bitrotRight(x : Int16, y : Int16) : Int16 { x <>> y };
 
   /// Returns the value of bit `p` in `x`, `x & 2**p == 2**p`.
   /// If `p >= 16`, the semantics is the same as for `bittest(x, p % 16)`.
   /// This is equivalent to checking if the `p`-th bit is set in `x`, using 0 indexing.
-  /// 
+  ///
   /// Example:
   /// ```motoko include=import
   /// Int16.bittest(128, 7) // => true
@@ -473,7 +473,7 @@ module {
 
   /// Returns the value of setting bit `p` in `x` to `1`.
   /// If `p >= 16`, the semantics is the same as for `bitset(x, p % 16)`.
-  /// 
+  ///
   /// Example:
   /// ```motoko include=import
   /// Int16.bitset(0, 7) // => +128
@@ -484,7 +484,7 @@ module {
 
   /// Returns the value of clearing bit `p` in `x` to `0`.
   /// If `p >= 16`, the semantics is the same as for `bitclear(x, p % 16)`.
-  /// 
+  ///
   /// Example:
   /// ```motoko include=import
   /// Int16.bitclear(-1, 7) // => -129
@@ -495,7 +495,7 @@ module {
 
   /// Returns the value of flipping bit `p` in `x`.
   /// If `p >= 16`, the semantics is the same as for `bitclear(x, p % 16)`.
-  /// 
+  ///
   /// Example:
   /// ```motoko include=import
   /// Int16.bitflip(255, 7) // => +127
@@ -505,7 +505,7 @@ module {
   };
 
   /// Returns the count of non-zero bits in `x`.
-  /// 
+  ///
   /// Example:
   /// ```motoko include=import
   /// Int16.bitcountNonZero(0xff) // => +8
@@ -513,7 +513,7 @@ module {
   public let bitcountNonZero : (x : Int16) -> Int16 = Prim.popcntInt16;
 
   /// Returns the count of leading zero bits in `x`.
-  /// 
+  ///
   /// Example:
   /// ```motoko include=import
   /// Int16.bitcountLeadingZero(0x80) // => +8
@@ -521,7 +521,7 @@ module {
   public let bitcountLeadingZero : (x : Int16) -> Int16 = Prim.clzInt16;
 
   /// Returns the count of trailing zero bits in `x`.
-  /// 
+  ///
   /// Example:
   /// ```motoko include=import
   /// Int16.bitcountTrailingZero(0x0100) // => +8
@@ -545,7 +545,7 @@ module {
   /// Int16.addWrap(2 ** 14, 2 ** 14) // => -32_768 // overflow
   /// ```
   ///
-  /// :::info 
+  /// :::info
   /// The reason why this function is defined in this library (in addition
   /// to the existing `+%` operator) is so that you can use it as a function
   /// value to pass to a higher order function. It is not possible to use `+%`
@@ -554,40 +554,40 @@ module {
   public func addWrap(x : Int16, y : Int16) : Int16 { x +% y };
 
   /// Returns the difference of `x` and `y`, `x -% y`.
-  /// 
+  ///
   /// Wraps on overflow/underflow.
-  /// 
+  ///
   /// Example:
   /// ```motoko include=import
   /// Int16.subWrap(-2 ** 15, 1) // => +32_767 // underflow
   /// ```
-  /// 
+  ///
 
   public func subWrap(x : Int16, y : Int16) : Int16 { x -% y };
 
   /// Returns the product of `x` and `y`, `x *% y`. Wraps on overflow.
-  /// 
+  ///
   /// Wraps on overflow/underflow.
-  /// 
+  ///
   /// Example:
   /// ```motoko include=import
   /// Int16.mulWrap(2 ** 8, 2 ** 8) // => 0 // overflow
   /// ```
-  /// 
+  ///
 
   public func mulWrap(x : Int16, y : Int16) : Int16 { x *% y };
 
   /// Returns `x` to the power of `y`, `x **% y`.
-  /// 
+  ///
   /// Wraps on overflow/underflow.
   /// Traps if `y < 0 or y >= 16`.
-  /// 
+  ///
   /// Example:
   /// ```motoko include=import
-  /// 
+  ///
   /// Int16.powWrap(2, 15) // => -32_768 // overflow
   /// ```
-  /// 
+  ///
 
   public func powWrap(x : Int16, y : Int16) : Int16 { x **% y }
 }

--- a/src/Int32.mo
+++ b/src/Int32.mo
@@ -1,14 +1,14 @@
 /// Provides utility functions on 32-bit signed integers.
-/// 
+///
 /// :::note
 /// Most operations are available as built-in operators (e.g. `1 + 1`).
 /// :::
-/// 
+///
 /// :::info Function form for higher-order use
-/// 
+///
 /// Several arithmetic and comparison functions (e.g. `add`, `sub`, `bitor`, `bitand`, `pow`) are defined in this module to enable their use as first-class function values, which is not possible with operators like `+`, `-`, `==`, etc., in Motoko. This allows you to pass these operations to higher-order functions such as `map`, `foldLeft`, or `sort`.
 /// :::
-/// 
+///
 /// ```motoko name=import
 /// import Int32 "mo:base/Int32";
 /// ```
@@ -21,7 +21,7 @@ module {
   public type Int32 = Prim.Types.Int32;
 
   /// Minimum 32-bit integer value, `-2 ** 31`.
-  /// 
+  ///
   /// Example:
   /// ```motoko include=import
   /// Int32.minimumValue // => -2_147_483_648
@@ -29,7 +29,7 @@ module {
   public let minimumValue = -2_147_483_648 : Int32;
 
   /// Maximum 32-bit integer value, `+2 ** 31 - 1`.
-  /// 
+  ///
   /// Example:
   /// ```motoko include=import
   /// Int32.maximumValue // => +2_147_483_647
@@ -37,7 +37,7 @@ module {
   public let maximumValue = 2_147_483_647 : Int32;
 
   /// Converts a 32-bit signed integer to a signed integer with infinite precision.
-  /// 
+  ///
   /// Example:
   /// ```motoko include=import
   /// Int32.toInt(123_456) // => 123_456 : Int
@@ -45,9 +45,9 @@ module {
   public let toInt : Int32 -> Int = Prim.int32ToInt;
 
   /// Converts a signed integer with infinite precision to a 32-bit signed integer.
-  /// 
+  ///
   /// Traps on overflow/underflow.
-  /// 
+  ///
   /// Example:
   /// ```motoko include=import
   /// Int32.fromInt(123_456) // => +123_456 : Int32
@@ -55,9 +55,9 @@ module {
   public let fromInt : Int -> Int32 = Prim.intToInt32;
 
   /// Converts a signed integer with infinite precision to a 32-bit signed integer.
-  /// 
+  ///
   /// Wraps on overflow/underflow.
-  /// 
+  ///
   /// Example:
   /// ```motoko include=import
   /// Int32.fromIntWrap(-123_456) // => -123_456 : Int
@@ -65,7 +65,7 @@ module {
   public let fromIntWrap : Int -> Int32 = Prim.intToInt32Wrap;
 
   /// Converts a 16-bit signed integer to a 32-bit signed integer.
-  /// 
+  ///
   /// Example:
   /// ```motoko include=import
   /// Int32.fromInt16(-123) // => -123 : Int32
@@ -73,9 +73,9 @@ module {
   public let fromInt16 : Int16 -> Int32 = Prim.int16ToInt32;
 
   /// Converts a 32-bit signed integer to a 16-bit signed integer.
-  /// 
+  ///
   /// Traps on overflow/underflow.
-  /// 
+  ///
   /// Example:
   /// ```motoko include=import
   /// Int32.toInt16(-123) // => -123 : Int16
@@ -83,9 +83,9 @@ module {
   public let toInt16 : Int32 -> Int16 = Prim.int32ToInt16;
 
   /// Converts a 64-bit signed integer to a 32-bit signed integer.
-  /// 
+  ///
   /// Traps on overflow/underflow.
-  /// 
+  ///
   /// Example:
   /// ```motoko include=import
   /// Int32.fromInt64(-123_456) // => -123_456 : Int32
@@ -93,7 +93,7 @@ module {
   public let fromInt64 : Int64 -> Int32 = Prim.int64ToInt32;
 
   /// Converts a 32-bit signed integer to a 64-bit signed integer.
-  /// 
+  ///
   /// Example:
   /// ```motoko include=import
   /// Int32.toInt64(-123_456) // => -123_456 : Int64
@@ -101,9 +101,9 @@ module {
   public let toInt64 : Int32 -> Int64 = Prim.int32ToInt64;
 
   /// Converts an unsigned 32-bit integer to a signed 32-bit integer.
-  /// 
+  ///
   /// Wraps on overflow/underflow.
-  /// 
+  ///
   /// Example:
   /// ```motoko include=import
   /// Int32.fromNat32(123_456) // => +123_456 : Int32
@@ -111,9 +111,9 @@ module {
   public let fromNat32 : Nat32 -> Int32 = Prim.nat32ToInt32;
 
   /// Converts a signed 32-bit integer to an unsigned 32-bit integer.
-  /// 
+  ///
   /// Wraps on overflow/underflow.
-  /// 
+  ///
   /// Example:
   /// ```motoko include=import
   /// Int32.toNat32(-1) // => 4_294_967_295 : Nat32 // underflow
@@ -122,7 +122,7 @@ module {
 
   /// Returns the Text representation of `x`. Textual representation _do not_
   /// contain underscores to represent commas.
-  /// 
+  ///
   /// Example:
   /// ```motoko include=import
   /// Int32.toText(-123456) // => "-123456"
@@ -132,9 +132,9 @@ module {
   };
 
   /// Returns the absolute value of `x`.
-  /// 
+  ///
   /// Traps when `x == -2 ** 31` (the minimum `Int32` value).
-  /// 
+  ///
   /// Example:
   /// ```motoko include=import
   /// Int32.abs(-123456) // => +123_456
@@ -144,7 +144,7 @@ module {
   };
 
   /// Returns the minimum of `x` and `y`.
-  /// 
+  ///
   /// Example:
   /// ```motoko include=import
   /// Int32.min(+2, -3) // => -3
@@ -154,7 +154,7 @@ module {
   };
 
   /// Returns the maximum of `x` and `y`.
-  /// 
+  ///
   /// Example:
   /// ```motoko include=import
   /// Int32.max(+2, -3) // => +2
@@ -165,18 +165,18 @@ module {
 
   /// Equality function for Int32 types.
   /// This is equivalent to `x == y`.
-  /// 
+  ///
   /// Example:
   /// ```motoko include=import
   /// Int32.equal(-1, -1); // => true
   /// ```
-  /// 
+  ///
 
-  /// 
+  ///
   /// Example:
   /// ```motoko include=import
   /// import Buffer "mo:base/Buffer";
-  /// 
+  ///
   /// let buffer1 = Buffer.Buffer<Int32>(1);
   /// buffer1.add(-3);
   /// let buffer2 = Buffer.Buffer<Int32>(1);
@@ -187,69 +187,69 @@ module {
 
   /// Inequality function for Int32 types.
   /// This is equivalent to `x != y`.
-  /// 
+  ///
   /// Example:
   /// ```motoko include=import
   /// Int32.notEqual(-1, -2); // => true
   /// ```
-  /// 
+  ///
 
   public func notEqual(x : Int32, y : Int32) : Bool { x != y };
 
   /// "Less than" function for Int32 types.
   /// This is equivalent to `x < y`.
-  /// 
+  ///
   /// Example:
   /// ```motoko include=import
   /// Int32.less(-2, 1); // => true
   /// ```
-  /// 
+  ///
 
   public func less(x : Int32, y : Int32) : Bool { x < y };
 
   /// "Less than or equal" function for Int32 types.
   /// This is equivalent to `x <= y`.
-  /// 
+  ///
   /// Example:
   /// ```motoko include=import
   /// Int32.lessOrEqual(-2, -2); // => true
   /// ```
-  /// 
+  ///
 
   public func lessOrEqual(x : Int32, y : Int32) : Bool { x <= y };
 
   /// "Greater than" function for Int32 types.
   /// This is equivalent to `x > y`.
-  /// 
+  ///
   /// Example:
   /// ```motoko include=import
   /// Int32.greater(-2, -3); // => true
   /// ```
-  /// 
+  ///
 
   public func greater(x : Int32, y : Int32) : Bool { x > y };
 
   /// "Greater than or equal" function for Int32 types.
   /// This is equivalent to `x >= y`.
-  /// 
+  ///
   /// Example:
   /// ```motoko include=import
   /// Int32.greaterOrEqual(-2, -2); // => true
   /// ```
-  /// 
+  ///
 
   public func greaterOrEqual(x : Int32, y : Int32) : Bool { x >= y };
 
   /// General-purpose comparison function for `Int32`. Returns the `Order` (
   /// either `#less`, `#equal`, or `#greater`) of comparing `x` with `y`.
-  /// 
+  ///
   /// Example:
   /// ```motoko include=import
   /// Int32.compare(-3, 2) // => #less
   /// ```
-  /// 
+  ///
   /// This function can be used as value for a high order function, such as a sort function.
-  /// 
+  ///
   /// Example:
   /// ```motoko include=import
   /// import Array "mo:base/Array";
@@ -260,28 +260,28 @@ module {
   };
 
   /// Returns the negation of `x`, `-x`.
-  /// 
+  ///
   /// Traps on overflow, i.e. for `neg(-2 ** 31)`.
-  /// 
+  ///
   /// Example:
   /// ```motoko include=import
   /// Int32.neg(123) // => -123
   /// ```
-  /// 
+  ///
 
   public func neg(x : Int32) : Int32 { -x };
 
   /// Returns the sum of `x` and `y`, `x + y`.
-  /// 
+  ///
   /// Traps on overflow/underflow.
-  /// 
+  ///
   /// Example:
   /// ```motoko include=import
   /// Int32.add(100, 23) // => +123
   /// ```
-  /// 
+  ///
 
-  /// 
+  ///
   /// Example:
   /// ```motoko include=import
   /// import Array "mo:base/Array";
@@ -290,16 +290,16 @@ module {
   public func add(x : Int32, y : Int32) : Int32 { x + y };
 
   /// Returns the difference of `x` and `y`, `x - y`.
-  /// 
+  ///
   /// Traps on overflow/underflow.
-  /// 
+  ///
   /// Example:
   /// ```motoko include=import
   /// Int32.sub(1234, 123) // => +1_111
   /// ```
-  /// 
+  ///
 
-  /// 
+  ///
   /// Example:
   /// ```motoko include=import
   /// import Array "mo:base/Array";
@@ -308,16 +308,16 @@ module {
   public func sub(x : Int32, y : Int32) : Int32 { x - y };
 
   /// Returns the product of `x` and `y`, `x * y`.
-  /// 
+  ///
   /// Traps on overflow/underflow.
-  /// 
+  ///
   /// Example:
   /// ```motoko include=import
   /// Int32.mul(123, 100) // => +12_300
   /// ```
-  /// 
+  ///
 
-  /// 
+  ///
   /// Example:
   /// ```motoko include=import
   /// import Array "mo:base/Array";
@@ -327,146 +327,146 @@ module {
 
   /// Returns the signed integer division of `x` by `y`, `x / y`.
   /// Rounds the quotient towards zero, which is the same as truncating the decimal places of the quotient.
-  /// 
+  ///
   /// Traps when `y` is zero.
-  /// 
+  ///
   /// Example:
   /// ```motoko include=import
   /// Int32.div(123, 10) // => +12
   /// ```
-  /// 
+  ///
 
   public func div(x : Int32, y : Int32) : Int32 { x / y };
 
   /// Returns the remainder of the signed integer division of `x` by `y`, `x % y`,
   /// which is defined as `x - x / y * y`.
-  /// 
+  ///
   /// Traps when `y` is zero.
-  /// 
+  ///
   /// Example:
   /// ```motoko include=import
   /// Int32.rem(123, 10) // => +3
   /// ```
-  /// 
+  ///
 
   public func rem(x : Int32, y : Int32) : Int32 { x % y };
 
   /// Returns `x` to the power of `y`, `x ** y`.
-  /// 
+  ///
   /// Traps on overflow/underflow and when `y < 0 or y >= 32`.
-  /// 
+  ///
   /// Example:
   /// ```motoko include=import
   /// Int32.pow(2, 10) // => +1_024
   /// ```
-  /// 
+  ///
 
   public func pow(x : Int32, y : Int32) : Int32 { x ** y };
 
   /// Returns the bitwise negation of `x`, `^x`.
-  /// 
+  ///
   /// Example:
   /// ```motoko include=import
   /// Int32.bitnot(-256 /* 0xffff_ff00 */) // => +255 // 0xff
   /// ```
-  /// 
+  ///
 
   public func bitnot(x : Int32) : Int32 { ^x };
 
   /// Returns the bitwise "and" of `x` and `y`, `x & y`.
-  /// 
+  ///
   /// Example:
   /// ```motoko include=import
   /// Int32.bitand(0xffff, 0x00f0) // => +240 // 0xf0
   /// ```
-  /// 
+  ///
 
   public func bitand(x : Int32, y : Int32) : Int32 { x & y };
 
   /// Returns the bitwise "or" of `x` and `y`, `x | y`.
-  /// 
+  ///
   /// Example:
   /// ```motoko include=import
   /// Int32.bitor(0xffff, 0x00f0) // => +65_535 // 0xffff
   /// ```
-  /// 
+  ///
 
   public func bitor(x : Int32, y : Int32) : Int32 { x | y };
 
   /// Returns the bitwise "exclusive or" of `x` and `y`, `x ^ y`.
-  /// 
+  ///
   /// Example:
   /// ```motoko include=import
   /// Int32.bitxor(0xffff, 0x00f0) // => +65_295 // 0xff0f
   /// ```
-  /// 
+  ///
 
   public func bitxor(x : Int32, y : Int32) : Int32 { x ^ y };
 
   /// Returns the bitwise left shift of `x` by `y`, `x << y`.
   /// The right bits of the shift filled with zeros.
   /// Left-overflowing bits, including the sign bit, are discarded.
-  /// 
+  ///
   /// For `y >= 32`, the semantics is the same as for `bitshiftLeft(x, y % 32)`.
   /// For `y < 0`,  the semantics is the same as for `bitshiftLeft(x, y + y % 32)`.
-  /// 
+  ///
   /// Example:
   /// ```motoko include=import
   /// Int32.bitshiftLeft(1, 8) // => +256 // 0x100 equivalent to `2 ** 8`.
   /// ```
-  /// 
+  ///
 
   public func bitshiftLeft(x : Int32, y : Int32) : Int32 { x << y };
 
   /// Returns the signed bitwise right shift of `x` by `y`, `x >> y`.
   /// The sign bit is retained and the left side is filled with the sign bit.
   /// Right-underflowing bits are discarded, i.e. not rotated to the left side.
-  /// 
+  ///
   /// For `y >= 32`, the semantics is the same as for `bitshiftRight(x, y % 32)`.
   /// For `y < 0`,  the semantics is the same as for `bitshiftRight (x, y + y % 32)`.
-  /// 
+  ///
   /// Example:
   /// ```motoko include=import
   /// Int32.bitshiftRight(1024, 8) // => +4 // equivalent to `1024 / (2 ** 8)`
   /// ```
-  /// 
+  ///
 
   public func bitshiftRight(x : Int32, y : Int32) : Int32 { x >> y };
 
   /// Returns the bitwise left rotatation of `x` by `y`, `x <<> y`.
   /// Each left-overflowing bit is inserted again on the right side.
   /// The sign bit is rotated like other bits, i.e. the rotation interprets the number as unsigned.
-  /// 
+  ///
   /// Changes the direction of rotation for negative `y`.
   /// For `y >= 32`, the semantics is the same as for `bitrotLeft(x, y % 32)`.
-  /// 
+  ///
   /// Example:
   /// ```motoko include=import
   /// Int32.bitrotLeft(0x2000_0001, 4) // => +18 // 0x12.
   /// ```
-  /// 
+  ///
 
   public func bitrotLeft(x : Int32, y : Int32) : Int32 { x <<> y };
 
   /// Returns the bitwise right rotation of `x` by `y`, `x <>> y`.
   /// Each right-underflowing bit is inserted again on the right side.
   /// The sign bit is rotated like other bits, i.e. the rotation interprets the number as unsigned.
-  /// 
+  ///
   /// Changes the direction of rotation for negative `y`.
   /// For `y >= 32`, the semantics is the same as for `bitrotRight(x, y % 32)`.
-  /// 
+  ///
   /// Example:
   /// ```motoko include=import
   /// Int32.bitrotRight(0x0002_0001, 8) // => +16_777_728 // 0x0100_0200.
   /// ```
-  /// 
+  ///
 
   public func bitrotRight(x : Int32, y : Int32) : Int32 { x <>> y };
 
   /// Returns the value of bit `p` in `x`, `x & 2**p == 2**p`.
   /// If `p >= 32`, the semantics is the same as for `bittest(x, p % 32)`.
   /// This is equivalent to checking if the `p`-th bit is set in `x`, using 0 indexing.
-  /// 
+  ///
   /// Example:
   /// ```motoko include=import
   /// Int32.bittest(128, 7) // => true
@@ -477,7 +477,7 @@ module {
 
   /// Returns the value of setting bit `p` in `x` to `1`.
   /// If `p >= 32`, the semantics is the same as for `bitset(x, p % 32)`.
-  /// 
+  ///
   /// Example:
   /// ```motoko include=import
   /// Int32.bitset(0, 7) // => +128
@@ -488,7 +488,7 @@ module {
 
   /// Returns the value of clearing bit `p` in `x` to `0`.
   /// If `p >= 32`, the semantics is the same as for `bitclear(x, p % 32)`.
-  /// 
+  ///
   /// Example:
   /// ```motoko include=import
   /// Int32.bitclear(-1, 7) // => -129
@@ -499,7 +499,7 @@ module {
 
   /// Returns the value of flipping bit `p` in `x`.
   /// If `p >= 32`, the semantics is the same as for `bitclear(x, p % 32)`.
-  /// 
+  ///
   /// Example:
   /// ```motoko include=import
   /// Int32.bitflip(255, 7) // => +127
@@ -509,7 +509,7 @@ module {
   };
 
   /// Returns the count of non-zero bits in `x`.
-  /// 
+  ///
   /// Example:
   /// ```motoko include=import
   /// Int32.bitcountNonZero(0xffff) // => +16
@@ -517,7 +517,7 @@ module {
   public let bitcountNonZero : (x : Int32) -> Int32 = Prim.popcntInt32;
 
   /// Returns the count of leading zero bits in `x`.
-  /// 
+  ///
   /// Example:
   /// ```motoko include=import
   /// Int32.bitcountLeadingZero(0x8000) // => +16
@@ -525,7 +525,7 @@ module {
   public let bitcountLeadingZero : (x : Int32) -> Int32 = Prim.clzInt32;
 
   /// Returns the count of trailing zero bits in `x`.
-  /// 
+  ///
   /// Example:
   /// ```motoko include=import
   /// Int32.bitcountTrailingZero(0x0201_0000) // => +16
@@ -559,39 +559,39 @@ module {
   public func addWrap(x : Int32, y : Int32) : Int32 { x +% y };
 
   /// Returns the difference of `x` and `y`, `x -% y`.
-  /// 
+  ///
   /// Wraps on overflow/underflow.
-  /// 
+  ///
   /// Example:
   /// ```motoko include=import
   /// Int32.subWrap(-2 ** 31, 1) // => +2_147_483_647 // underflow
   /// ```
-  /// 
+  ///
 
   public func subWrap(x : Int32, y : Int32) : Int32 { x -% y };
 
   /// Returns the product of `x` and `y`, `x *% y`. Wraps on overflow.
-  /// 
+  ///
   /// Wraps on overflow/underflow.
-  /// 
+  ///
   /// Example:
   /// ```motoko include=import
   /// Int32.mulWrap(2 ** 16, 2 ** 16) // => 0 // overflow
   /// ```
-  /// 
+  ///
 
   public func mulWrap(x : Int32, y : Int32) : Int32 { x *% y };
 
   /// Returns `x` to the power of `y`, `x **% y`.
-  /// 
+  ///
   /// Wraps on overflow/underflow.
   /// Traps if `y < 0 or y >= 32`.
-  /// 
+  ///
   /// Example:
   /// ```motoko include=import
   /// Int32.powWrap(2, 31) // => -2_147_483_648 // overflow
   /// ```
-  /// 
+  ///
 
   public func powWrap(x : Int32, y : Int32) : Int32 { x **% y };
 

--- a/src/Int64.mo
+++ b/src/Int64.mo
@@ -1,14 +1,14 @@
 /// Provides utility functions on 64-bit signed integers.
-/// 
+///
 /// :::note
 /// Most operations are available as built-in operators (e.g. `1 + 1`).
 /// :::
-/// 
+///
 /// :::info Function form for higher-order use
-/// 
+///
 /// Several arithmetic and comparison functions (e.g. `add`, `sub`, `bitor`, `bitand`, `pow`) are defined in this module to enable their use as first-class function values, which is not possible with operators like `+`, `-`, `==`, etc., in Motoko. This allows you to pass these operations to higher-order functions such as `map`, `foldLeft`, or `sort`.
 /// :::
-/// 
+///
 /// Import from the base library to use this module.
 /// ```motoko name=import
 /// import Int64 "mo:base/Int64";
@@ -23,7 +23,7 @@ module {
   public type Int64 = Prim.Types.Int64;
 
   /// Minimum 64-bit integer value, `-2 ** 63`.
-  /// 
+  ///
   /// Example:
   /// ```motoko include=import
   /// Int64.minimumValue // => -9_223_372_036_854_775_808
@@ -31,7 +31,7 @@ module {
   public let minimumValue = -9_223_372_036_854_775_808 : Int64;
 
   /// Maximum 64-bit integer value, `+2 ** 63 - 1`.
-  /// 
+  ///
   /// Example:
   /// ```motoko include=import
   /// Int64.maximumValue // => +9_223_372_036_854_775_807
@@ -39,7 +39,7 @@ module {
   public let maximumValue = 9_223_372_036_854_775_807 : Int64;
 
   /// Converts a 64-bit signed integer to a signed integer with infinite precision.
-  /// 
+  ///
   /// Example:
   /// ```motoko include=import
   /// Int64.toInt(123_456) // => 123_456 : Int
@@ -47,9 +47,9 @@ module {
   public let toInt : Int64 -> Int = Prim.int64ToInt;
 
   /// Converts a signed integer with infinite precision to a 64-bit signed integer.
-  /// 
+  ///
   /// Traps on overflow/underflow.
-  /// 
+  ///
   /// Example:
   /// ```motoko include=import
   /// Int64.fromInt(123_456) // => +123_456 : Int64
@@ -57,9 +57,9 @@ module {
   public let fromInt : Int -> Int64 = Prim.intToInt64;
 
   /// Converts a 32-bit signed integer to a 64-bit signed integer.
-  /// 
+  ///
   /// Traps on overflow/underflow.
-  /// 
+  ///
   /// Example:
   /// ```motoko include=import
   /// Int64.fromInt32(-123_456) // => -123_456 : Int64
@@ -67,9 +67,9 @@ module {
   public let fromInt32 : Int32 -> Int64 = Prim.int32ToInt64;
 
   /// Converts a 64-bit signed integer to a 32-bit signed integer.
-  /// 
+  ///
   /// Wraps on overflow/underflow.
-  /// 
+  ///
   /// Example:
   /// ```motoko include=import
   /// Int64.toInt32(-123_456) // => -123_456 : Int32
@@ -77,9 +77,9 @@ module {
   public let toInt32 : Int64 -> Int32 = Prim.int64ToInt32;
 
   /// Converts a signed integer with infinite precision to a 64-bit signed integer.
-  /// 
+  ///
   /// Wraps on overflow/underflow.
-  /// 
+  ///
   /// Example:
   /// ```motoko include=import
   /// Int64.fromIntWrap(-123_456) // => -123_456 : Int64
@@ -87,9 +87,9 @@ module {
   public let fromIntWrap : Int -> Int64 = Prim.intToInt64Wrap;
 
   /// Converts an unsigned 64-bit integer to a signed 64-bit integer.
-  /// 
+  ///
   /// Wraps on overflow/underflow.
-  /// 
+  ///
   /// Example:
   /// ```motoko include=import
   /// Int64.fromNat64(123_456) // => +123_456 : Int64
@@ -97,9 +97,9 @@ module {
   public let fromNat64 : Nat64 -> Int64 = Prim.nat64ToInt64;
 
   /// Converts a signed 64-bit integer to an unsigned 64-bit integer.
-  /// 
+  ///
   /// Wraps on overflow/underflow.
-  /// 
+  ///
   /// Example:
   /// ```motoko include=import
   /// Int64.toNat64(-1) // => 18_446_744_073_709_551_615 : Nat64 // underflow
@@ -108,8 +108,8 @@ module {
 
   /// Returns the Text representation of `x`. Textual representation _do not_
   /// contain underscores to represent commas.
-  /// 
-  /// 
+  ///
+  ///
   /// Example:
   /// ```motoko include=import
   /// Int64.toText(-123456) // => "-123456"
@@ -119,9 +119,9 @@ module {
   };
 
   /// Returns the absolute value of `x`.
-  /// 
+  ///
   /// Traps when `x == -2 ** 63` (the minimum `Int64` value).
-  /// 
+  ///
   /// Example:
   /// ```motoko include=import
   /// Int64.abs(-123456) // => +123_456
@@ -131,7 +131,7 @@ module {
   };
 
   /// Returns the minimum of `x` and `y`.
-  /// 
+  ///
   /// Example:
   /// ```motoko include=import
   /// Int64.min(+2, -3) // => -3
@@ -141,7 +141,7 @@ module {
   };
 
   /// Returns the maximum of `x` and `y`.
-  /// 
+  ///
   /// Example:
   /// ```motoko include=import
   /// Int64.max(+2, -3) // => +2
@@ -152,18 +152,18 @@ module {
 
   /// Equality function for Int64 types.
   /// This is equivalent to `x == y`.
-  /// 
+  ///
   /// Example:
   /// ```motoko include=import
   /// Int64.equal(-1, -1); // => true
   /// ```
-  /// 
+  ///
 
-  /// 
+  ///
   /// Example:
   /// ```motoko include=import
   /// import Buffer "mo:base/Buffer";
-  /// 
+  ///
   /// let buffer1 = Buffer.Buffer<Int64>(1);
   /// buffer1.add(-3);
   /// let buffer2 = Buffer.Buffer<Int64>(1);
@@ -174,69 +174,69 @@ module {
 
   /// Inequality function for Int64 types.
   /// This is equivalent to `x != y`.
-  /// 
+  ///
   /// Example:
   /// ```motoko include=import
   /// Int64.notEqual(-1, -2); // => true
   /// ```
-  /// 
+  ///
 
   public func notEqual(x : Int64, y : Int64) : Bool { x != y };
 
   /// "Less than" function for Int64 types.
   /// This is equivalent to `x < y`.
-  /// 
+  ///
   /// Example:
   /// ```motoko include=import
   /// Int64.less(-2, 1); // => true
   /// ```
-  /// 
+  ///
 
   public func less(x : Int64, y : Int64) : Bool { x < y };
 
   /// "Less than or equal" function for Int64 types.
   /// This is equivalent to `x <= y`.
-  /// 
+  ///
   /// Example:
   /// ```motoko include=import
   /// Int64.lessOrEqual(-2, -2); // => true
   /// ```
-  /// 
+  ///
 
   public func lessOrEqual(x : Int64, y : Int64) : Bool { x <= y };
 
   /// "Greater than" function for Int64 types.
   /// This is equivalent to `x > y`.
-  /// 
+  ///
   /// Example:
   /// ```motoko include=import
   /// Int64.greater(-2, -3); // => true
   /// ```
-  /// 
+  ///
 
   public func greater(x : Int64, y : Int64) : Bool { x > y };
 
   /// "Greater than or equal" function for Int64 types.
   /// This is equivalent to `x >= y`.
-  /// 
+  ///
   /// Example:
   /// ```motoko include=import
   /// Int64.greaterOrEqual(-2, -2); // => true
   /// ```
-  /// 
+  ///
 
   public func greaterOrEqual(x : Int64, y : Int64) : Bool { x >= y };
 
   /// General-purpose comparison function for `Int64`. Returns the `Order` (
   /// either `#less`, `#equal`, or `#greater`) of comparing `x` with `y`.
-  /// 
+  ///
   /// Example:
   /// ```motoko include=import
   /// Int64.compare(-3, 2) // => #less
   /// ```
-  /// 
+  ///
   /// This function can be used as value for a high order function, such as a sort function.
-  /// 
+  ///
   /// Example:
   /// ```motoko include=import
   /// import Array "mo:base/Array";
@@ -247,28 +247,28 @@ module {
   };
 
   /// Returns the negation of `x`, `-x`.
-  /// 
+  ///
   /// Traps on overflow, i.e. for `neg(-2 ** 63)`.
-  /// 
+  ///
   /// Example:
   /// ```motoko include=import
   /// Int64.neg(123) // => -123
   /// ```
-  /// 
+  ///
 
   public func neg(x : Int64) : Int64 { -x };
 
   /// Returns the sum of `x` and `y`, `x + y`.
-  /// 
+  ///
   /// Traps on overflow/underflow.
-  /// 
+  ///
   /// Example:
   /// ```motoko include=import
   /// Int64.add(1234, 123) // => +1_357
   /// ```
-  /// 
+  ///
 
-  /// 
+  ///
   /// Example:
   /// ```motoko include=import
   /// import Array "mo:base/Array";
@@ -277,16 +277,16 @@ module {
   public func add(x : Int64, y : Int64) : Int64 { x + y };
 
   /// Returns the difference of `x` and `y`, `x - y`.
-  /// 
+  ///
   /// Traps on overflow/underflow.
-  /// 
+  ///
   /// Example:
   /// ```motoko include=import
   /// Int64.sub(123, 100) // => +23
   /// ```
-  /// 
+  ///
 
-  /// 
+  ///
   /// Example:
   /// ```motoko include=import
   /// import Array "mo:base/Array";
@@ -295,16 +295,16 @@ module {
   public func sub(x : Int64, y : Int64) : Int64 { x - y };
 
   /// Returns the product of `x` and `y`, `x * y`.
-  /// 
+  ///
   /// Traps on overflow/underflow.
-  /// 
+  ///
   /// Example:
   /// ```motoko include=import
   /// Int64.mul(123, 10) // => +1_230
   /// ```
-  /// 
+  ///
 
-  /// 
+  ///
   /// Example:
   /// ```motoko include=import
   /// import Array "mo:base/Array";
@@ -314,147 +314,147 @@ module {
 
   /// Returns the signed integer division of `x` by `y`, `x / y`.
   /// Rounds the quotient towards zero, which is the same as truncating the decimal places of the quotient.
-  /// 
+  ///
   /// Traps when `y` is zero.
-  /// 
+  ///
   /// Example:
   /// ```motoko include=import
   /// Int64.div(123, 10) // => +12
   /// ```
-  /// 
+  ///
 
   public func div(x : Int64, y : Int64) : Int64 { x / y };
 
   /// Returns the remainder of the signed integer division of `x` by `y`, `x % y`,
   /// which is defined as `x - x / y * y`.
-  /// 
+  ///
   /// Traps when `y` is zero.
-  /// 
+  ///
   /// Example:
   /// ```motoko include=import
   /// Int64.rem(123, 10) // => +3
   /// ```
-  /// 
+  ///
 
   public func rem(x : Int64, y : Int64) : Int64 { x % y };
 
   /// Returns `x` to the power of `y`, `x ** y`.
-  /// 
+  ///
   /// Traps on overflow/underflow and when `y < 0 or y >= 64`.
-  /// 
+  ///
   /// Example:
   /// ```motoko include=import
   /// Int64.pow(2, 10) // => +1_024
   /// ```
-  /// 
+  ///
 
   public func pow(x : Int64, y : Int64) : Int64 { x ** y };
 
   /// Returns the bitwise negation of `x`, `^x`.
-  /// 
+  ///
   /// Example:
   /// ```motoko include=import
   /// Int64.bitnot(-256 /* 0xffff_ffff_ffff_ff00 */) // => +255 // 0xff
   /// ```
-  /// 
+  ///
 
   public func bitnot(x : Int64) : Int64 { ^x };
 
   /// Returns the bitwise "and" of `x` and `y`, `x & y`.
-  /// 
+  ///
   /// Example:
   /// ```motoko include=import
   /// Int64.bitand(0xffff, 0x00f0) // => +240 // 0xf0
   /// ```
-  /// 
+  ///
 
   public func bitand(x : Int64, y : Int64) : Int64 { x & y };
 
   /// Returns the bitwise "or" of `x` and `y`, `x | y`.
-  /// 
+  ///
   /// Example:
   /// ```motoko include=import
   /// Int64.bitor(0xffff, 0x00f0) // => +65_535 // 0xffff
   /// ```
-  /// 
+  ///
 
   public func bitor(x : Int64, y : Int64) : Int64 { x | y };
 
   /// Returns the bitwise "exclusive or" of `x` and `y`, `x ^ y`.
-  /// 
+  ///
   /// Example:
   /// ```motoko include=import
   /// Int64.bitxor(0xffff, 0x00f0) // => +65_295 // 0xff0f
   /// ```
-  /// 
+  ///
 
   public func bitxor(x : Int64, y : Int64) : Int64 { x ^ y };
 
   /// Returns the bitwise left shift of `x` by `y`, `x << y`.
   /// The right bits of the shift filled with zeros.
   /// Left-overflowing bits, including the sign bit, are discarded.
-  /// 
+  ///
   /// For `y >= 64`, the semantics is the same as for `bitshiftLeft(x, y % 64)`.
   /// For `y < 0`,  the semantics is the same as for `bitshiftLeft(x, y + y % 64)`.
-  /// 
+  ///
   /// Example:
   /// ```motoko include=import
   /// Int64.bitshiftLeft(1, 8) // => +256 // 0x100 equivalent to `2 ** 8`.
   /// ```
-  /// 
+  ///
 
   public func bitshiftLeft(x : Int64, y : Int64) : Int64 { x << y };
 
   /// Returns the signed bitwise right shift of `x` by `y`, `x >> y`.
   /// The sign bit is retained and the left side is filled with the sign bit.
   /// Right-underflowing bits are discarded, i.e. not rotated to the left side.
-  /// 
+  ///
   /// For `y >= 64`, the semantics is the same as for `bitshiftRight(x, y % 64)`.
   /// For `y < 0`,  the semantics is the same as for `bitshiftRight (x, y + y % 64)`.
-  /// 
+  ///
   /// Example:
   /// ```motoko include=import
   /// Int64.bitshiftRight(1024, 8) // => +4 // equivalent to `1024 / (2 ** 8)`
   /// ```
-  /// 
+  ///
 
   public func bitshiftRight(x : Int64, y : Int64) : Int64 { x >> y };
 
   /// Returns the bitwise left rotatation of `x` by `y`, `x <<> y`.
   /// Each left-overflowing bit is inserted again on the right side.
   /// The sign bit is rotated like other bits, i.e. the rotation interprets the number as unsigned.
-  /// 
+  ///
   /// Changes the direction of rotation for negative `y`.
   /// For `y >= 64`, the semantics is the same as for `bitrotLeft(x, y % 64)`.
-  /// 
+  ///
   /// Example:
   /// ```motoko include=import
-  /// 
+  ///
   /// Int64.bitrotLeft(0x2000_0000_0000_0001, 4) // => +18 // 0x12.
   /// ```
-  /// 
+  ///
 
   public func bitrotLeft(x : Int64, y : Int64) : Int64 { x <<> y };
 
   /// Returns the bitwise right rotation of `x` by `y`, `x <>> y`.
   /// Each right-underflowing bit is inserted again on the right side.
   /// The sign bit is rotated like other bits, i.e. the rotation interprets the number as unsigned.
-  /// 
+  ///
   /// Changes the direction of rotation for negative `y`.
   /// For `y >= 64`, the semantics is the same as for `bitrotRight(x, y % 64)`.
-  /// 
+  ///
   /// Example:
   /// ```motoko include=import
   /// Int64.bitrotRight(0x0002_0000_0000_0001, 48) // => +65538 // 0x1_0002.
   /// ```
-  /// 
+  ///
 
   public func bitrotRight(x : Int64, y : Int64) : Int64 { x <>> y };
 
   /// Returns the value of bit `p` in `x`, `x & 2**p == 2**p`.
   /// If `p >= 64`, the semantics is the same as for `bittest(x, p % 64)`.
   /// This is equivalent to checking if the `p`-th bit is set in `x`, using 0 indexing.
-  /// 
+  ///
   /// Example:
   /// ```motoko include=import
   /// Int64.bittest(128, 7) // => true
@@ -465,7 +465,7 @@ module {
 
   /// Returns the value of setting bit `p` in `x` to `1`.
   /// If `p >= 64`, the semantics is the same as for `bitset(x, p % 64)`.
-  /// 
+  ///
   /// Example:
   /// ```motoko include=import
   /// Int64.bitset(0, 7) // => +128
@@ -476,7 +476,7 @@ module {
 
   /// Returns the value of clearing bit `p` in `x` to `0`.
   /// If `p >= 64`, the semantics is the same as for `bitclear(x, p % 64)`.
-  /// 
+  ///
   /// Example:
   /// ```motoko include=import
   /// Int64.bitclear(-1, 7) // => -129
@@ -487,7 +487,7 @@ module {
 
   /// Returns the value of flipping bit `p` in `x`.
   /// If `p >= 64`, the semantics is the same as for `bitclear(x, p % 64)`.
-  /// 
+  ///
   /// Example:
   /// ```motoko include=import
   /// Int64.bitflip(255, 7) // => +127
@@ -497,7 +497,7 @@ module {
   };
 
   /// Returns the count of non-zero bits in `x`.
-  /// 
+  ///
   /// Example:
   /// ```motoko include=import
   /// Int64.bitcountNonZero(0xffff) // => +16
@@ -505,7 +505,7 @@ module {
   public let bitcountNonZero : (x : Int64) -> Int64 = Prim.popcntInt64;
 
   /// Returns the count of leading zero bits in `x`.
-  /// 
+  ///
   /// Example:
   /// ```motoko include=import
   /// Int64.bitcountLeadingZero(0x8000_0000) // => +32
@@ -513,7 +513,7 @@ module {
   public let bitcountLeadingZero : (x : Int64) -> Int64 = Prim.clzInt64;
 
   /// Returns the count of trailing zero bits in `x`.
-  /// 
+  ///
   /// Example:
   /// ```motoko include=import
   /// Int64.bitcountTrailingZero(0x0201_0000) // => +16
@@ -538,7 +538,7 @@ module {
   /// Int64.addWrap(2 ** 62, 2 ** 62) // => -9_223_372_036_854_775_808 // overflow
   /// ```
   ///
-  /// :::info 
+  /// :::info
   /// The reason why this function is defined in this library (in addition
   /// to the existing `+%` operator) is so that you can use it as a function
   /// value to pass to a higher order function. It is not possible to use `+%`
@@ -547,39 +547,39 @@ module {
   public func addWrap(x : Int64, y : Int64) : Int64 { x +% y };
 
   /// Returns the difference of `x` and `y`, `x -% y`.
-  /// 
+  ///
   /// Wraps on overflow/underflow.
-  /// 
+  ///
   /// Example:
   /// ```motoko include=import
   /// Int64.subWrap(-2 ** 63, 1) // => +9_223_372_036_854_775_807 // underflow
   /// ```
-  /// 
+  ///
 
   public func subWrap(x : Int64, y : Int64) : Int64 { x -% y };
 
   /// Returns the product of `x` and `y`, `x *% y`. Wraps on overflow.
-  /// 
+  ///
   /// Wraps on overflow/underflow.
-  /// 
+  ///
   /// Example:
   /// ```motoko include=import
   /// Int64.mulWrap(2 ** 32, 2 ** 32) // => 0 // overflow
   /// ```
-  /// 
+  ///
 
   public func mulWrap(x : Int64, y : Int64) : Int64 { x *% y };
 
   /// Returns `x` to the power of `y`, `x **% y`.
-  /// 
+  ///
   /// Wraps on overflow/underflow.
   /// Traps if `y < 0 or y >= 64`.
-  /// 
+  ///
   /// Example:
   /// ```motoko include=import
   /// Int64.powWrap(2, 63) // => -9_223_372_036_854_775_808 // overflow
   /// ```
-  /// 
+  ///
 
   public func powWrap(x : Int64, y : Int64) : Int64 { x **% y }
 }

--- a/src/Int8.mo
+++ b/src/Int8.mo
@@ -1,15 +1,15 @@
 /// Provides utility functions on 8-bit signed integers.
-/// 
+///
 /// :::info Function form for higher-order use
-/// 
+///
 /// Several arithmetic and comparison functions (e.g. `add`, `sub`, `bitor`, `bitand`, `pow`) are defined in this module to enable their use as first-class function values, which is not possible with operators like `+`, `-`, `==`, etc., in Motoko. This allows you to pass these operations to higher-order functions such as `map`, `foldLeft`, or `sort`.
 /// :::
-/// 
+///
 /// :::note
 /// Most operations are available as built-in operators (e.g. `1 + 1`).
 /// :::
 /// Import from the base library to use this module.
-/// 
+///
 /// ```motoko name=import
 /// import Int8 "mo:base/Int8";
 /// ```
@@ -22,7 +22,7 @@ module {
   public type Int8 = Prim.Types.Int8;
 
   /// Minimum 8-bit integer value, `-2 ** 7`.
-  /// 
+  ///
   /// Example:
   /// ```motoko include=import
   /// Int8.minimumValue // => -128
@@ -30,7 +30,7 @@ module {
   public let minimumValue = -128 : Int8;
 
   /// Maximum 8-bit integer value, `+2 ** 7 - 1`.
-  /// 
+  ///
   /// Example:
   /// ```motoko include=import
   /// Int8.maximumValue // => +127
@@ -38,7 +38,7 @@ module {
   public let maximumValue = 127 : Int8;
 
   /// Converts an 8-bit signed integer to a signed integer with infinite precision.
-  /// 
+  ///
   /// Example:
   /// ```motoko include=import
   /// Int8.toInt(123) // => 123 : Int
@@ -46,9 +46,9 @@ module {
   public let toInt : Int8 -> Int = Prim.int8ToInt;
 
   /// Converts a signed integer with infinite precision to an 8-bit signed integer.
-  /// 
+  ///
   /// Traps on overflow/underflow.
-  /// 
+  ///
   /// Example:
   /// ```motoko include=import
   /// Int8.fromInt(123) // => +123 : Int8
@@ -56,9 +56,9 @@ module {
   public let fromInt : Int -> Int8 = Prim.intToInt8;
 
   /// Converts a signed integer with infinite precision to an 8-bit signed integer.
-  /// 
+  ///
   /// Wraps on overflow/underflow.
-  /// 
+  ///
   /// Example:
   /// ```motoko include=import
   /// Int8.fromIntWrap(-123) // => -123 : Int
@@ -66,9 +66,9 @@ module {
   public let fromIntWrap : Int -> Int8 = Prim.intToInt8Wrap;
 
   /// Converts a 16-bit signed integer to an 8-bit signed integer.
-  /// 
+  ///
   /// Traps on overflow/underflow.
-  /// 
+  ///
   /// Example:
   /// ```motoko include=import
   /// Int8.fromInt16(123) // => +123 : Int8
@@ -76,7 +76,7 @@ module {
   public let fromInt16 : Int16 -> Int8 = Prim.int16ToInt8;
 
   /// Converts an 8-bit signed integer to a 16-bit signed integer.
-  /// 
+  ///
   /// Example:
   /// ```motoko include=import
   /// Int8.toInt16(123) // => +123 : Int16
@@ -84,9 +84,9 @@ module {
   public let toInt16 : Int8 -> Int16 = Prim.int8ToInt16;
 
   /// Converts an unsigned 8-bit integer to a signed 8-bit integer.
-  /// 
+  ///
   /// Wraps on overflow/underflow.
-  /// 
+  ///
   /// Example:
   /// ```motoko include=import
   /// Int8.fromNat8(123) // => +123 : Int8
@@ -94,9 +94,9 @@ module {
   public let fromNat8 : Nat8 -> Int8 = Prim.nat8ToInt8;
 
   /// Converts a signed 8-bit integer to an unsigned 8-bit integer.
-  /// 
+  ///
   /// Wraps on overflow/underflow.
-  /// 
+  ///
   /// Example:
   /// ```motoko include=import
   /// Int8.toNat8(-1) // => 255 : Nat8 // underflow
@@ -104,7 +104,7 @@ module {
   public let toNat8 : Int8 -> Nat8 = Prim.int8ToNat8;
 
   /// Converts an integer number to its textual representation.
-  /// 
+  ///
   /// Example:
   /// ```motoko include=import
   /// Int8.toText(-123) // => "-123"
@@ -114,9 +114,9 @@ module {
   };
 
   /// Returns the absolute value of `x`.
-  /// 
+  ///
   /// Traps when `x == -2 ** 7` (the minimum `Int8` value).
-  /// 
+  ///
   /// Example:
   /// ```motoko include=import
   /// Int8.abs(-123) // => +123
@@ -126,7 +126,7 @@ module {
   };
 
   /// Returns the minimum of `x` and `y`.
-  /// 
+  ///
   /// Example:
   /// ```motoko include=import
   /// Int8.min(+2, -3) // => -3
@@ -136,7 +136,7 @@ module {
   };
 
   /// Returns the maximum of `x` and `y`.
-  /// 
+  ///
   /// Example:
   /// ```motoko include=import
   /// Int8.max(+2, -3) // => +2
@@ -147,18 +147,18 @@ module {
 
   /// Equality function for Int8 types.
   /// This is equivalent to `x == y`.
-  /// 
+  ///
   /// Example:
   /// ```motoko include=import
   /// Int8.equal(-1, -1); // => true
   /// ```
-  /// 
+  ///
 
-  /// 
+  ///
   /// Example:
   /// ```motoko include=import
   /// import Buffer "mo:base/Buffer";
-  /// 
+  ///
   /// let buffer1 = Buffer.Buffer<Int8>(1);
   /// buffer1.add(-3);
   /// let buffer2 = Buffer.Buffer<Int8>(1);
@@ -169,69 +169,69 @@ module {
 
   /// Inequality function for Int8 types.
   /// This is equivalent to `x != y`.
-  /// 
+  ///
   /// Example:
   /// ```motoko include=import
   /// Int8.notEqual(-1, -2); // => true
   /// ```
-  /// 
+  ///
 
   public func notEqual(x : Int8, y : Int8) : Bool { x != y };
 
   /// "Less than" function for Int8 types.
   /// This is equivalent to `x < y`.
-  /// 
+  ///
   /// Example:
   /// ```motoko include=import
   /// Int8.less(-2, 1); // => true
   /// ```
-  /// 
+  ///
 
   public func less(x : Int8, y : Int8) : Bool { x < y };
 
   /// "Less than or equal" function for Int8 types.
   /// This is equivalent to `x <= y`.
-  /// 
+  ///
   /// Example:
   /// ```motoko include=import
   /// Int8.lessOrEqual(-2, -2); // => true
   /// ```
-  /// 
+  ///
 
   public func lessOrEqual(x : Int8, y : Int8) : Bool { x <= y };
 
   /// "Greater than" function for Int8 types.
   /// This is equivalent to `x > y`.
-  /// 
+  ///
   /// Example:
   /// ```motoko include=import
   /// Int8.greater(-2, -3); // => true
   /// ```
-  /// 
+  ///
 
   public func greater(x : Int8, y : Int8) : Bool { x > y };
 
   /// "Greater than or equal" function for Int8 types.
   /// This is equivalent to `x >= y`.
-  /// 
+  ///
   /// Example:
   /// ```motoko include=import
   /// Int8.greaterOrEqual(-2, -2); // => true
   /// ```
-  /// 
+  ///
 
   public func greaterOrEqual(x : Int8, y : Int8) : Bool { x >= y };
 
   /// General-purpose comparison function for `Int8`. Returns the `Order` (
   /// either `#less`, `#equal`, or `#greater`) of comparing `x` with `y`.
-  /// 
+  ///
   /// Example:
   /// ```motoko include=import
   /// Int8.compare(-3, 2) // => #less
   /// ```
-  /// 
+  ///
   /// This function can be used as value for a high order function, such as a sort function.
-  /// 
+  ///
   /// Example:
   /// ```motoko include=import
   /// import Array "mo:base/Array";
@@ -242,28 +242,28 @@ module {
   };
 
   /// Returns the negation of `x`, `-x`.
-  /// 
+  ///
   /// Traps on overflow, i.e. for `neg(-2 ** 7)`.
-  /// 
+  ///
   /// Example:
   /// ```motoko include=import
   /// Int8.neg(123) // => -123
   /// ```
-  /// 
+  ///
 
   public func neg(x : Int8) : Int8 { -x };
 
   /// Returns the sum of `x` and `y`, `x + y`.
-  /// 
+  ///
   /// Traps on overflow/underflow.
-  /// 
+  ///
   /// Example:
   /// ```motoko include=import
   /// Int8.add(100, 23) // => +123
   /// ```
-  /// 
+  ///
 
-  /// 
+  ///
   /// Example:
   /// ```motoko include=import
   /// import Array "mo:base/Array";
@@ -272,16 +272,16 @@ module {
   public func add(x : Int8, y : Int8) : Int8 { x + y };
 
   /// Returns the difference of `x` and `y`, `x - y`.
-  /// 
+  ///
   /// Traps on overflow/underflow.
-  /// 
+  ///
   /// Example:
   /// ```motoko include=import
   /// Int8.sub(123, 23) // => +100
   /// ```
-  /// 
+  ///
 
-  /// 
+  ///
   /// Example:
   /// ```motoko include=import
   /// import Array "mo:base/Array";
@@ -290,16 +290,16 @@ module {
   public func sub(x : Int8, y : Int8) : Int8 { x - y };
 
   /// Returns the product of `x` and `y`, `x * y`.
-  /// 
+  ///
   /// Traps on overflow/underflow.
-  /// 
+  ///
   /// Example:
   /// ```motoko include=import
   /// Int8.mul(12, 10) // => +120
   /// ```
-  /// 
+  ///
 
-  /// 
+  ///
   /// Example:
   /// ```motoko include=import
   /// import Array "mo:base/Array";
@@ -309,146 +309,146 @@ module {
 
   /// Returns the signed integer division of `x` by `y`, `x / y`.
   /// Rounds the quotient towards zero, which is the same as truncating the decimal places of the quotient.
-  /// 
+  ///
   /// Traps when `y` is zero.
-  /// 
+  ///
   /// Example:
   /// ```motoko include=import
   /// Int8.div(123, 10) // => +12
   /// ```
-  /// 
+  ///
 
   public func div(x : Int8, y : Int8) : Int8 { x / y };
 
   /// Returns the remainder of the signed integer division of `x` by `y`, `x % y`,
   /// which is defined as `x - x / y * y`.
-  /// 
+  ///
   /// Traps when `y` is zero.
-  /// 
+  ///
   /// Example:
   /// ```motoko include=import
   /// Int8.rem(123, 10) // => +3
   /// ```
-  /// 
+  ///
 
   public func rem(x : Int8, y : Int8) : Int8 { x % y };
 
   /// Returns `x` to the power of `y`, `x ** y`.
-  /// 
+  ///
   /// Traps on overflow/underflow and when `y < 0 or y >= 8`.
-  /// 
+  ///
   /// Example:
   /// ```motoko include=import
   /// Int8.pow(2, 6) // => +64
   /// ```
-  /// 
+  ///
 
   public func pow(x : Int8, y : Int8) : Int8 { x ** y };
 
   /// Returns the bitwise negation of `x`, `^x`.
-  /// 
+  ///
   /// Example:
   /// ```motoko include=import
   /// Int8.bitnot(-16 /* 0xf0 */) // => +15 // 0x0f
   /// ```
-  /// 
+  ///
 
   public func bitnot(x : Int8) : Int8 { ^x };
 
   /// Returns the bitwise "and" of `x` and `y`, `x & y`.
-  /// 
+  ///
   /// Example:
   /// ```motoko include=import
   /// Int8.bitand(0x1f, 0x70) // => +16 // 0x10
   /// ```
-  /// 
+  ///
 
   public func bitand(x : Int8, y : Int8) : Int8 { x & y };
 
   /// Returns the bitwise "or" of `x` and `y`, `x | y`.
-  /// 
+  ///
   /// Example:
   /// ```motoko include=import
   /// Int8.bitor(0x0f, 0x70) // => +127 // 0x7f
   /// ```
-  /// 
+  ///
 
   public func bitor(x : Int8, y : Int8) : Int8 { x | y };
 
   /// Returns the bitwise "exclusive or" of `x` and `y`, `x ^ y`.
-  /// 
+  ///
   /// Example:
   /// ```motoko include=import
   /// Int8.bitxor(0x70, 0x7f) // => +15 // 0x0f
   /// ```
-  /// 
+  ///
 
   public func bitxor(x : Int8, y : Int8) : Int8 { x ^ y };
 
   /// Returns the bitwise left shift of `x` by `y`, `x << y`.
   /// The right bits of the shift filled with zeros.
   /// Left-overflowing bits, including the sign bit, are discarded.
-  /// 
+  ///
   /// For `y >= 8`, the semantics is the same as for `bitshiftLeft(x, y % 8)`.
   /// For `y < 0`,  the semantics is the same as for `bitshiftLeft(x, y + y % 8)`.
-  /// 
+  ///
   /// Example:
   /// ```motoko include=import
   /// Int8.bitshiftLeft(1, 4) // => +16 // 0x10 equivalent to `2 ** 4`.
   /// ```
-  /// 
+  ///
 
   public func bitshiftLeft(x : Int8, y : Int8) : Int8 { x << y };
 
   /// Returns the signed bitwise right shift of `x` by `y`, `x >> y`.
   /// The sign bit is retained and the left side is filled with the sign bit.
   /// Right-underflowing bits are discarded, i.e. not rotated to the left side.
-  /// 
+  ///
   /// For `y >= 8`, the semantics is the same as for `bitshiftRight(x, y % 8)`.
   /// For `y < 0`,  the semantics is the same as for `bitshiftRight (x, y + y % 8)`.
-  /// 
+  ///
   /// Example:
   /// ```motoko include=import
   /// Int8.bitshiftRight(64, 4) // => +4 // equivalent to `64 / (2 ** 4)`
   /// ```
-  /// 
+  ///
 
   public func bitshiftRight(x : Int8, y : Int8) : Int8 { x >> y };
 
   /// Returns the bitwise left rotatation of `x` by `y`, `x <<> y`.
   /// Each left-overflowing bit is inserted again on the right side.
   /// The sign bit is rotated like other bits, i.e. the rotation interprets the number as unsigned.
-  /// 
+  ///
   /// Changes the direction of rotation for negative `y`.
   /// For `y >= 8`, the semantics is the same as for `bitrotLeft(x, y % 8)`.
-  /// 
+  ///
   /// Example:
   /// ```motoko include=import
   /// Int8.bitrotLeft(0x11 /* 0b0001_0001 */, 2) // => +68 // 0b0100_0100 == 0x44.
   /// ```
-  /// 
+  ///
 
   public func bitrotLeft(x : Int8, y : Int8) : Int8 { x <<> y };
 
   /// Returns the bitwise right rotation of `x` by `y`, `x <>> y`.
   /// Each right-underflowing bit is inserted again on the right side.
   /// The sign bit is rotated like other bits, i.e. the rotation interprets the number as unsigned.
-  /// 
+  ///
   /// Changes the direction of rotation for negative `y`.
   /// For `y >= 8`, the semantics is the same as for `bitrotRight(x, y % 8)`.
-  /// 
+  ///
   /// Example:
   /// ```motoko include=import
   /// Int8.bitrotRight(0x11 /* 0b0001_0001 */, 1) // => -120 // 0b1000_1000 == 0x88.
   /// ```
-  /// 
+  ///
 
   public func bitrotRight(x : Int8, y : Int8) : Int8 { x <>> y };
 
   /// Returns the value of bit `p` in `x`, `x & 2**p == 2**p`.
   /// If `p >= 8`, the semantics is the same as for `bittest(x, p % 8)`.
   /// This is equivalent to checking if the `p`-th bit is set in `x`, using 0 indexing.
-  /// 
+  ///
   /// Example:
   /// ```motoko include=import
   /// Int8.bittest(64, 6) // => true
@@ -459,7 +459,7 @@ module {
 
   /// Returns the value of setting bit `p` in `x` to `1`.
   /// If `p >= 8`, the semantics is the same as for `bitset(x, p % 8)`.
-  /// 
+  ///
   /// Example:
   /// ```motoko include=import
   /// Int8.bitset(0, 6) // => +64
@@ -470,7 +470,7 @@ module {
 
   /// Returns the value of clearing bit `p` in `x` to `0`.
   /// If `p >= 8`, the semantics is the same as for `bitclear(x, p % 8)`.
-  /// 
+  ///
   /// Example:
   /// ```motoko include=import
   /// Int8.bitclear(-1, 6) // => -65
@@ -481,7 +481,7 @@ module {
 
   /// Returns the value of flipping bit `p` in `x`.
   /// If `p >= 8`, the semantics is the same as for `bitclear(x, p % 8)`.
-  /// 
+  ///
   /// Example:
   /// ```motoko include=import
   /// Int8.bitflip(127, 6) // => +63
@@ -491,7 +491,7 @@ module {
   };
 
   /// Returns the count of non-zero bits in `x`.
-  /// 
+  ///
   /// Example:
   /// ```motoko include=import
   /// Int8.bitcountNonZero(0x0f) // => +4
@@ -499,7 +499,7 @@ module {
   public let bitcountNonZero : (x : Int8) -> Int8 = Prim.popcntInt8;
 
   /// Returns the count of leading zero bits in `x`.
-  /// 
+  ///
   /// Example:
   /// ```motoko include=import
   /// Int8.bitcountLeadingZero(0x08) // => +4
@@ -507,7 +507,7 @@ module {
   public let bitcountLeadingZero : (x : Int8) -> Int8 = Prim.clzInt8;
 
   /// Returns the count of trailing zero bits in `x`.
-  /// 
+  ///
   /// Example:
   /// ```motoko include=import
   /// Int8.bitcountTrailingZero(0x10) // => +4
@@ -515,51 +515,51 @@ module {
   public let bitcountTrailingZero : (x : Int8) -> Int8 = Prim.ctzInt8;
 
   /// Returns the sum of `x` and `y`, `x +% y`.
-  /// 
+  ///
   /// Wraps on overflow/underflow.
-  /// 
+  ///
   /// Example:
   /// ```motoko include=import
   /// Int8.addWrap(2 ** 6, 2 ** 6) // => -128 // overflow
   /// ```
-  /// 
+  ///
 
   public func addWrap(x : Int8, y : Int8) : Int8 { x +% y };
 
   /// Returns the difference of `x` and `y`, `x -% y`.
-  /// 
+  ///
   /// Wraps on overflow/underflow.
-  /// 
+  ///
   /// Example:
   /// ```motoko include=import
   /// Int8.subWrap(-2 ** 7, 1) // => +127 // underflow
   /// ```
-  /// 
+  ///
 
   public func subWrap(x : Int8, y : Int8) : Int8 { x -% y };
 
   /// Returns the product of `x` and `y`, `x *% y`. Wraps on overflow.
-  /// 
+  ///
   /// Wraps on overflow/underflow.
-  /// 
+  ///
   /// Example:
   /// ```motoko include=import
   /// Int8.mulWrap(2 ** 4, 2 ** 4) // => 0 // overflow
   /// ```
-  /// 
+  ///
 
   public func mulWrap(x : Int8, y : Int8) : Int8 { x *% y };
 
   /// Returns `x` to the power of `y`, `x **% y`.
-  /// 
+  ///
   /// Wraps on overflow/underflow.
   /// Traps if `y < 0 or y >= 8`.
-  /// 
+  ///
   /// Example:
   /// ```motoko include=import
   /// Int8.powWrap(2, 7) // => -128 // overflow
   /// ```
-  /// 
+  ///
 
   public func powWrap(x : Int8, y : Int8) : Int8 { x **% y };
 

--- a/src/Iter.mo
+++ b/src/Iter.mo
@@ -8,11 +8,11 @@ module {
 
   /// An iterator that produces values of type `T`. Calling `next` returns
   /// `null` when iteration is finished.
-  /// 
+  ///
   /// Iterators are inherently stateful. Calling `next` "consumes" a value from
   /// the Iterator that cannot be put back, so keep that in mind when sharing
   /// iterators between consumers.
-  /// 
+  ///
   /// An iterater `i` can be iterated over using
   /// ```
   /// for (x in i) {
@@ -49,7 +49,7 @@ module {
 
   /// Calls a function `f` on every value produced by an iterator and discards
   /// the results. If you're looking to keep these results use `map` instead.
-  /// 
+  ///
   /// ```motoko
   /// import Iter "mo:base/Iter";
   /// var sum = 0;

--- a/src/List.mo
+++ b/src/List.mo
@@ -1,13 +1,13 @@
 /// Purely-functional, singly-linked lists.
 /// A list of type `List<T>` is either `null` or an optional pair of a value of type `T` and a tail, itself of type `List<T>`.
-/// 
+///
 /// :::note Assumptions
-/// 
+///
 /// Runtime and space complexity assumes that `equal`, and other functions execute in `O(1)` time and space.
 /// :::
-/// 
+///
 /// To use this library, import it using:
-/// 
+///
 /// ```motoko name=initialize
 /// import List "mo:base/List";
 /// ```
@@ -26,24 +26,24 @@ module {
   public type List<T> = ?(T, List<T>);
 
   /// Create an empty list.
-  /// 
+  ///
   /// Example:
   /// ```motoko include=initialize
   /// List.nil<Nat>() // => null
   /// ```
-  /// 
+  ///
   /// | Runtime   | Space     |
   /// |-----------|-----------|
   /// | `O(1)` | `O(1)` |
   public func nil<T>() : List<T> = null;
 
   /// Check whether a list is empty and return true if the list is empty.
-  /// 
+  ///
   /// Example:
   /// ```motoko include=initialize
   /// List.isNil<Nat>(null) // => true
   /// ```
-  /// 
+  ///
   /// | Runtime   | Space     |
   /// |-----------|-----------|
   /// | `O(1)` | `O(1)` |
@@ -55,12 +55,12 @@ module {
   };
 
   /// Add `x` to the head of `list`, and return the new list.
-  /// 
+  ///
   /// Example:
   /// ```motoko include=initialize
   /// List.push<Nat>(0, null) // => ?(0, null);
   /// ```
-  /// 
+  ///
   /// | Runtime   | Space     |
   /// |-----------|-----------|
   /// | `O(1)` | `O(1)` |
@@ -71,7 +71,7 @@ module {
   /// ```motoko include=initialize
   /// List.last<Nat>(?(0, ?(1, null))) // => ?1
   /// ```
-  /// 
+  ///
   /// | Runtime   | Space     |
   /// |-----------|-----------|
   /// | `O(size)` | `O(1)` |
@@ -85,12 +85,12 @@ module {
 
   /// Remove the head of the list, returning the optioned head and the tail of the list in a pair.
   /// Returns `(null, null)` if the list is empty.
-  /// 
+  ///
   /// Example:
   /// ```motoko include=initialize
   /// List.pop<Nat>(?(0, ?(1, null))) // => (?0, ?(1, null))
   /// ```
-  /// 
+  ///
   /// | Runtime   | Space     |
   /// |-----------|-----------|
   /// | `O(1)` | `O(1)` |
@@ -102,12 +102,12 @@ module {
   };
 
   /// Return the length of the list.
-  /// 
+  ///
   /// Example:
   /// ```motoko include=initialize
   /// List.size<Nat>(?(0, ?(1, null))) // => 2
   /// ```
-  /// 
+  ///
   /// | Runtime   | Space     |
   /// |-----------|-----------|
   /// | `O(size)` | `O(1)` |
@@ -121,19 +121,19 @@ module {
     rec(l, 0)
   };
   /// Access any item in a list, zero-based.
-  /// 
+  ///
   /// :::note Consideration
   /// Indexing into a list is a linear operation, and usually an
   /// indication that a list might not be the best data structure
   /// to use.
   /// :::
-  /// 
+  ///
   /// Example:
-  /// 
+  ///
   /// ```motoko include=initialize
   /// List.get<Nat>(?(0, ?(1, null)), 1) // => ?1
   /// ```
-  /// 
+  ///
   /// | Runtime   | Space     |
   /// |-----------|-----------|
   /// | `O(size)` | `O(1)` |
@@ -146,12 +146,12 @@ module {
   };
 
   /// Reverses the list.
-  /// 
+  ///
   /// Example:
   /// ```motoko include=initialize
   /// List.reverse<Nat>(?(0, ?(1, ?(2, null)))) // => ?(2, ?(1, ?(0, null)))
   /// ```
-  /// 
+  ///
   /// | Runtime   | Space     |
   /// |-----------|-----------|
   /// | `O(size)` | `O(size)` |
@@ -166,18 +166,18 @@ module {
   };
 
   /// Call the given function for its side effect, with each list element in turn.
-  /// 
+  ///
   /// Example:
   /// ```motoko include=initialize
   /// var sum = 0;
   /// List.iterate<Nat>(?(0, ?(1, ?(2, null))), func n { sum += n });
   /// sum // => 3
   /// ```
-  /// 
+  ///
   /// | Runtime   | Space     |
   /// |-----------|-----------|
   /// | `O(size)` | `O(size)` |
-  /// 
+  ///
   public func iterate<T>(l : List<T>, f : T -> ()) {
     switch l {
       case null { () };
@@ -187,13 +187,13 @@ module {
 
   /// Call the given function `f` on each list element and collect the results
   /// in a new list.
-  /// 
+  ///
   /// Example:
   /// ```motoko include=initialize
   /// import Nat = "mo:base/Nat"
   /// List.map<Nat, Text>(?(0, ?(1, ?(2, null))), Nat.toText) // => ?("0", ?("1", ?("2", null))
   /// ```
-  /// 
+  ///
   /// | Runtime   | Space     |
   /// |-----------|-----------|
   /// | `O(size)` | `O(size)` |
@@ -207,12 +207,12 @@ module {
 
   /// Create a new list with only those elements of the original list for which
   /// the given function (often called the _predicate_) returns true.
-  /// 
+  ///
   /// Example:
   /// ```motoko include=initialize
   /// List.filter<Nat>(?(0, ?(1, ?(2, null))), func n { n != 1 }) // => ?(0, ?(2, null))
   /// ```
-  /// 
+  ///
   /// | Runtime   | Space     |
   /// |-----------|-----------|
   /// | `O(size)` | `O(size)` |
@@ -233,16 +233,16 @@ module {
   /// The first list only includes the elements for which the given
   /// function `f` returns true and the second list only includes
   /// the elements for which the function returns false.
-  /// 
+  ///
   /// Example:
   /// ```motoko include=initialize
   /// List.partition<Nat>(?(0, ?(1, ?(2, null))), func n { n != 1 }) // => (?(0, ?(2, null)), ?(1, null))
   /// ```
-  /// 
+  ///
   /// | Runtime   | Space     |
   /// |-----------|-----------|
   /// | `O(size)` | `O(size)` |
-  /// 
+  ///
   public func partition<T>(l : List<T>, f : T -> Bool) : (List<T>, List<T>) {
     switch l {
       case null { (null, null) };
@@ -261,7 +261,7 @@ module {
 
   /// Call the given function on each list element, and collect the non-null results
   /// in a new list.
-  /// 
+  ///
   /// Example:
   /// ```motoko include=initialize
   /// List.mapFilter<Nat, Nat>(
@@ -275,11 +275,11 @@ module {
   ///   }
   /// ) // => ?(4, ?(6, null))
   /// ```
-  /// 
+  ///
   /// | Runtime   | Space     |
   /// |-----------|-----------|
   /// | `O(size)` | `O(size)` |
-  /// 
+  ///
   public func mapFilter<T, U>(l : List<T>, f : T -> ?U) : List<U> {
     switch l {
       case null { null };
@@ -294,7 +294,7 @@ module {
 
   /// Maps a Result-returning function `f` over a List and returns either
   /// the first error or a list of successful values.
-  /// 
+  ///
   /// Example:
   /// ```motoko include=initialize
   /// List.mapResult<Nat, Nat, Text>(
@@ -308,11 +308,11 @@ module {
   ///   }
   /// ); // => #ok ?(2, ?(4, ?(6, null))
   /// ```
-  /// 
+  ///
   /// | Runtime   | Space     |
   /// |-----------|-----------|
   /// | `O(size)` | `O(size)` |
-  /// 
+  ///
   public func mapResult<T, R, E>(xs : List<T>, f : T -> Result.Result<R, E>) : Result.Result<List<R>, E> {
     func go(xs : List<T>, acc : List<R>) : Result.Result<List<R>, E> {
       switch xs {
@@ -329,7 +329,7 @@ module {
   };
 
   /// Append the elements from the reverse of one list, 'l', to another list, 'm'.
-  /// 
+  ///
   /// Example:
   /// ```motoko include=initialize
   /// List.revAppend<Nat>(
@@ -337,7 +337,7 @@ module {
   ///   ?(3, ?(4, ?(5, null)))
   /// ); // => ?(0, ?(1, ?(2, ?(3, ?(4, ?(5, null))))))
   /// ```
-  /// 
+  ///
   /// | Runtime     | Space       |
   /// |-------------|-------------|
   /// | `O(size(l))`  | `O(size(l))`  |
@@ -349,7 +349,7 @@ module {
   };
 
   /// Append the elements from one list to another list.
-  /// 
+  ///
   /// Example:
   /// ```motoko include=initialize
   /// List.append<Nat>(
@@ -357,7 +357,7 @@ module {
   ///   ?(3, ?(4, ?(5, null)))
   /// ) // => ?(0, ?(1, ?(2, ?(3, ?(4, ?(5, null))))))
   /// ```
-  /// 
+  ///
   /// | Runtime     | Space       |
   /// |-------------|-------------|
   /// | `O(size(l))`  | `O(size(l))`  |
@@ -366,7 +366,7 @@ module {
   };
 
   /// Flatten, or concatenate, a list of lists as a list.
-  /// 
+  ///
   /// Example:
   /// ```motoko include=initialize
   /// List.flatten<Nat>(
@@ -375,7 +375,7 @@ module {
   ///       null))
   /// ); // => ?(0, ?(1, ?(2, ?(3, ?(4, ?(5, null))))))
   /// ```
-  /// 
+  ///
   /// | Runtime     | Space       |
   /// |-------------|-------------|
   /// | `O(size*size)`  | `O(size*size)`  |
@@ -387,7 +387,7 @@ module {
   /// Returns the first `n` elements of the given list.
   /// If the given list has fewer than `n` elements, this function returns
   /// a copy of the full input list.
-  /// 
+  ///
   /// Example:
   /// ```motoko include=initialize
   /// List.take<Nat>(
@@ -395,7 +395,7 @@ module {
   ///   2
   /// ); // => ?(0, ?(1, null))
   /// ```
-  /// 
+  ///
   /// | Runtime     | Space       |
   /// |-------------|-------------|
   /// | `O(n)`  | `O(n)`  |
@@ -408,7 +408,7 @@ module {
   };
 
   /// Drop the first `n` elements from the given list.
-  /// 
+  ///
   /// Example:
   /// ```motoko include=initialize
   /// List.drop<Nat>(
@@ -416,7 +416,7 @@ module {
   ///   2
   /// ); // => ?(2, null)
   /// ```
-  /// 
+  ///
   /// | Runtime     | Space       |
   /// |-------------|-------------|
   /// | `O(n)`  | `O(1)`  |
@@ -431,7 +431,7 @@ module {
   /// Collapses the elements in `list` into a single value by starting with `base`
   /// and progessively combining elements into `base` with `combine`. Iteration runs
   /// left to right.
-  /// 
+  ///
   /// Example:
   /// ```motoko include=initialize
   /// import Nat "mo:base/Nat";
@@ -441,11 +441,11 @@ module {
   ///   func (acc, x) { acc # Nat.toText(x)}
   /// ) // => "123"
   /// ```
-  /// 
+  ///
   /// | Runtime        | Space (Heap) | Space (Stack) |
   /// |----------------|--------------|----------------|
   /// | `O(size(list))`  | `O(1)`         | `O(1)`    |
-  /// 
+  ///
 
   public func foldLeft<T, S>(list : List<T>, base : S, combine : (S, T) -> S) : S {
     switch list {
@@ -457,7 +457,7 @@ module {
   /// Collapses the elements in `buffer` into a single value by starting with `base`
   /// and progessively combining elements into `base` with `combine`. Iteration runs
   /// right to left.
-  /// 
+  ///
   /// Example:
   /// ```motoko include=initialize
   /// import Nat "mo:base/Nat";
@@ -467,11 +467,11 @@ module {
   ///   func (x, acc) { Nat.toText(x) # acc}
   /// ) // => "123"
   /// ```
-  /// 
+  ///
   /// | Runtime       | Space (Heap) | Space (Stack)     |
   /// |---------------|--------------|-------------------|
   /// | `O(size(list))` | `O(1)`         | `O(size(list))`  |
-  /// 
+  ///
   public func foldRight<T, S>(list : List<T>, base : S, combine : (T, S) -> S) : S {
     switch list {
       case null { base };
@@ -481,7 +481,7 @@ module {
 
   /// Return the first element for which the given predicate `f` is true,
   /// if such an element exists.
-  /// 
+  ///
   /// Example:
   /// ```motoko include=initialize
   /// List.find<Nat>(
@@ -489,11 +489,11 @@ module {
   ///   func n { n > 1 }
   /// ); // => ?2
   /// ```
-  /// 
+  ///
   /// | Runtime   | Space     |
   /// |-----------|-----------|
   /// | `O(size)` | `O(1)` |
-  /// 
+  ///
 
   public func find<T>(l : List<T>, f : T -> Bool) : ?T {
     switch l {
@@ -504,7 +504,7 @@ module {
 
   /// Return true if there exists a list element for which
   /// the given predicate `f` is true.
-  /// 
+  ///
   /// Example:
   /// ```motoko include=initialize
   /// List.some<Nat>(
@@ -512,11 +512,11 @@ module {
   ///   func n { n > 1 }
   /// ) // => true
   /// ```
-  /// 
+  ///
   /// | Runtime   | Space     |
   /// |-----------|-----------|
   /// | `O(size)` | `O(1)` |
-  /// 
+  ///
 
   public func some<T>(l : List<T>, f : T -> Bool) : Bool {
     switch l {
@@ -527,7 +527,7 @@ module {
 
   /// Return true if the given predicate `f` is true for all list
   /// elements.
-  /// 
+  ///
   /// Example:
   /// ```motoko include=initialize
   /// List.all<Nat>(
@@ -535,11 +535,11 @@ module {
   ///   func n { n > 1 }
   /// ); // => false
   /// ```
-  /// 
+  ///
   /// | Runtime   | Space     |
   /// |-----------|-----------|
   /// | `O(size)` | `O(1)` |
-  /// 
+  ///
 
   public func all<T>(l : List<T>, f : T -> Bool) : Bool {
     switch l {
@@ -551,7 +551,7 @@ module {
   /// Merge two ordered lists into a single ordered list.
   /// This function requires both list to be ordered as specified
   /// by the given relation `lessThanOrEqual`.
-  /// 
+  ///
   /// Example:
   /// ```motoko include=initialize
   /// List.merge<Nat>(
@@ -560,11 +560,11 @@ module {
   ///   func (n1, n2) { n1 <= n2 }
   /// ); // => ?(1, ?(2, ?(2, ?(4, ?(4, ?(6, null))))))),
   /// ```
-  /// 
+  ///
   /// | Runtime                    | Space                  |
   /// |----------------------------|------------------------|
   /// | `O(size(l1) + size(l2))`     | `O(size(l1) + size(l2))` |
-  /// 
+  ///
 
   // TODO: replace by merge taking a compare : (T, T) -> Order.Order function?
   public func merge<T>(l1 : List<T>, l2 : List<T>, lessThanOrEqual : (T, T) -> Bool) : List<T> {
@@ -596,22 +596,22 @@ module {
   };
 
   /// Compare two lists using lexicographic ordering specified by argument function `compare`.
-  /// 
+  ///
   /// Example:
   /// ```motoko include=initialize
   /// import Nat "mo:base/Nat";
-  /// 
+  ///
   /// List.compare<Nat>(
   ///   ?(1, ?(2, null)),
   ///   ?(3, ?(4, null)),
   ///   Nat.compare
   /// ) // => #less
   /// ```
-  /// 
+  ///
   /// | Runtime                    | Space                  |
   /// |----------------------------|------------------------|
   /// | `O(size(l1))`     | `O(1)` |
-  /// 
+  ///
 
   public func compare<T>(l1 : List<T>, l2 : List<T>, compare : (T, T) -> Order.Order) : Order.Order {
     compareAux<T>(l1, l2, compare)
@@ -627,29 +627,29 @@ module {
     }
   };
   /// Compare two lists for equality using the argument function `equal` to determine equality of their elements.
-  /// 
+  ///
   /// Example:
   /// ```motoko include=initialize
   /// import Nat "mo:base/Nat";
-  /// 
+  ///
   /// List.equal<Nat>(
   ///   ?(1, ?(2, null)),
   ///   ?(3, ?(4, null)),
   ///   Nat.equal
   /// ); // => false
   /// ```
-  /// 
+  ///
   /// | Runtime                    | Space                  |
   /// |----------------------------|------------------------|
   /// | `O(size(l1))`     | `O(1)` |
-  /// 
+  ///
   public func equal<T>(l1 : List<T>, l2 : List<T>, equal : (T, T) -> Bool) : Bool {
     equalAux<T>(l1, l2, equal)
   };
 
   /// Generate a list based on a length and a function that maps from
   /// a list index to a list element.
-  /// 
+  ///
   /// Example:
   /// ```motoko include=initialize
   /// List.tabulate<Nat>(
@@ -657,11 +657,11 @@ module {
   ///   func n { n * 2 }
   /// ) // => ?(0, ?(2, (?4, null)))
   /// ```
-  /// 
+  ///
   /// | Runtime                    | Space                  |
   /// |----------------------------|------------------------|
   /// | `O(n)`     | `O(n)` |
-  /// 
+  ///
 
   public func tabulate<T>(n : Nat, f : Nat -> T) : List<T> {
     var i = 0;
@@ -674,21 +674,21 @@ module {
   };
 
   /// Create a list with exactly one element.
-  /// 
+  ///
   /// Example:
   /// ```motoko include=initialize
   /// List.make<Nat>(
   ///   0
   /// ) // => ?(0, null)
   /// ```
-  /// 
+  ///
   /// | Runtime   | Space     |
   /// |-----------|-----------|
   /// | `O(1)` | `O(1)` |
   public func make<T>(x : T) : List<T> = ?(x, null);
 
   /// Create a list of the given length with the same value in each position.
-  /// 
+  ///
   /// Example:
   /// ```motoko include=initialize
   /// List.replicate<Nat>(
@@ -696,7 +696,7 @@ module {
   ///   0
   /// ) // => ?(0, ?(0, ?(0, null)))
   /// ```
-  /// 
+  ///
   /// | Runtime                    | Space                  |
   /// |----------------------------|------------------------|
   /// | `O(n)`     | `O(n)` |
@@ -711,10 +711,10 @@ module {
   };
 
   /// Create a list of pairs from a pair of lists.
-  /// 
+  ///
   /// If the given lists have different lengths, then the created list will have a
   /// length equal to the length of the smaller list.
-  /// 
+  ///
   /// Example:
   /// ```motoko include=initialize
   /// List.zip<Nat, Text>(
@@ -722,7 +722,7 @@ module {
   ///   ?("0", ?("1", null)),
   /// ) // => ?((0, "0"), ?((1, "1"), null))
   /// ```
-  /// 
+  ///
   /// | Runtime                    | Space                  |
   /// |----------------------------|------------------------|
   /// | `O(min(size(xs), size(ys)))`     | `O(min(size(xs), size(ys)))` |
@@ -730,26 +730,26 @@ module {
 
   /// Create a list in which elements are created by applying function `f` to each pair `(x, y)` of elements
   /// occuring at the same position in list `xs` and list `ys`.
-  /// 
+  ///
   /// If the given lists have different lengths, then the created list will have a
   /// length equal to the length of the smaller list.
-  /// 
+  ///
   /// Example:
   /// ```motoko include=initialize
   /// import Nat = "mo:base/Nat";
   /// import Char = "mo:base/Char";
-  /// 
+  ///
   /// List.zipWith<Nat, Char, Text>(
   ///   ?(0, ?(1, ?(2, null))),
   ///   ?('a', ?('b', null)),
   ///   func (n, c) { Nat.toText(n) # Char.toText(c) }
   /// ) // => ?("0a", ?("1b", null))
   /// ```
-  /// 
+  ///
   /// | Runtime                    | Space                  |
   /// |----------------------------|------------------------|
   /// | `O(min(size(xs), size(ys)))`     | `O(min(size(xs), size(ys)))` |
-  /// 
+  ///
 
   public func zipWith<T, U, V>(
     xs : List<T>,
@@ -770,7 +770,7 @@ module {
   };
 
   /// Split the given list at the given zero-based index.
-  /// 
+  ///
   /// Example:
   /// ```motoko include=initialize
   /// List.split<Nat>(
@@ -778,7 +778,7 @@ module {
   ///   ?(0, ?(1, ?(2, null)))
   /// ) // => (?(0, ?(1, null)), ?(2, null))
   /// ```
-  /// 
+  ///
   /// | Runtime     | Space       |
   /// |-------------|-------------|
   /// | `O(n)`  | `O(n)`  |
@@ -802,7 +802,7 @@ module {
   /// Split the given list into chunks of length `n`.
   /// The last chunk will be shorter if the length of the given list
   /// does not divide by `n` evenly.
-  /// 
+  ///
   /// Example:
   /// ```motoko include=initialize
   /// List.chunks<Nat>(
@@ -815,7 +815,7 @@ module {
   ///             null)))
   /// */
   /// ```
-  /// 
+  ///
   /// | Runtime   | Space     |
   /// |-----------|-----------|
   /// | `O(size)` | `O(size)` |
@@ -829,13 +829,13 @@ module {
   };
 
   /// Convert an array into a list.
-  /// 
+  ///
   /// Example:
   /// ```motoko include=initialize
   /// List.fromArray<Nat>([ 0, 1, 2, 3, 4])
   /// // =>  ?(0, ?(1, ?(2, ?(3, ?(4, null)))))
   /// ```
-  /// 
+  ///
   /// | Runtime   | Space     |
   /// |-----------|-----------|
   /// | `O(size)` | `O(size)` |
@@ -850,13 +850,13 @@ module {
   };
 
   /// Convert a mutable array into a list.
-  /// 
+  ///
   /// Example:
   /// ```motoko include=initialize
   /// List.fromVarArray<Nat>([var 0, 1, 2, 3, 4])
   /// // =>  ?(0, ?(1, ?(2, ?(3, ?(4, null)))))
   /// ```
-  /// 
+  ///
   /// | Runtime   | Space     |
   /// |-----------|-----------|
   /// | `O(size)` | `O(size)` |
@@ -868,7 +868,7 @@ module {
   /// List.toArray<Nat>(?(0, ?(1, ?(2, ?(3, ?(4, null))))))
   /// // => [0, 1, 2, 3, 4]
   /// ```
-  /// 
+  ///
   /// | Runtime   | Space     |
   /// |-----------|-----------|
   /// | `O(size)` | `O(size)` |
@@ -894,7 +894,7 @@ module {
   /// List.toVarArray<Nat>(?(0, ?(1, ?(2, ?(3, ?(4, null))))))
   /// // => [var 0, 1, 2, 3, 4]
   /// ```
-  /// 
+  ///
   /// | Runtime   | Space     |
   /// |-----------|-----------|
   /// | `O(size)` | `O(size)` |
@@ -910,7 +910,7 @@ module {
   /// sum
   /// // => 10
   /// ```
-  /// 
+  ///
   /// | Runtime   | Space     |
   /// |-----------|-----------|
   /// | `O(1)` | `O(1)` |

--- a/src/Nat.mo
+++ b/src/Nat.mo
@@ -1,17 +1,17 @@
 /// Natural numbers with infinite precision.
-/// 
+///
 /// :::note
 /// Most operations on integer numbers (e.g. addition) are available as built-in operators (e.g. `1 + 1`).
 /// This module provides equivalent functions and `Text` conversion.
 /// :::
-/// 
+///
 /// :::info Function form for higher-order use
-/// 
+///
 /// Several arithmetic and comparison functions (e.g. `add`, `sub`, `equal`, `less`, `pow`) are defined in this module to enable their use as first-class function values, which is not possible with operators like `+`, `-`, `==`, etc., in Motoko. This allows you to pass these operations to higher-order functions such as `map`, `foldLeft`, or `sort`.
 /// :::
-/// 
+///
 /// Import from the base library to use this module.
-/// 
+///
 /// ```motoko name=import
 /// import Nat "mo:base/Nat";
 /// ```
@@ -28,7 +28,7 @@ module {
 
   /// Converts a natural number to its textual representation. Textual
   /// representation _does not_ contain underscores to represent commas.
-  /// 
+  ///
   /// Example:
   /// ```motoko include=import
   /// Nat.toText 1234 // => "1234"
@@ -37,7 +37,7 @@ module {
 
   /// Creates a natural number from its textual representation. Returns `null`
   /// if the input is not a valid natural number.
-  /// 
+  ///
   /// :::note
   /// The textual representation _must not_ contain underscores.
   /// :::
@@ -62,7 +62,7 @@ module {
   };
 
   /// Returns the minimum of `x` and `y`.
-  /// 
+  ///
   /// Example:
   /// ```motoko include=import
   /// Nat.min(1, 2) // => 1
@@ -72,7 +72,7 @@ module {
   };
 
   /// Returns the maximum of `x` and `y`.
-  /// 
+  ///
   /// Example:
   /// ```motoko include=import
   /// Nat.max(1, 2) // => 2
@@ -83,19 +83,19 @@ module {
 
   /// Equality function for Nat types.
   /// This is equivalent to `x == y`.
-  /// 
+  ///
   /// Example:
   /// ```motoko include=import
   /// ignore Nat.equal(1, 1); // => true
   /// 1 == 1 // => true
   /// ```
-  /// 
+  ///
 
-  /// 
+  ///
   /// Example:
   /// ```motoko include=import
   /// import Buffer "mo:base/Buffer";
-  /// 
+  ///
   /// let buffer1 = Buffer.Buffer<Nat>(3);
   /// let buffer2 = Buffer.Buffer<Nat>(3);
   /// Buffer.equal(buffer1, buffer2, Nat.equal) // => true
@@ -104,74 +104,74 @@ module {
 
   /// Inequality function for Nat types.
   /// This is equivalent to `x != y`.
-  /// 
+  ///
   /// Example:
   /// ```motoko include=import
   /// ignore Nat.notEqual(1, 2); // => true
   /// 1 != 2 // => true
   /// ```
-  /// 
+  ///
 
   public func notEqual(x : Nat, y : Nat) : Bool { x != y };
 
   /// "Less than" function for Nat types.
   /// This is equivalent to `x < y`.
-  /// 
+  ///
   /// Example:
   /// ```motoko include=import
   /// ignore Nat.less(1, 2); // => true
   /// 1 < 2 // => true
   /// ```
-  /// 
+  ///
 
   public func less(x : Nat, y : Nat) : Bool { x < y };
 
   /// "Less than or equal" function for Nat types.
   /// This is equivalent to `x <= y`.
-  /// 
+  ///
   /// Example:
   /// ```motoko include=import
   /// ignore Nat.lessOrEqual(1, 2); // => true
   /// 1 <= 2 // => true
   /// ```
-  /// 
+  ///
 
   public func lessOrEqual(x : Nat, y : Nat) : Bool { x <= y };
 
   /// "Greater than" function for Nat types.
   /// This is equivalent to `x > y`.
-  /// 
+  ///
   /// Example:
   /// ```motoko include=import
   /// ignore Nat.greater(2, 1); // => true
   /// 2 > 1 // => true
   /// ```
-  /// 
+  ///
 
   public func greater(x : Nat, y : Nat) : Bool { x > y };
 
   /// "Greater than or equal" function for Nat types.
   /// This is equivalent to `x >= y`.
-  /// 
+  ///
   /// Example:
   /// ```motoko include=import
   /// ignore Nat.greaterOrEqual(2, 1); // => true
   /// 2 >= 1 // => true
   /// ```
-  /// 
+  ///
 
   public func greaterOrEqual(x : Nat, y : Nat) : Bool { x >= y };
 
   /// General purpose comparison function for `Nat`. Returns the `Order` (
   /// either `#less`, `#equal`, or `#greater`) of comparing `x` with `y`.
-  /// 
+  ///
   /// Example:
   /// ```motoko include=import
   /// Nat.compare(2, 3) // => #less
   /// ```
-  /// 
+  ///
   /// This function can be used as value for a high order function, such as a sort function.
-  /// 
+  ///
   /// Example:
   /// ```motoko include=import
   /// import Array "mo:base/Array";
@@ -183,15 +183,15 @@ module {
 
   /// Returns the sum of `x` and `y`, `x + y`. This operator will never overflow
   /// because `Nat` is infinite precision.
-  /// 
+  ///
   /// Example:
   /// ```motoko include=import
   /// ignore Nat.add(1, 2); // => 3
   /// 1 + 2 // => 3
   /// ```
-  /// 
+  ///
 
-  /// 
+  ///
   /// Example:
   /// ```motoko include=import
   /// import Array "mo:base/Array";
@@ -201,16 +201,16 @@ module {
 
   /// Returns the difference of `x` and `y`, `x - y`.
   /// Traps on underflow below `0`.
-  /// 
+  ///
   /// Example:
   /// ```motoko include=import
   /// ignore Nat.sub(2, 1); // => 1
   /// // Add a type annotation to avoid a warning about the subtraction
   /// 2 - 1 : Nat // => 1
   /// ```
-  /// 
+  ///
 
-  /// 
+  ///
   /// Example:
   /// ```motoko include=import
   /// import Array "mo:base/Array";
@@ -220,15 +220,15 @@ module {
 
   /// Returns the product of `x` and `y`, `x * y`. This operator will never
   /// overflow because `Nat` is infinite precision.
-  /// 
+  ///
   /// Example:
   /// ```motoko include=import
   /// ignore Nat.mul(2, 3); // => 6
   /// 2 * 3 // => 6
   /// ```
-  /// 
+  ///
 
-  /// 
+  ///
   /// Example:
   /// ```motoko include=import
   /// import Array "mo:base/Array";
@@ -238,60 +238,60 @@ module {
 
   /// Returns the unsigned integer division of `x` by `y`,  `x / y`.
   /// Traps when `y` is zero.
-  /// 
+  ///
   /// The quotient is rounded down, which is equivalent to truncating the
   /// decimal places of the quotient.
-  /// 
+  ///
   /// Example:
   /// ```motoko include=import
   /// ignore Nat.div(6, 2); // => 3
   /// 6 / 2 // => 3
   /// ```
-  /// 
+  ///
 
   public func div(x : Nat, y : Nat) : Nat { x / y };
 
   /// Returns the remainder of unsigned integer division of `x` by `y`,  `x % y`.
   /// Traps when `y` is zero.
-  /// 
+  ///
   /// Example:
   /// ```motoko include=import
   /// ignore Nat.rem(6, 4); // => 2
   /// 6 % 4 // => 2
   /// ```
-  /// 
+  ///
 
   public func rem(x : Nat, y : Nat) : Nat { x % y };
 
   /// Returns `x` to the power of `y`, `x ** y`. Traps when `y > 2^32`. This operator
   /// will never overflow because `Nat` is infinite precision.
-  /// 
+  ///
   /// Example:
   /// ```motoko include=import
   /// ignore Nat.pow(2, 3); // => 8
   /// 2 ** 3 // => 8
   /// ```
-  /// 
+  ///
 
   public func pow(x : Nat, y : Nat) : Nat { x ** y };
 
   /// Returns the (conceptual) bitwise shift left of `x` by `y`, `x * (2 ** y)`.
-  /// 
+  ///
   /// Example:
   /// ```motoko include=import
   /// Nat.bitshiftLeft(1, 3); // => 8
   /// ```
-  /// 
+  ///
 
   public func bitshiftLeft(x : Nat, y : Nat32) : Nat { Prim.shiftLeft(x, y) };
 
   /// Returns the (conceptual) bitwise shift right of `x` by `y`, `x / (2 ** y)`.
-  /// 
+  ///
   /// Example:
   /// ```motoko include=import
   /// Nat.bitshiftRight(8, 3); // => 1
   /// ```
-  /// 
+  ///
 
   public func bitshiftRight(x : Nat, y : Nat32) : Nat { Prim.shiftRight(x, y) };
 

--- a/src/Nat16.mo
+++ b/src/Nat16.mo
@@ -1,17 +1,17 @@
 /// Provides utility functions on 16-bit unsigned integers.
-/// 
+///
 /// :::note
 /// Most operations on integer numbers (e.g. addition) are available as built-in operators (e.g. `1 + 1`).
 /// This module provides equivalent functions and `Text` conversion.
 /// :::
-/// 
+///
 /// :::info Function form for higher-order use
-/// 
+///
 /// Several arithmetic and comparison functions (e.g. `add`, `sub`, `equal`, `less`, `pow`) are defined in this module to enable their use as first-class function values, which is not possible with operators like `+`, `-`, `==`, etc., in Motoko. This allows you to pass these operations to higher-order functions such as `map`, `foldLeft`, or `sort`.
 /// :::
-/// 
+///
 /// Import from the base library to use this module.
-/// 
+///
 /// ```motoko name=import
 /// import Nat16 "mo:base/Nat16";
 /// ```
@@ -24,7 +24,7 @@ module {
   public type Nat16 = Prim.Types.Nat16;
 
   /// Maximum 16-bit natural number. `2 ** 16 - 1`.
-  /// 
+  ///
   /// Example:
   /// ```motoko include=import
   /// Nat16.maximumValue; // => 65536 : Nat16
@@ -32,7 +32,7 @@ module {
   public let maximumValue = 65535 : Nat16;
 
   /// Converts a 16-bit unsigned integer to an unsigned integer with infinite precision.
-  /// 
+  ///
   /// Example:
   /// ```motoko include=import
   /// Nat16.toNat(123); // => 123 : Nat
@@ -40,9 +40,9 @@ module {
   public let toNat : Nat16 -> Nat = Prim.nat16ToNat;
 
   /// Converts an unsigned integer with infinite precision to a 16-bit unsigned integer.
-  /// 
+  ///
   /// Traps on overflow.
-  /// 
+  ///
   /// Example:
   /// ```motoko include=import
   /// Nat16.fromNat(123); // => 123 : Nat16
@@ -50,7 +50,7 @@ module {
   public let fromNat : Nat -> Nat16 = Prim.natToNat16;
 
   /// Converts an 8-bit unsigned integer to a 16-bit unsigned integer.
-  /// 
+  ///
   /// Example:
   /// ```motoko include=import
   /// Nat16.fromNat8(123); // => 123 : Nat16
@@ -60,9 +60,9 @@ module {
   };
 
   /// Converts a 16-bit unsigned integer to an 8-bit unsigned integer.
-  /// 
+  ///
   /// Traps on overflow.
-  /// 
+  ///
   /// Example:
   /// ```motoko include=import
   /// Nat16.toNat8(123); // => 123 : Nat8
@@ -72,9 +72,9 @@ module {
   };
 
   /// Converts a 32-bit unsigned integer to a 16-bit unsigned integer.
-  /// 
+  ///
   /// Traps on overflow.
-  /// 
+  ///
   /// Example:
   /// ```motoko include=import
   /// Nat16.fromNat32(123); // => 123 : Nat16
@@ -84,7 +84,7 @@ module {
   };
 
   /// Converts a 16-bit unsigned integer to a 32-bit unsigned integer.
-  /// 
+  ///
   /// Example:
   /// ```motoko include=import
   /// Nat16.toNat32(123); // => 123 : Nat32
@@ -94,9 +94,9 @@ module {
   };
 
   /// Converts a signed integer with infinite precision to a 16-bit unsigned integer.
-  /// 
+  ///
   /// Wraps on overflow/underflow.
-  /// 
+  ///
   /// Example:
   /// ```motoko include=import
   /// Nat16.fromIntWrap(123 : Int); // => 123 : Nat16
@@ -105,7 +105,7 @@ module {
 
   /// Converts `x` to its textual representation. Textual representation _do not_
   /// contain underscores to represent commas.
-  /// 
+  ///
   /// Example:
   /// ```motoko include=import
   /// Nat16.toText(1234); // => "1234" : Text
@@ -115,7 +115,7 @@ module {
   };
 
   /// Returns the minimum of `x` and `y`.
-  /// 
+  ///
   /// Example:
   /// ```motoko include=import
   /// Nat16.min(123, 200); // => 123 : Nat16
@@ -125,7 +125,7 @@ module {
   };
 
   /// Returns the maximum of `x` and `y`.
-  /// 
+  ///
   /// Example:
   /// ```motoko include=import
   /// Nat16.max(123, 200); // => 200 : Nat16
@@ -136,19 +136,19 @@ module {
 
   /// Equality function for Nat16 types.
   /// This is equivalent to `x == y`.
-  /// 
+  ///
   /// Example:
   /// ```motoko include=import
   /// ignore Nat16.equal(1, 1); // => true
   /// (1 : Nat16) == (1 : Nat16) // => true
   /// ```
-  /// 
+  ///
 
-  /// 
+  ///
   /// Example:
   /// ```motoko include=import
   /// import Buffer "mo:base/Buffer";
-  /// 
+  ///
   /// let buffer1 = Buffer.Buffer<Nat16>(3);
   /// let buffer2 = Buffer.Buffer<Nat16>(3);
   /// Buffer.equal(buffer1, buffer2, Nat16.equal) // => true
@@ -157,74 +157,74 @@ module {
 
   /// Inequality function for Nat16 types.
   /// This is equivalent to `x != y`.
-  /// 
+  ///
   /// Example:
   /// ```motoko include=import
   /// ignore Nat16.notEqual(1, 2); // => true
   /// (1 : Nat16) != (2 : Nat16) // => true
   /// ```
-  /// 
+  ///
 
   public func notEqual(x : Nat16, y : Nat16) : Bool { x != y };
 
   /// "Less than" function for Nat16 types.
   /// This is equivalent to `x < y`.
-  /// 
+  ///
   /// Example:
   /// ```motoko include=import
   /// ignore Nat16.less(1, 2); // => true
   /// (1 : Nat16) < (2 : Nat16) // => true
   /// ```
-  /// 
+  ///
 
   public func less(x : Nat16, y : Nat16) : Bool { x < y };
 
   /// "Less than or equal" function for Nat16 types.
   /// This is equivalent to `x <= y`.
-  /// 
+  ///
   /// Example:
   /// ```motoko include=import
   /// ignore Nat16.lessOrEqual(1, 2); // => true
   /// (1 : Nat16) <= (2 : Nat16) // => true
   /// ```
-  /// 
+  ///
 
   public func lessOrEqual(x : Nat16, y : Nat16) : Bool { x <= y };
 
   /// "Greater than" function for Nat16 types.
   /// This is equivalent to `x > y`.
-  /// 
+  ///
   /// Example:
   /// ```motoko include=import
   /// ignore Nat16.greater(2, 1); // => true
   /// (2 : Nat16) > (1 : Nat16) // => true
   /// ```
-  /// 
+  ///
 
   public func greater(x : Nat16, y : Nat16) : Bool { x > y };
 
   /// "Greater than or equal" function for Nat16 types.
   /// This is equivalent to `x >= y`.
-  /// 
+  ///
   /// Example:
   /// ```motoko include=import
   /// ignore Nat16.greaterOrEqual(2, 1); // => true
   /// (2 : Nat16) >= (1 : Nat16) // => true
   /// ```
-  /// 
+  ///
 
   public func greaterOrEqual(x : Nat16, y : Nat16) : Bool { x >= y };
 
   /// General purpose comparison function for `Nat16`. Returns the `Order` (
   /// either `#less`, `#equal`, or `#greater`) of comparing `x` with `y`.
-  /// 
+  ///
   /// Example:
   /// ```motoko include=import
   /// Nat16.compare(2, 3) // => #less
   /// ```
-  /// 
+  ///
   /// This function can be used as value for a high order function, such as a sort function.
-  /// 
+  ///
   /// Example:
   /// ```motoko include=import
   /// import Array "mo:base/Array";
@@ -236,15 +236,15 @@ module {
 
   /// Returns the sum of `x` and `y`, `x + y`.
   /// Traps on overflow.
-  /// 
+  ///
   /// Example:
   /// ```motoko include=import
   /// ignore Nat16.add(1, 2); // => 3
   /// (1 : Nat16) + (2 : Nat16) // => 3
   /// ```
-  /// 
+  ///
 
-  /// 
+  ///
   /// Example:
   /// ```motoko include=import
   /// import Array "mo:base/Array";
@@ -254,15 +254,15 @@ module {
 
   /// Returns the difference of `x` and `y`, `x - y`.
   /// Traps on underflow.
-  /// 
+  ///
   /// Example:
   /// ```motoko include=import
   /// ignore Nat16.sub(2, 1); // => 1
   /// (2 : Nat16) - (1 : Nat16) // => 1
   /// ```
-  /// 
+  ///
 
-  /// 
+  ///
   /// Example:
   /// ```motoko include=import
   /// import Array "mo:base/Array";
@@ -272,15 +272,15 @@ module {
 
   /// Returns the product of `x` and `y`, `x * y`.
   /// Traps on overflow.
-  /// 
+  ///
   /// Example:
   /// ```motoko include=import
   /// ignore Nat16.mul(2, 3); // => 6
   /// (2 : Nat16) * (3 : Nat16) // => 6
   /// ```
-  /// 
+  ///
 
-  /// 
+  ///
   /// Example:
   /// ```motoko include=import
   /// import Array "mo:base/Array";
@@ -290,64 +290,64 @@ module {
 
   /// Returns the quotient of `x` divided by `y`, `x / y`.
   /// Traps when `y` is zero.
-  /// 
+  ///
   /// Example:
   /// ```motoko include=import
   /// ignore Nat16.div(6, 2); // => 3
   /// (6 : Nat16) / (2 : Nat16) // => 3
   /// ```
-  /// 
+  ///
 
   public func div(x : Nat16, y : Nat16) : Nat16 { x / y };
 
   /// Returns the remainder of `x` divided by `y`, `x % y`.
   /// Traps when `y` is zero.
-  /// 
+  ///
   /// Example:
   /// ```motoko include=import
   /// ignore Nat16.rem(6, 4); // => 2
   /// (6 : Nat16) % (4 : Nat16) // => 2
   /// ```
-  /// 
+  ///
 
   public func rem(x : Nat16, y : Nat16) : Nat16 { x % y };
 
   /// Returns the power of `x` to `y`, `x ** y`.
   /// Traps on overflow.
-  /// 
+  ///
   /// Example:
   /// ```motoko include=import
   /// ignore Nat16.pow(2, 3); // => 8
   /// (2 : Nat16) ** (3 : Nat16) // => 8
   /// ```
-  /// 
+  ///
 
   public func pow(x : Nat16, y : Nat16) : Nat16 { x ** y };
 
   /// Returns the bitwise negation of `x`, `^x`.
-  /// 
+  ///
   /// Example:
   /// ```motoko include=import
   /// ignore Nat16.bitnot(0); // => 65535
   /// ^(0 : Nat16) // => 65535
   /// ```
-  /// 
+  ///
 
   public func bitnot(x : Nat16) : Nat16 { ^x };
 
   /// Returns the bitwise and of `x` and `y`, `x & y`.
-  /// 
+  ///
   /// Example:
   /// ```motoko include=import
   /// ignore Nat16.bitand(0, 1); // => 0
   /// (0 : Nat16) & (1 : Nat16) // => 0
   /// ```
-  /// 
+  ///
 
   public func bitand(x : Nat16, y : Nat16) : Nat16 { x & y };
 
   /// Returns the bitwise or of `x` and `y`, `x | y`.
-  /// 
+  ///
   /// Example:
   /// ```motoko include=import
   /// ignore Nat16.bitor(0, 1); // => 1
@@ -356,7 +356,7 @@ module {
   public func bitor(x : Nat16, y : Nat16) : Nat16 { x | y };
 
   /// Returns the bitwise exclusive or of `x` and `y`, `x ^ y`.
-  /// 
+  ///
   /// Example:
   /// ```motoko include=import
   /// ignore Nat16.bitxor(0, 1); // => 1
@@ -365,52 +365,52 @@ module {
   public func bitxor(x : Nat16, y : Nat16) : Nat16 { x ^ y };
 
   /// Returns the bitwise shift left of `x` by `y`, `x << y`.
-  /// 
+  ///
   /// Example:
   /// ```motoko include=import
   /// ignore Nat16.bitshiftLeft(1, 3); // => 8
   /// (1 : Nat16) << (3 : Nat16) // => 8
   /// ```
-  /// 
+  ///
 
   public func bitshiftLeft(x : Nat16, y : Nat16) : Nat16 { x << y };
 
   /// Returns the bitwise shift right of `x` by `y`, `x >> y`.
-  /// 
+  ///
   /// Example:
   /// ```motoko include=import
   /// ignore Nat16.bitshiftRight(8, 3); // => 1
   /// (8 : Nat16) >> (3 : Nat16) // => 1
   /// ```
-  /// 
+  ///
 
   public func bitshiftRight(x : Nat16, y : Nat16) : Nat16 { x >> y };
 
   /// Returns the bitwise rotate left of `x` by `y`, `x <<> y`.
-  /// 
+  ///
   /// Example:
   /// ```motoko include=import
   /// ignore Nat16.bitrotLeft(2, 1); // => 4
   /// (2 : Nat16) <<> (1 : Nat16) // => 4
   /// ```
-  /// 
+  ///
 
   public func bitrotLeft(x : Nat16, y : Nat16) : Nat16 { x <<> y };
 
   /// Returns the bitwise rotate right of `x` by `y`, `x <>> y`.
-  /// 
+  ///
   /// Example:
   /// ```motoko include=import
   /// ignore Nat16.bitrotRight(1, 1); // => 32768
   /// (1 : Nat16) <>> (1 : Nat16) // => 32768
   /// ```
-  /// 
+  ///
 
   public func bitrotRight(x : Nat16, y : Nat16) : Nat16 { x <>> y };
 
   /// Returns the value of bit `p mod 16` in `x`, `(x & 2^(p mod 16)) == 2^(p mod 16)`.
   /// This is equivalent to checking if the `p`-th bit is set in `x`, using 0 indexing.
-  /// 
+  ///
   /// Example:
   /// ```motoko include=import
   /// Nat16.bittest(5, 2); // => true
@@ -420,7 +420,7 @@ module {
   };
 
   /// Returns the value of setting bit `p mod 16` in `x` to `1`.
-  /// 
+  ///
   /// Example:
   /// ```motoko include=import
   /// Nat16.bitset(0, 2); // => 4
@@ -430,7 +430,7 @@ module {
   };
 
   /// Returns the value of clearing bit `p mod 16` in `x` to `0`.
-  /// 
+  ///
   /// Example:
   /// ```motoko include=import
   /// Nat16.bitclear(5, 2); // => 1
@@ -440,7 +440,7 @@ module {
   };
 
   /// Returns the value of flipping bit `p mod 16` in `x`.
-  /// 
+  ///
   /// Example:
   /// ```motoko include=import
   /// Nat16.bitflip(5, 2); // => 1
@@ -450,7 +450,7 @@ module {
   };
 
   /// Returns the count of non-zero bits in `x`.
-  /// 
+  ///
   /// Example:
   /// ```motoko include=import
   /// Nat16.bitcountNonZero(5); // => 2
@@ -458,7 +458,7 @@ module {
   public let bitcountNonZero : (x : Nat16) -> Nat16 = Prim.popcntNat16;
 
   /// Returns the count of leading zero bits in `x`.
-  /// 
+  ///
   /// Example:
   /// ```motoko include=import
   /// Nat16.bitcountLeadingZero(5); // => 13
@@ -466,7 +466,7 @@ module {
   public let bitcountLeadingZero : (x : Nat16) -> Nat16 = Prim.clzNat16;
 
   /// Returns the count of trailing zero bits in `x`.
-  /// 
+  ///
   /// Example:
   /// ```motoko include=import
   /// Nat16.bitcountTrailingZero(5); // => 0
@@ -489,7 +489,7 @@ module {
   /// (65532 : Nat16) +% (5 : Nat16) // => 1
   /// ```
   ///
-  /// :::info 
+  /// :::info
   /// The reason why this function is defined in this library (in addition
   /// to the existing `+%` operator) is so that you can use it as a function
   /// value to pass to a higher order function. It is not possible to use `+%`
@@ -498,35 +498,35 @@ module {
   public func addWrap(x : Nat16, y : Nat16) : Nat16 { x +% y };
 
   /// Returns the difference of `x` and `y`, `x -% y`. Wraps on underflow.
-  /// 
+  ///
   /// Example:
   /// ```motoko include=import
   /// ignore Nat16.subWrap(1, 2); // => 65535
   /// (1 : Nat16) -% (2 : Nat16) // => 65535
   /// ```
-  /// 
+  ///
 
   public func subWrap(x : Nat16, y : Nat16) : Nat16 { x -% y };
 
   /// Returns the product of `x` and `y`, `x *% y`. Wraps on overflow.
-  /// 
+  ///
   /// Example:
   /// ```motoko include=import
   /// ignore Nat16.mulWrap(655, 101); // => 619
   /// (655 : Nat16) *% (101 : Nat16) // => 619
   /// ```
-  /// 
+  ///
 
   public func mulWrap(x : Nat16, y : Nat16) : Nat16 { x *% y };
 
   /// Returns `x` to the power of `y`, `x **% y`. Wraps on overflow.
-  /// 
+  ///
   /// Example:
   /// ```motoko include=import
   /// ignore Nat16.powWrap(2, 16); // => 0
   /// (2 : Nat16) **% (16 : Nat16) // => 0
   /// ```
-  /// 
+  ///
 
   public func powWrap(x : Nat16, y : Nat16) : Nat16 { x **% y };
 

--- a/src/Nat64.mo
+++ b/src/Nat64.mo
@@ -1,21 +1,21 @@
 /// Provides utility functions on 64-bit unsigned integers.
-/// 
+///
 /// :::note
 /// Most operations on integer numbers (e.g. addition) are available as built-in operators (e.g. `1 + 1`).
 /// This module provides equivalent functions and `Text` conversion.
 /// :::
-/// 
+///
 /// :::info Function form for higher-order use
-/// 
+///
 /// Several arithmetic and comparison functions (e.g. `add`, `sub`, `equal`, `less`, `pow`) are defined in this module to enable their use as first-class function values, which is not possible with operators like `+`, `-`, `==`, etc., in Motoko. This allows you to pass these operations to higher-order functions such as `map`, `foldLeft`, or `sort`.
 /// :::
-/// 
+///
 /// Import from the base library to use this module.
-/// 
+///
 /// ```motoko name=import
 /// import Nat64 "mo:base/Nat64";
 /// ```
-/// 
+///
 import Nat "Nat";
 import Prim "mo:⛔";
 
@@ -25,7 +25,7 @@ module {
   public type Nat64 = Prim.Types.Nat64;
 
   /// Maximum 64-bit natural number. `2 ** 64 - 1`.
-  /// 
+  ///
   /// Example:
   /// ```motoko include=import
   /// Nat64.maximumValue; // => 18446744073709551615 : Nat64
@@ -34,7 +34,7 @@ module {
   public let maximumValue = 18446744073709551615 : Nat64;
 
   /// Converts a 64-bit unsigned integer to an unsigned integer with infinite precision.
-  /// 
+  ///
   /// Example:
   /// ```motoko include=import
   /// Nat64.toNat(123); // => 123 : Nat
@@ -42,9 +42,9 @@ module {
   public let toNat : Nat64 -> Nat = Prim.nat64ToNat;
 
   /// Converts an unsigned integer with infinite precision to a 64-bit unsigned integer.
-  /// 
+  ///
   /// Traps on overflow.
-  /// 
+  ///
   /// Example:
   /// ```motoko include=import
   /// Nat64.fromNat(123); // => 123 : Nat64
@@ -52,7 +52,7 @@ module {
   public let fromNat : Nat -> Nat64 = Prim.natToNat64;
 
   /// Converts a 32-bit unsigned integer to a 64-bit unsigned integer.
-  /// 
+  ///
   /// Example:
   /// ```motoko include=import
   /// Nat64.fromNat32(123); // => 123 : Nat64
@@ -62,9 +62,9 @@ module {
   };
 
   /// Converts a 64-bit unsigned integer to a 32-bit unsigned integer.
-  /// 
+  ///
   /// Traps on overflow.
-  /// 
+  ///
   /// Example:
   /// ```motoko include=import
   /// Nat64.toNat32(123); // => 123 : Nat32
@@ -74,9 +74,9 @@ module {
   };
 
   /// Converts a signed integer with infinite precision to a 64-bit unsigned integer.
-  /// 
+  ///
   /// Traps on overflow/underflow.
-  /// 
+  ///
   /// Example:
   /// ```motoko include=import
   /// Nat64.fromIntWrap(123); // => 123 : Nat64
@@ -85,7 +85,7 @@ module {
 
   /// Converts `x` to its textual representation. Textual representation _do not_
   /// contain underscores to represent commas.
-  /// 
+  ///
   /// Example:
   /// ```motoko include=import
   /// Nat64.toText(1234); // => "1234" : Text
@@ -95,7 +95,7 @@ module {
   };
 
   /// Returns the minimum of `x` and `y`.
-  /// 
+  ///
   /// Example:
   /// ```motoko include=import
   /// Nat64.min(123, 456); // => 123 : Nat64
@@ -105,7 +105,7 @@ module {
   };
 
   /// Returns the maximum of `x` and `y`.
-  /// 
+  ///
   /// Example:
   /// ```motoko include=import
   /// Nat64.max(123, 456); // => 456 : Nat64
@@ -116,19 +116,19 @@ module {
 
   /// Equality function for Nat64 types.
   /// This is equivalent to `x == y`.
-  /// 
+  ///
   /// Example:
   /// ```motoko include=import
   /// ignore Nat64.equal(1, 1); // => true
   /// (1 : Nat64) == (1 : Nat64) // => true
   /// ```
-  /// 
+  ///
 
-  /// 
+  ///
   /// Example:
   /// ```motoko include=import
   /// import Buffer "mo:base/Buffer";
-  /// 
+  ///
   /// let buffer1 = Buffer.Buffer<Nat64>(3);
   /// let buffer2 = Buffer.Buffer<Nat64>(3);
   /// Buffer.equal(buffer1, buffer2, Nat64.equal) // => true
@@ -137,74 +137,74 @@ module {
 
   /// Inequality function for Nat64 types.
   /// This is equivalent to `x != y`.
-  /// 
+  ///
   /// Example:
   /// ```motoko include=import
   /// ignore Nat64.notEqual(1, 2); // => true
   /// (1 : Nat64) != (2 : Nat64) // => true
   /// ```
-  /// 
+  ///
 
   public func notEqual(x : Nat64, y : Nat64) : Bool { x != y };
 
   /// "Less than" function for Nat64 types.
   /// This is equivalent to `x < y`.
-  /// 
+  ///
   /// Example:
   /// ```motoko include=import
   /// ignore Nat64.less(1, 2); // => true
   /// (1 : Nat64) < (2 : Nat64) // => true
   /// ```
-  /// 
+  ///
 
   public func less(x : Nat64, y : Nat64) : Bool { x < y };
 
   /// "Less than or equal" function for Nat64 types.
   /// This is equivalent to `x <= y`.
-  /// 
+  ///
   /// Example:
   /// ```motoko include=import
   /// ignore Nat64.lessOrEqual(1, 2); // => true
   /// (1 : Nat64) <= (2 : Nat64) // => true
   /// ```
-  /// 
+  ///
 
   public func lessOrEqual(x : Nat64, y : Nat64) : Bool { x <= y };
 
   /// "Greater than" function for Nat64 types.
   /// This is equivalent to `x > y`.
-  /// 
+  ///
   /// Example:
   /// ```motoko include=import
   /// ignore Nat64.greater(2, 1); // => true
   /// (2 : Nat64) > (1 : Nat64) // => true
   /// ```
-  /// 
+  ///
 
   public func greater(x : Nat64, y : Nat64) : Bool { x > y };
 
   /// "Greater than or equal" function for Nat64 types.
   /// This is equivalent to `x >= y`.
-  /// 
+  ///
   /// Example:
   /// ```motoko include=import
   /// ignore Nat64.greaterOrEqual(2, 1); // => true
   /// (2 : Nat64) >= (1 : Nat64) // => true
   /// ```
-  /// 
+  ///
 
   public func greaterOrEqual(x : Nat64, y : Nat64) : Bool { x >= y };
 
   /// General purpose comparison function for `Nat64`. Returns the `Order` (
   /// either `#less`, `#equal`, or `#greater`) of comparing `x` with `y`.
-  /// 
+  ///
   /// Example:
   /// ```motoko include=import
   /// Nat64.compare(2, 3) // => #less
   /// ```
-  /// 
+  ///
   /// This function can be used as value for a high order function, such as a sort function.
-  /// 
+  ///
   /// Example:
   /// ```motoko include=import
   /// import Array "mo:base/Array";
@@ -216,15 +216,15 @@ module {
 
   /// Returns the sum of `x` and `y`, `x + y`.
   /// Traps on overflow.
-  /// 
+  ///
   /// Example:
   /// ```motoko include=import
   /// ignore Nat64.add(1, 2); // => 3
   /// (1 : Nat64) + (2 : Nat64) // => 3
   /// ```
-  /// 
+  ///
 
-  /// 
+  ///
   /// Example:
   /// ```motoko include=import
   /// import Array "mo:base/Array";
@@ -234,15 +234,15 @@ module {
 
   /// Returns the difference of `x` and `y`, `x - y`.
   /// Traps on underflow.
-  /// 
+  ///
   /// Example:
   /// ```motoko include=import
   /// ignore Nat64.sub(3, 1); // => 2
   /// (3 : Nat64) - (1 : Nat64) // => 2
   /// ```
-  /// 
+  ///
 
-  /// 
+  ///
   /// Example:
   /// ```motoko include=import
   /// import Array "mo:base/Array";
@@ -252,15 +252,15 @@ module {
 
   /// Returns the product of `x` and `y`, `x * y`.
   /// Traps on overflow.
-  /// 
+  ///
   /// Example:
   /// ```motoko include=import
   /// ignore Nat64.mul(2, 3); // => 6
   /// (2 : Nat64) * (3 : Nat64) // => 6
   /// ```
-  /// 
+  ///
 
-  /// 
+  ///
   /// Example:
   /// ```motoko include=import
   /// import Array "mo:base/Array";
@@ -270,130 +270,130 @@ module {
 
   /// Returns the quotient of `x` divided by `y`, `x / y`.
   /// Traps when `y` is zero.
-  /// 
+  ///
   /// Example:
   /// ```motoko include=import
   /// ignore Nat64.div(6, 2); // => 3
   /// (6 : Nat64) / (2 : Nat64) // => 3
   /// ```
-  /// 
+  ///
 
   public func div(x : Nat64, y : Nat64) : Nat64 { x / y };
 
   /// Returns the remainder of `x` divided by `y`, `x % y`.
   /// Traps when `y` is zero.
-  /// 
+  ///
   /// Example:
   /// ```motoko include=import
   /// ignore Nat64.rem(6, 4); // => 2
   /// (6 : Nat64) % (4 : Nat64) // => 2
   /// ```
-  /// 
+  ///
 
   public func rem(x : Nat64, y : Nat64) : Nat64 { x % y };
 
   /// Returns `x` to the power of `y`, `x ** y`. Traps on overflow.
-  /// 
+  ///
   /// Example:
   /// ```motoko include=import
   /// ignore Nat64.pow(2, 3); // => 8
   /// (2 : Nat64) ** (3 : Nat64) // => 8
   /// ```
-  /// 
+  ///
 
   public func pow(x : Nat64, y : Nat64) : Nat64 { x ** y };
 
   /// Returns the bitwise negation of `x`, `^x`.
-  /// 
+  ///
   /// Example:
   /// ```motoko include=import
   /// ignore Nat64.bitnot(0); // => 18446744073709551615
   /// ^(0 : Nat64) // => 18446744073709551615
   /// ```
-  /// 
+  ///
 
   public func bitnot(x : Nat64) : Nat64 { ^x };
 
   /// Returns the bitwise and of `x` and `y`, `x & y`.
-  /// 
+  ///
   /// Example:
   /// ```motoko include=import
   /// ignore Nat64.bitand(1, 3); // => 1
   /// (1 : Nat64) & (3 : Nat64) // => 1
   /// ```
-  /// 
+  ///
 
   public func bitand(x : Nat64, y : Nat64) : Nat64 { x & y };
 
   /// Returns the bitwise or of `x` and `y`, `x | y`.
-  /// 
+  ///
   /// Example:
   /// ```motoko include=import
   /// ignore Nat64.bitor(1, 3); // => 3
   /// (1 : Nat64) | (3 : Nat64) // => 3
   /// ```
-  /// 
+  ///
 
   public func bitor(x : Nat64, y : Nat64) : Nat64 { x | y };
 
   /// Returns the bitwise exclusive or of `x` and `y`, `x ^ y`.
-  /// 
+  ///
   /// Example:
   /// ```motoko include=import
   /// ignore Nat64.bitxor(1, 3); // => 2
   /// (1 : Nat64) ^ (3 : Nat64) // => 2
   /// ```
-  /// 
+  ///
 
   public func bitxor(x : Nat64, y : Nat64) : Nat64 { x ^ y };
 
   /// Returns the bitwise shift left of `x` by `y`, `x << y`.
-  /// 
+  ///
   /// Example:
   /// ```motoko include=import
   /// ignore Nat64.bitshiftLeft(1, 3); // => 8
   /// (1 : Nat64) << (3 : Nat64) // => 8
   /// ```
-  /// 
+  ///
 
   public func bitshiftLeft(x : Nat64, y : Nat64) : Nat64 { x << y };
 
   /// Returns the bitwise shift right of `x` by `y`, `x >> y`.
-  /// 
+  ///
   /// Example:
   /// ```motoko include=import
   /// ignore Nat64.bitshiftRight(8, 3); // => 1
   /// (8 : Nat64) >> (3 : Nat64) // => 1
   /// ```
-  /// 
+  ///
 
   public func bitshiftRight(x : Nat64, y : Nat64) : Nat64 { x >> y };
 
   /// Returns the bitwise rotate left of `x` by `y`, `x <<> y`.
-  /// 
+  ///
   /// Example:
   /// ```motoko include=import
   /// ignore Nat64.bitrotLeft(1, 3); // => 8
   /// (1 : Nat64) <<> (3 : Nat64) // => 8
   /// ```
-  /// 
+  ///
 
   public func bitrotLeft(x : Nat64, y : Nat64) : Nat64 { x <<> y };
 
   /// Returns the bitwise rotate right of `x` by `y`, `x <>> y`.
-  /// 
+  ///
   /// Example:
   /// ```motoko include=import
   /// ignore Nat64.bitrotRight(8, 3); // => 1
   /// (8 : Nat64) <>> (3 : Nat64) // => 1
   /// ```
-  /// 
+  ///
 
   public func bitrotRight(x : Nat64, y : Nat64) : Nat64 { x <>> y };
 
   /// Returns the value of bit `p mod 64` in `x`, `(x & 2^(p mod 64)) == 2^(p mod 64)`.
   /// This is equivalent to checking if the `p`-th bit is set in `x`, using 0 indexing.
-  /// 
+  ///
   /// Example:
   /// ```motoko include=import
   /// Nat64.bittest(5, 2); // => true
@@ -403,7 +403,7 @@ module {
   };
 
   /// Returns the value of setting bit `p mod 64` in `x` to `1`.
-  /// 
+  ///
   /// Example:
   /// ```motoko include=import
   /// Nat64.bitset(5, 1); // => 7
@@ -413,7 +413,7 @@ module {
   };
 
   /// Returns the value of clearing bit `p mod 64` in `x` to `0`.
-  /// 
+  ///
   /// Example:
   /// ```motoko include=import
   /// Nat64.bitclear(5, 2); // => 1
@@ -423,7 +423,7 @@ module {
   };
 
   /// Returns the value of flipping bit `p mod 64` in `x`.
-  /// 
+  ///
   /// Example:
   /// ```motoko include=import
   /// Nat64.bitflip(5, 2); // => 1
@@ -433,7 +433,7 @@ module {
   };
 
   /// Returns the count of non-zero bits in `x`.
-  /// 
+  ///
   /// Example:
   /// ```motoko include=import
   /// Nat64.bitcountNonZero(5); // => 2
@@ -441,7 +441,7 @@ module {
   public let bitcountNonZero : (x : Nat64) -> Nat64 = Prim.popcntNat64;
 
   /// Returns the count of leading zero bits in `x`.
-  /// 
+  ///
   /// Example:
   /// ```motoko include=import
   /// Nat64.bitcountLeadingZero(5); // => 61
@@ -449,7 +449,7 @@ module {
   public let bitcountLeadingZero : (x : Nat64) -> Nat64 = Prim.clzNat64;
 
   /// Returns the count of trailing zero bits in `x`.
-  /// 
+  ///
   /// Example:
   /// ```motoko include=import
   /// Nat64.bitcountTrailingZero(16); // => 4
@@ -473,7 +473,7 @@ module {
   /// Nat64.maximumValue +% (1 : Nat64) // => 0
   /// ```
   ///
-  /// :::info 
+  /// :::info
   /// The reason why this function is defined in this library (in addition
   /// to the existing `+%` operator) is so that you can use it as a function
   /// value to pass to a higher order function. It is not possible to use `+%`
@@ -482,35 +482,35 @@ module {
   public func addWrap(x : Nat64, y : Nat64) : Nat64 { x +% y };
 
   /// Returns the difference of `x` and `y`, `x -% y`. Wraps on underflow.
-  /// 
+  ///
   /// Example:
   /// ```motoko include=import
   /// ignore Nat64.subWrap(0, 1); // => 18446744073709551615
   /// (0 : Nat64) -% (1 : Nat64) // => 18446744073709551615
   /// ```
-  /// 
+  ///
 
   public func subWrap(x : Nat64, y : Nat64) : Nat64 { x -% y };
 
   /// Returns the product of `x` and `y`, `x *% y`. Wraps on overflow.
-  /// 
+  ///
   /// Example:
   /// ```motoko include=import
   /// ignore Nat64.mulWrap(4294967296, 4294967296); // => 0
   /// (4294967296 : Nat64) *% (4294967296 : Nat64) // => 0
   /// ```
-  /// 
+  ///
 
   public func mulWrap(x : Nat64, y : Nat64) : Nat64 { x *% y };
 
   /// Returns `x` to the power of `y`, `x **% y`. Wraps on overflow.
-  /// 
+  ///
   /// Example:
   /// ```motoko include=import
   /// ignore Nat64.powWrap(2, 64); // => 0
   /// (2 : Nat64) **% (64 : Nat64) // => 0
   /// ```
-  /// 
+  ///
 
   public func powWrap(x : Nat64, y : Nat64) : Nat64 { x **% y };
 

--- a/src/Nat8.mo
+++ b/src/Nat8.mo
@@ -1,17 +1,17 @@
 /// Provides utility functions on 8-bit unsigned integers.
-/// 
+///
 /// :::note
 /// Most operations on integer numbers (e.g. addition) are available as built-in operators (e.g. `1 + 1`).
 /// This module provides equivalent functions and `Text` conversion.
 /// :::
-/// 
+///
 /// :::info Function form for higher-order use
-/// 
+///
 /// Several arithmetic and comparison functions (e.g. `add`, `sub`, `equal`, `less`, `pow`) are defined in this module to enable their use as first-class function values, which is not possible with operators like `+`, `-`, `==`, etc., in Motoko. This allows you to pass these operations to higher-order functions such as `map`, `foldLeft`, or `sort`.
 /// :::
-/// 
+///
 /// Import from the base library to use this module.
-/// 
+///
 /// ```motoko name=import
 /// import Nat8 "mo:base/Nat8";
 /// ```
@@ -24,7 +24,7 @@ module {
   public type Nat8 = Prim.Types.Nat8;
 
   /// Maximum 8-bit natural number. `2 ** 8 - 1`.
-  /// 
+  ///
   /// Example:
   /// ```motoko include=import
   /// Nat8.maximumValue; // => 255 : Nat8
@@ -32,7 +32,7 @@ module {
   public let maximumValue = 255 : Nat8;
 
   /// Converts an 8-bit unsigned integer to an unsigned integer with infinite precision.
-  /// 
+  ///
   /// Example:
   /// ```motoko include=import
   /// Nat8.toNat(123); // => 123 : Nat
@@ -40,9 +40,9 @@ module {
   public let toNat : Nat8 -> Nat = Prim.nat8ToNat;
 
   /// Converts an unsigned integer with infinite precision to an 8-bit unsigned integer.
-  /// 
+  ///
   /// Traps on overflow.
-  /// 
+  ///
   /// Example:
   /// ```motoko include=import
   /// Nat8.fromNat(123); // => 123 : Nat8
@@ -50,9 +50,9 @@ module {
   public let fromNat : Nat -> Nat8 = Prim.natToNat8;
 
   /// Converts a 16-bit unsigned integer to a 8-bit unsigned integer.
-  /// 
+  ///
   /// Traps on overflow.
-  /// 
+  ///
   /// Example:
   /// ```motoko include=import
   /// Nat8.fromNat16(123); // => 123 : Nat8
@@ -60,7 +60,7 @@ module {
   public let fromNat16 : Nat16 -> Nat8 = Prim.nat16ToNat8;
 
   /// Converts an 8-bit unsigned integer to a 16-bit unsigned integer.
-  /// 
+  ///
   /// Example:
   /// ```motoko include=import
   /// Nat8.toNat16(123); // => 123 : Nat16
@@ -68,9 +68,9 @@ module {
   public let toNat16 : Nat8 -> Nat16 = Prim.nat8ToNat16;
 
   /// Converts a signed integer with infinite precision to an 8-bit unsigned integer.
-  /// 
+  ///
   /// Wraps on overflow/underflow.
-  /// 
+  ///
   /// Example:
   /// ```motoko include=import
   /// Nat8.fromIntWrap(123); // => 123 : Nat8
@@ -78,7 +78,7 @@ module {
   public let fromIntWrap : Int -> Nat8 = Prim.intToNat8Wrap;
 
   /// Converts `x` to its textual representation.
-  /// 
+  ///
   /// Example:
   /// ```motoko include=import
   /// Nat8.toText(123); // => "123" : Text
@@ -88,7 +88,7 @@ module {
   };
 
   /// Returns the minimum of `x` and `y`.
-  /// 
+  ///
   /// Example:
   /// ```motoko include=import
   /// Nat8.min(123, 200); // => 123 : Nat8
@@ -98,7 +98,7 @@ module {
   };
 
   /// Returns the maximum of `x` and `y`.
-  /// 
+  ///
   /// Example:
   /// ```motoko include=import
   /// Nat8.max(123, 200); // => 200 : Nat8
@@ -109,19 +109,19 @@ module {
 
   /// Equality function for Nat8 types.
   /// This is equivalent to `x == y`.
-  /// 
+  ///
   /// Example:
   /// ```motoko include=import
   /// ignore Nat8.equal(1, 1); // => true
   /// (1 : Nat8) == (1 : Nat8) // => true
   /// ```
-  /// 
+  ///
 
-  /// 
+  ///
   /// Example:
   /// ```motoko include=import
   /// import Buffer "mo:base/Buffer";
-  /// 
+  ///
   /// let buffer1 = Buffer.Buffer<Nat8>(3);
   /// let buffer2 = Buffer.Buffer<Nat8>(3);
   /// Buffer.equal(buffer1, buffer2, Nat8.equal) // => true
@@ -130,74 +130,74 @@ module {
 
   /// Inequality function for Nat8 types.
   /// This is equivalent to `x != y`.
-  /// 
+  ///
   /// Example:
   /// ```motoko include=import
   /// ignore Nat8.notEqual(1, 2); // => true
   /// (1 : Nat8) != (2 : Nat8) // => true
   /// ```
-  /// 
+  ///
 
   public func notEqual(x : Nat8, y : Nat8) : Bool { x != y };
 
   /// "Less than" function for Nat8 types.
   /// This is equivalent to `x < y`.
-  /// 
+  ///
   /// Example:
   /// ```motoko include=import
   /// ignore Nat8.less(1, 2); // => true
   /// (1 : Nat8) < (2 : Nat8) // => true
   /// ```
-  /// 
+  ///
 
   public func less(x : Nat8, y : Nat8) : Bool { x < y };
 
   /// "Less than or equal" function for Nat8 types.
   /// This is equivalent to `x <= y`.
-  /// 
+  ///
   /// Example:
   /// ```motoko include=import
   /// ignore Nat.lessOrEqual(1, 2); // => true
   /// 1 <= 2 // => true
   /// ```
-  /// 
+  ///
 
   public func lessOrEqual(x : Nat8, y : Nat8) : Bool { x <= y };
 
   /// "Greater than" function for Nat8 types.
   /// This is equivalent to `x > y`.
-  /// 
+  ///
   /// Example:
   /// ```motoko include=import
   /// ignore Nat8.greater(2, 1); // => true
   /// (2 : Nat8) > (1 : Nat8) // => true
   /// ```
-  /// 
+  ///
 
   public func greater(x : Nat8, y : Nat8) : Bool { x > y };
 
   /// "Greater than or equal" function for Nat8 types.
   /// This is equivalent to `x >= y`.
-  /// 
+  ///
   /// Example:
   /// ```motoko include=import
   /// ignore Nat8.greaterOrEqual(2, 1); // => true
   /// (2 : Nat8) >= (1 : Nat8) // => true
   /// ```
-  /// 
+  ///
 
   public func greaterOrEqual(x : Nat8, y : Nat8) : Bool { x >= y };
 
   /// General purpose comparison function for `Nat8`. Returns the `Order` (
   /// either `#less`, `#equal`, or `#greater`) of comparing `x` with `y`.
-  /// 
+  ///
   /// Example:
   /// ```motoko include=import
   /// Nat8.compare(2, 3) // => #less
   /// ```
-  /// 
+  ///
   /// This function can be used as value for a high order function, such as a sort function.
-  /// 
+  ///
   /// Example:
   /// ```motoko include=import
   /// import Array "mo:base/Array";
@@ -209,15 +209,15 @@ module {
 
   /// Returns the sum of `x` and `y`, `x + y`.
   /// Traps on overflow.
-  /// 
+  ///
   /// Example:
   /// ```motoko include=import
   /// ignore Nat8.add(1, 2); // => 3
   /// (1 : Nat8) + (2 : Nat8) // => 3
   /// ```
-  /// 
+  ///
 
-  /// 
+  ///
   /// Example:
   /// ```motoko include=import
   /// import Array "mo:base/Array";
@@ -227,15 +227,15 @@ module {
 
   /// Returns the difference of `x` and `y`, `x - y`.
   /// Traps on underflow.
-  /// 
+  ///
   /// Example:
   /// ```motoko include=import
   /// ignore Nat8.sub(2, 1); // => 1
   /// (2 : Nat8) - (1 : Nat8) // => 1
   /// ```
-  /// 
+  ///
 
-  /// 
+  ///
   /// Example:
   /// ```motoko include=import
   /// import Array "mo:base/Array";
@@ -245,15 +245,15 @@ module {
 
   /// Returns the product of `x` and `y`, `x * y`.
   /// Traps on overflow.
-  /// 
+  ///
   /// Example:
   /// ```motoko include=import
   /// ignore Nat8.mul(2, 3); // => 6
   /// (2 : Nat8) * (3 : Nat8) // => 6
   /// ```
-  /// 
+  ///
 
-  /// 
+  ///
   /// Example:
   /// ```motoko include=import
   /// import Array "mo:base/Array";
@@ -263,131 +263,131 @@ module {
 
   /// Returns the quotient of `x` divided by `y`, `x / y`.
   /// Traps when `y` is zero.
-  /// 
+  ///
   /// Example:
   /// ```motoko include=import
   /// ignore Nat8.div(6, 2); // => 3
   /// (6 : Nat8) / (2 : Nat8) // => 3
   /// ```
-  /// 
+  ///
 
   public func div(x : Nat8, y : Nat8) : Nat8 { x / y };
 
   /// Returns the remainder of `x` divided by `y`, `x % y`.
   /// Traps when `y` is zero.
-  /// 
+  ///
   /// Example:
   /// ```motoko include=import
   /// ignore Nat8.rem(6, 4); // => 2
   /// (6 : Nat8) % (4 : Nat8) // => 2
   /// ```
-  /// 
+  ///
 
   public func rem(x : Nat8, y : Nat8) : Nat8 { x % y };
 
   /// Returns `x` to the power of `y`, `x ** y`.
   /// Traps on overflow.
-  /// 
+  ///
   /// Example:
   /// ```motoko include=import
   /// ignore Nat8.pow(2, 3); // => 8
   /// (2 : Nat8) ** (3 : Nat8) // => 8
   /// ```
-  /// 
+  ///
 
   public func pow(x : Nat8, y : Nat8) : Nat8 { x ** y };
 
   /// Returns the bitwise negation of `x`, `^x`.
-  /// 
+  ///
   /// Example:
   /// ```motoko include=import
   /// ignore Nat8.bitnot(0); // => 255
   /// ^(0 : Nat8) // => 255
   /// ```
-  /// 
+  ///
 
   public func bitnot(x : Nat8) : Nat8 { ^x };
 
   /// Returns the bitwise and of `x` and `y`, `x & y`.
-  /// 
+  ///
   /// Example:
   /// ```motoko include=import
   /// ignore Nat8.bitand(3, 2); // => 2
   /// (3 : Nat8) & (2 : Nat8) // => 2
   /// ```
-  /// 
+  ///
 
   public func bitand(x : Nat8, y : Nat8) : Nat8 { x & y };
 
   /// Returns the bitwise or of `x` and `y`, `x | y`.
-  /// 
+  ///
   /// Example:
   /// ```motoko include=import
   /// ignore Nat8.bitor(3, 2); // => 3
   /// (3 : Nat8) | (2 : Nat8) // => 3
   /// ```
-  /// 
+  ///
 
   public func bitor(x : Nat8, y : Nat8) : Nat8 { x | y };
 
   /// Returns the bitwise exclusive or of `x` and `y`, `x ^ y`.
-  /// 
+  ///
   /// Example:
   /// ```motoko include=import
   /// ignore Nat8.bitxor(3, 2); // => 1
   /// (3 : Nat8) ^ (2 : Nat8) // => 1
   /// ```
-  /// 
+  ///
 
   public func bitxor(x : Nat8, y : Nat8) : Nat8 { x ^ y };
 
   /// Returns the bitwise shift left of `x` by `y`, `x << y`.
-  /// 
+  ///
   /// Example:
   /// ```motoko include=import
   /// ignore Nat8.bitshiftLeft(1, 2); // => 4
   /// (1 : Nat8) << (2 : Nat8) // => 4
   /// ```
-  /// 
+  ///
 
   public func bitshiftLeft(x : Nat8, y : Nat8) : Nat8 { x << y };
 
   /// Returns the bitwise shift right of `x` by `y`, `x >> y`.
-  /// 
+  ///
   /// Example:
   /// ```motoko include=import
   /// ignore Nat8.bitshiftRight(4, 2); // => 1
   /// (4 : Nat8) >> (2 : Nat8) // => 1
   /// ```
-  /// 
+  ///
 
   public func bitshiftRight(x : Nat8, y : Nat8) : Nat8 { x >> y };
 
   /// Returns the bitwise rotate left of `x` by `y`, `x <<> y`.
-  /// 
+  ///
   /// Example:
   /// ```motoko include=import
   /// ignore Nat8.bitrotLeft(128, 1); // => 1
   /// (128 : Nat8) <<> (1 : Nat8) // => 1
   /// ```
-  /// 
+  ///
 
   public func bitrotLeft(x : Nat8, y : Nat8) : Nat8 { x <<> y };
 
   /// Returns the bitwise rotate right of `x` by `y`, `x <>> y`.
-  /// 
+  ///
   /// Example:
   /// ```motoko include=import
   /// ignore Nat8.bitrotRight(1, 1); // => 128
   /// (1 : Nat8) <>> (1 : Nat8) // => 128
   /// ```
-  /// 
+  ///
 
   public func bitrotRight(x : Nat8, y : Nat8) : Nat8 { x <>> y };
 
   /// Returns the value of bit `p mod 8` in `x`, `(x & 2^(p mod 8)) == 2^(p mod 8)`.
   /// This is equivalent to checking if the `p`-th bit is set in `x`, using 0 indexing.
-  /// 
+  ///
   /// Example:
   /// ```motoko include=import
   /// Nat8.bittest(5, 2); // => true
@@ -397,7 +397,7 @@ module {
   };
 
   /// Returns the value of setting bit `p mod 8` in `x` to `1`.
-  /// 
+  ///
   /// Example:
   /// ```motoko include=import
   /// Nat8.bitset(5, 1); // => 7
@@ -407,7 +407,7 @@ module {
   };
 
   /// Returns the value of clearing bit `p mod 8` in `x` to `0`.
-  /// 
+  ///
   /// Example:
   /// ```motoko include=import
   /// Nat8.bitclear(5, 2); // => 1
@@ -417,7 +417,7 @@ module {
   };
 
   /// Returns the value of flipping bit `p mod 8` in `x`.
-  /// 
+  ///
   /// Example:
   /// ```motoko include=import
   /// Nat8.bitflip(5, 2); // => 1
@@ -427,7 +427,7 @@ module {
   };
 
   /// Returns the count of non-zero bits in `x`.
-  /// 
+  ///
   /// Example:
   /// ```motoko include=import
   /// Nat8.bitcountNonZero(5); // => 2
@@ -435,7 +435,7 @@ module {
   public let bitcountNonZero : (x : Nat8) -> Nat8 = Prim.popcntNat8;
 
   /// Returns the count of leading zero bits in `x`.
-  /// 
+  ///
   /// Example:
   /// ```motoko include=import
   /// Nat8.bitcountLeadingZero(5); // => 5
@@ -443,7 +443,7 @@ module {
   public let bitcountLeadingZero : (x : Nat8) -> Nat8 = Prim.clzNat8;
 
   /// Returns the count of trailing zero bits in `x`.
-  /// 
+  ///
   /// Example:
   /// ```motoko include=import
   /// Nat8.bitcountTrailingZero(6); // => 1
@@ -451,18 +451,18 @@ module {
   public let bitcountTrailingZero : (x : Nat8) -> Nat8 = Prim.ctzNat8;
 
   /// Returns the sum of `x` and `y`, `x +% y`. Wraps on overflow.
-  /// 
+  ///
   /// Example:
   /// ```motoko include=import
   /// ignore Nat8.addWrap(230, 26); // => 0
   /// (230 : Nat8) +% (26 : Nat8) // => 0
   /// ```
-  /// 
+  ///
 
   public func addWrap(x : Nat8, y : Nat8) : Nat8 { x +% y };
 
   /// Returns the difference of `x` and `y`, `x -% y`. Wraps on underflow.
-  /// 
+  ///
   /// Example:
   /// ```motoko include=import
   /// ignore Nat8.subWrap(0, 1); // => 255
@@ -472,24 +472,24 @@ module {
   public func subWrap(x : Nat8, y : Nat8) : Nat8 { x -% y };
 
   /// Returns the product of `x` and `y`, `x *% y`. Wraps on overflow.
-  /// 
+  ///
   /// Example:
   /// ```motoko include=import
   /// ignore Nat8.mulWrap(230, 26); // => 92
   /// (230 : Nat8) *% (26 : Nat8) // => 92
   /// ```
-  /// 
+  ///
 
   public func mulWrap(x : Nat8, y : Nat8) : Nat8 { x *% y };
 
   /// Returns `x` to the power of `y`, `x **% y`. Wraps on overflow.
-  /// 
+  ///
   /// Example:
   /// ```motoko include=import
   /// ignore Nat8.powWrap(2, 8); // => 0
   /// (2 : Nat8) **% (8 : Nat8) // => 0
   /// ```
-  /// 
+  ///
 
   public func powWrap(x : Nat8, y : Nat8) : Nat8 { x **% y };
 

--- a/src/None.mo
+++ b/src/None.mo
@@ -1,5 +1,5 @@
 /// The `None` type represents a type with _no_ value.
-/// 
+///
 /// It is often used to type code that fails to return control (e.g. an infinite loop)
 /// or to designate impossible values (e.g. the type `?None` only contains `null`).
 

--- a/src/Option.mo
+++ b/src/Option.mo
@@ -1,24 +1,24 @@
 /// Optional values can be seen as a typesafe `null`. A value of type `?Int` can
 /// be constructed with either `null` or `?42`. The simplest way to get at the
 /// contents of an optional is to use pattern matching:
-/// 
+///
 /// ```motoko
 /// let optionalInt1 : ?Int = ?42;
 /// let optionalInt2 : ?Int = null;
-/// 
+///
 /// let int1orZero : Int = switch optionalInt1 {
 ///   case null 0;
 ///   case (?int) int;
 /// };
 /// assert int1orZero == 42;
-/// 
+///
 /// let int2orZero : Int = switch optionalInt2 {
 ///   case null 0;
 ///   case (?int) int;
 /// };
 /// assert int2orZero == 0;
 /// ```
-/// 
+///
 /// The functions in this module capture some common operations when working
 /// with optionals that can be more succinct than using pattern matching.
 
@@ -53,7 +53,7 @@ module {
 
   /// Applies a function to the wrapped value, but discards the result. Use
   /// `iterate` if you're only interested in the side effect `f` produces.
-  /// 
+  ///
   /// ```motoko
   /// import Option "mo:base/Option";
   /// var counter : Nat = 0;
@@ -135,29 +135,23 @@ module {
     case (_, _) { false }
   };
 
-  /// :::warning Deprecated function
-  ///
-  /// `Option.assertSome` will be removed soon. Use an `assert` expression instead.
-  ///
-  /// :::
+  /// Asserts that the value is not `null`; fails otherwise.
+  /// @deprecated Option.assertSome will be removed soon; use an assert expression instead
   public func assertSome(x : ?Any) = switch x {
     case null { P.unreachable() };
     case _ {}
   };
 
-  /// :::warning Deprecated function
-  /// 
-  /// `Option.assertNull` will be removed soon. Use an `assert` expression instead.
-  /// :::
+  /// Asserts that the value _is_ `null`; fails otherwise.
+  /// @deprecated Option.assertNull will be removed soon; use an assert expression instead
   public func assertNull(x : ?Any) = switch x {
     case null {};
     case _ { P.unreachable() }
   };
 
-  /// :::warning Deprecated function
-  /// 
-  /// `Option.unwrap` is unsafe and will be removed soon. Use a `switch` or `do?` expression instead.
-  /// :::
+  /// Unwraps an optional value, i.e. `unwrap(?x) = x`.
+  ///
+  /// @deprecated Option.unwrap is unsafe and fails if the argument is null; it will be removed soon; use a `switch` or `do?` expression instead
   public func unwrap<T>(x : ?T) : T = switch x {
     case null { P.unreachable() };
     case (?x_) { x_ }

--- a/src/OrderedSet.mo
+++ b/src/OrderedSet.mo
@@ -1,35 +1,35 @@
 /// Stable ordered set implemented as a red-black tree.
-/// 
+///
 /// A red-black tree is a balanced binary search tree ordered by the elements.
-/// 
+///
 /// The tree data structure internally colors each of its nodes either red or black,
 /// and uses this information to balance the tree during the modifying operations.
-/// 
+///
 /// | Runtime   | Space |
 /// |----------|------------|
 /// | `O(log(n))` (worst case per insertion, removal, or retrieval)  | `O(n)` (for storing the entire tree) |
-/// 
+///
 /// `n` denotes the number of key-value entries (i.e. nodes) stored in the tree.
-/// 
+///
 /// :::note Garbage collection
-/// 
+///
 /// Unless stated otherwise, operations that iterate over or modify the map (such as insertion, deletion, traversal, and transformation) may create temporary objects with worst-case space usage of `O(log(n))` or `O(n)`. These objects are short-lived and will be collected by the garbage collector automatically.
-/// 
+///
 /// :::
-/// 
+///
 /// :::note Assumptions
-/// 
+///
 /// Runtime and space complexity assumes that `compare`, `equal`, and other functions execute in `O(1)` time and space.
 /// :::
-/// 
+///
 /// :::info Credits
-/// 
+///
 /// The core of this implementation is derived from:
-/// 
+///
 /// * Ken Friis Larsen's [RedBlackMap.sml](https://github.com/kfl/mosml/blob/master/src/mosmllib/Redblackmap.sml), which itself is based on:
 /// * Stefan Kahrs, "Red-black trees with types", Journal of Functional Programming, 11(4): 425-432 (2001), [version 1 in web appendix](http://www.cs.ukc.ac.uk/people/staff/smk/redblack/rb.html).
 /// :::
-/// 
+///
 import Debug "Debug";
 import Buffer "Buffer";
 import I "Iter";
@@ -54,23 +54,23 @@ module {
 
   /// Class that captures element type `T` along with its ordering function `compare`
   /// and provide all operations to work with a set of type `Set<T>`.
-  /// 
+  ///
   /// An instance object should be created once as a canister field to ensure
   /// that the same ordering function is used for every operation.
-  /// 
+  ///
   /// Example:
   /// ```motoko
   /// import Set "mo:base/OrderedSet";
   /// import Nat "mo:base/Nat";
-  /// 
+  ///
   /// actor {
   ///   let natSet = Set.Make<Nat>(Nat.compare); // : Operations<Nat>
   ///   stable var usedIds : Set.Set<Nat> = natSet.empty();
-  /// 
+  ///
   ///   public func createId(id : Nat) : async () {
   ///     usedIds := natSet.put(usedIds, id);
   ///   };
-  /// 
+  ///
   ///   public func idIsUsed(id: Nat) : async Bool {
   ///      natSet.contains(usedIds, id)
   ///   }
@@ -80,21 +80,21 @@ module {
 
     /// Returns a new Set, containing all entries given by the iterator `i`.
     /// If there are multiple identical entries only one is taken.
-    /// 
+    ///
     /// Example:
     /// ```motoko
     /// import Set "mo:base/OrderedSet";
     /// import Nat "mo:base/Nat";
     /// import Iter "mo:base/Iter";
     /// import Debug "mo:base/Debug";
-    /// 
+    ///
     /// let natSet = Set.Make<Nat>(Nat.compare);
     /// let set = natSet.fromIter(Iter.fromArray([0, 2, 1]));
-    /// 
+    ///
     /// Debug.print(debug_show(Iter.toArray(natSet.vals(set))));
     /// // [0, 1, 2]
     /// ```
-    /// 
+    ///
     /// | Runtime   | Space |
     /// |----------|------------|
     /// | `O(n * log(n))`  | `O(n)` (retained memory + garbage) |
@@ -108,30 +108,30 @@ module {
 
     /// Insert the value `value` into the set `s`. Has no effect if `value` is already
     /// present in the set. Returns a modified set.
-    /// 
+    ///
     /// Example:
     /// ```motoko
     /// import Set "mo:base/OrderedSet";
     /// import Nat "mo:base/Nat";
     /// import Iter "mo:base/Iter";
     /// import Debug "mo:base/Debug";
-    /// 
+    ///
     /// let natSet = Set.Make<Nat>(Nat.compare);
     /// var set = natSet.empty();
-    /// 
+    ///
     /// set := natSet.put(set, 0);
     /// set := natSet.put(set, 2);
     /// set := natSet.put(set, 1);
-    /// 
+    ///
     /// Debug.print(debug_show(Iter.toArray(natSet.vals(set))));
     /// // [0, 1, 2]
     /// ```
-    /// 
+    ///
     /// Runtime: `O(log(n))`.
     /// Space: `O(log(n))`.
     /// where `n` denotes the number of elements stored in the set and
     /// assuming that the `compare` function implements an `O(1)` comparison.
-    /// 
+    ///
     /// Note: The returned set shares with the `s` most of the tree nodes.
     /// Garbage collecting one of sets (e.g. after an assignment `m := natSet.delete(m, k)`)
     /// causes collecting `O(log(n))` nodes.
@@ -139,110 +139,110 @@ module {
 
     /// Deletes the value `value` from the set `s`. Has no effect if `value` is not
     /// present in the set. Returns modified set.
-    /// 
+    ///
     /// Example:
     /// ```motoko
     /// import Set "mo:base/OrderedSet";
     /// import Nat "mo:base/Nat";
     /// import Iter "mo:base/Iter";
     /// import Debug "mo:base/Debug";
-    /// 
+    ///
     /// let natSet = Set.Make<Nat>(Nat.compare);
     /// let set = natSet.fromIter(Iter.fromArray([0, 2, 1]));
-    /// 
+    ///
     /// Debug.print(debug_show(Iter.toArray(natSet.vals(natSet.delete(set, 1)))));
     /// Debug.print(debug_show(Iter.toArray(natSet.vals(natSet.delete(set, 42)))));
     /// // [0, 2]
     /// // [0, 1, 2]
     /// ```
-    /// 
+    ///
     /// | Runtime     | Space         |
     /// |-------------|---------------|
     /// | `O(log(n))` | `O(log(n))`   |
     public func delete(s : Set<T>, value : T) : Set<T> = Internal.delete(s, compare, value);
 
     /// Test if the set 's' contains a given element.
-    /// 
+    ///
     /// Example:
     /// ```motoko
     /// import Set "mo:base/OrderedSet";
     /// import Nat "mo:base/Nat";
     /// import Iter "mo:base/Iter";
     /// import Debug "mo:base/Debug";
-    /// 
+    ///
     /// let natSet = Set.Make<Nat>(Nat.compare);
     /// let set = natSet.fromIter(Iter.fromArray([0, 2, 1]));
-    /// 
+    ///
     /// Debug.print(debug_show natSet.contains(set, 1)); // => true
     /// Debug.print(debug_show natSet.contains(set, 42)); // => false
     /// ```
-    /// 
+    ///
     /// | Runtime     | Space         |
     /// |-------------|---------------|
     /// | `O(log(n))` | `O(1)`   |
     public func contains(s : Set<T>, value : T) : Bool = Internal.contains(s.root, compare, value);
 
     /// Get a maximal element of the set `s` if it is not empty, otherwise returns `null`
-    /// 
+    ///
     /// Example:
     /// ```motoko
     /// import Set "mo:base/OrderedSet";
     /// import Nat "mo:base/Nat";
     /// import Iter "mo:base/Iter";
     /// import Debug "mo:base/Debug";
-    /// 
+    ///
     /// let natSet = Set.Make<Nat>(Nat.compare);
     /// let s1 = natSet.fromIter(Iter.fromArray([0, 2, 1]));
     /// let s2 = natSet.empty();
-    /// 
+    ///
     /// Debug.print(debug_show(natSet.max(s1))); // => ?2
     /// Debug.print(debug_show(natSet.max(s2))); // => null
     /// ```
-    /// 
+    ///
     /// | Runtime     | Space         |
     /// |-------------|---------------|
     /// | `O(log(n))` | `O(1)`   |
     public func max(s : Set<T>) : ?T = Internal.max(s.root);
 
     /// Get a minimal element of the set `s` if it is not empty, otherwise returns `null`
-    /// 
+    ///
     /// Example:
     /// ```motoko
     /// import Set "mo:base/OrderedSet";
     /// import Nat "mo:base/Nat";
     /// import Iter "mo:base/Iter";
     /// import Debug "mo:base/Debug";
-    /// 
+    ///
     /// let natSet = Set.Make<Nat>(Nat.compare);
     /// let s1 = natSet.fromIter(Iter.fromArray([0, 2, 1]));
     /// let s2 = natSet.empty();
-    /// 
+    ///
     /// Debug.print(debug_show(natSet.min(s1))); // => ?0
     /// Debug.print(debug_show(natSet.min(s2))); // => null
     /// ```
-    /// 
+    ///
     /// | Runtime     | Space         |
     /// |-------------|---------------|
     /// | `O(log(n))` | `O(log(1))`   |
     public func min(s : Set<T>) : ?T = Internal.min(s.root);
 
     /// [Set union](https://en.wikipedia.org/wiki/Union_(set_theory)) operation.
-    /// 
+    ///
     /// Example:
     /// ```motoko
     /// import Set "mo:base/OrderedSet";
     /// import Nat "mo:base/Nat";
     /// import Iter "mo:base/Iter";
     /// import Debug "mo:base/Debug";
-    /// 
+    ///
     /// let natSet = Set.Make<Nat>(Nat.compare);
     /// let set1 = natSet.fromIter(Iter.fromArray([0, 1, 2]));
     /// let set2 = natSet.fromIter(Iter.fromArray([2, 3, 4]));
-    /// 
+    ///
     /// Debug.print(debug_show Iter.toArray(natSet.vals(natSet.union(set1, set2))));
     /// // [0, 1, 2, 3, 4]
     /// ```
-    /// 
+    ///
     /// | Runtime     | Space         |
     /// |-------------|---------------|
     /// | `O(m* log(n))` | `O(m)`retained + garbage   |
@@ -255,26 +255,26 @@ module {
     };
 
     /// [Set intersection](https://en.wikipedia.org/wiki/Intersection_(set_theory)) operation.
-    /// 
+    ///
     /// Example:
     /// ```motoko
     /// import Set "mo:base/OrderedSet";
     /// import Nat "mo:base/Nat";
     /// import Iter "mo:base/Iter";
     /// import Debug "mo:base/Debug";
-    /// 
+    ///
     /// let natSet = Set.Make<Nat>(Nat.compare);
     /// let set1 = natSet.fromIter(Iter.fromArray([0, 1, 2]));
     /// let set2 = natSet.fromIter(Iter.fromArray([1, 2, 3]));
-    /// 
+    ///
     /// Debug.print(debug_show Iter.toArray(natSet.vals(natSet.intersect(set1, set2))));
     /// // [1, 2]
     /// ```
-    /// 
+    ///
     /// | Runtime     | Space         |
     /// |-------------|---------------|
     /// | `O(m* log(n))` | `O(m)`retained + garbage   |
-    /// 
+    ///
     /// Note: Creates `O(m)` temporary objects that will be collected as garbage.
     public func intersect(s1 : Set<T>, s2 : Set<T>) : Set<T> {
       let elems = Buffer.Buffer<T>(Nat.min(Nat.min(s1.size, s2.size), 100));
@@ -301,22 +301,22 @@ module {
     };
 
     /// [Set difference](https://en.wikipedia.org/wiki/Difference_(set_theory)).
-    /// 
+    ///
     /// Example:
     /// ```motoko
     /// import Set "mo:base/OrderedSet";
     /// import Nat "mo:base/Nat";
     /// import Iter "mo:base/Iter";
     /// import Debug "mo:base/Debug";
-    /// 
+    ///
     /// let natSet = Set.Make<Nat>(Nat.compare);
     /// let set1 = natSet.fromIter(Iter.fromArray([0, 1, 2]));
     /// let set2 = natSet.fromIter(Iter.fromArray([1, 2, 3]));
-    /// 
+    ///
     /// Debug.print(debug_show Iter.toArray(natSet.vals(natSet.diff(set1, set2))));
     /// // [0]
     /// ```
-    /// 
+    ///
     /// | Runtime     | Space         |
     /// |-------------|---------------|
     /// | `O(m* log(n))` | `O(m)`retained + garbage   |
@@ -349,25 +349,25 @@ module {
     /// `x` in the old set is transformed into a new entry `x2`, where
     /// the new value `x2` is created by applying `f` to `x`.
     /// The result set may be smaller than the original set due to duplicate elements.
-    /// 
+    ///
     /// Example:
     /// ```motoko
     /// import Set "mo:base/OrderedSet";
     /// import Nat "mo:base/Nat";
     /// import Iter "mo:base/Iter";
     /// import Debug "mo:base/Debug";
-    /// 
+    ///
     /// let natSet = Set.Make<Nat>(Nat.compare);
     /// let set = natSet.fromIter(Iter.fromArray([0, 1, 2, 3]));
-    /// 
+    ///
     /// func f(x : Nat) : Nat = if (x < 2) { x } else { 0 };
-    /// 
+    ///
     /// let resSet = natSet.map(set, f);
-    /// 
+    ///
     /// Debug.print(debug_show(Iter.toArray(natSet.vals(resSet))));
     /// // [0, 1]
     /// ```
-    /// 
+    ///
     /// Cost of mapping all the elements:
     /// | Runtime     | Space         |
     /// |-------------|---------------|
@@ -379,28 +379,28 @@ module {
     /// `x` in the old set, if `f` evaluates to `null`, the element is discarded.
     /// Otherwise, the entry is transformed into a new entry `x2`, where
     /// the new value `x2` is the result of applying `f` to `x`.
-    /// 
+    ///
     /// Example:
     /// ```motoko
     /// import Set "mo:base/OrderedSet";
     /// import Nat "mo:base/Nat";
     /// import Iter "mo:base/Iter";
     /// import Debug "mo:base/Debug";
-    /// 
+    ///
     /// let natSet = Set.Make<Nat>(Nat.compare);
     /// let set = natSet.fromIter(Iter.fromArray([0, 1, 2, 3]));
-    /// 
+    ///
     /// func f(x : Nat) : ?Nat {
     ///   if(x == 0) {null}
     ///   else { ?( x * 2 )}
     /// };
-    /// 
+    ///
     /// let newRbSet = natSet.mapFilter(set, f);
-    /// 
+    ///
     /// Debug.print(debug_show(Iter.toArray(natSet.vals(newRbSet))));
     /// // [2, 4, 6]
     /// ```
-    /// 
+    ///
     /// | Runtime     | Space         |
     /// |-------------|---------------|
     /// | `O(n* log(n))` | `O(n)`retained + garbage   |
@@ -417,21 +417,21 @@ module {
     };
 
     /// Test if `set1` is subset of `set2`.
-    /// 
+    ///
     /// Example:
     /// ```motoko
     /// import Set "mo:base/OrderedSet";
     /// import Nat "mo:base/Nat";
     /// import Iter "mo:base/Iter";
     /// import Debug "mo:base/Debug";
-    /// 
+    ///
     /// let natSet = Set.Make<Nat>(Nat.compare);
     /// let set1 = natSet.fromIter(Iter.fromArray([1, 2]));
     /// let set2 = natSet.fromIter(Iter.fromArray([0, 2, 1]));
-    /// 
+    ///
     /// Debug.print(debug_show natSet.isSubset(set1, set2)); // => true
     /// ```
-    /// 
+    ///
     /// | Runtime     | Space         |
     /// |-------------|---------------|
     /// | `O(n* log(n))` | `O(1)`   |
@@ -441,22 +441,22 @@ module {
     };
 
     /// Test if two sets are equal.
-    /// 
+    ///
     /// Example:
     /// ```motoko
     /// import Set "mo:base/OrderedSet";
     /// import Nat "mo:base/Nat";
     /// import Iter "mo:base/Iter";
     /// import Debug "mo:base/Debug";
-    /// 
+    ///
     /// let natSet = Set.Make<Nat>(Nat.compare);
     /// let set1 = natSet.fromIter(Iter.fromArray([0, 2, 1]));
     /// let set2 = natSet.fromIter(Iter.fromArray([1, 2]));
-    /// 
+    ///
     /// Debug.print(debug_show natSet.equals(set1, set1)); // => true
     /// Debug.print(debug_show natSet.equals(set1, set2)); // => false
     /// ```
-    /// 
+    ///
     /// | Runtime     | Space         |
     /// |-------------|---------------|
     /// | `O(m * log(n))` | `O(1)`   |
@@ -490,17 +490,17 @@ module {
     /// Returns an Iterator (`Iter`) over the elements of the set.
     /// Iterator provides a single method `next()`, which returns
     /// elements in ascending order, or `null` when out of elements to iterate over.
-    /// 
+    ///
     /// Example:
     /// ```motoko
     /// import Set "mo:base/OrderedSet";
     /// import Nat "mo:base/Nat";
     /// import Iter "mo:base/Iter";
     /// import Debug "mo:base/Debug";
-    /// 
+    ///
     /// let natSet = Set.Make<Nat>(Nat.compare);
     /// let set = natSet.fromIter(Iter.fromArray([0, 2, 1]));
-    /// 
+    ///
     /// Debug.print(debug_show(Iter.toArray(natSet.vals(set))));
     /// // [0, 1, 2]
     /// ```
@@ -511,17 +511,17 @@ module {
     public func vals(s : Set<T>) : I.Iter<T> = Internal.iter(s.root, #fwd);
 
     /// Same as `vals()` but iterates over elements of the set `s` in the descending order.
-    /// 
+    ///
     /// Example:
     /// ```motoko
     /// import Set "mo:base/OrderedSet";
     /// import Nat "mo:base/Nat";
     /// import Iter "mo:base/Iter";
     /// import Debug "mo:base/Debug";
-    /// 
+    ///
     /// let natSet = Set.Make<Nat>(Nat.compare);
     /// let set = natSet.fromIter(Iter.fromArray([0, 2, 1]));
-    /// 
+    ///
     /// Debug.print(debug_show(Iter.toArray(natSet.valsRev(set))));
     /// // [2, 1, 0]
     /// ```
@@ -532,39 +532,39 @@ module {
     public func valsRev(s : Set<T>) : I.Iter<T> = Internal.iter(s.root, #bwd);
 
     /// Create a new empty Set.
-    /// 
+    ///
     /// Example:
     /// ```motoko
     /// import Set "mo:base/OrderedSet";
     /// import Nat "mo:base/Nat";
     /// import Debug "mo:base/Debug";
-    /// 
+    ///
     /// let natSet = Set.Make<Nat>(Nat.compare);
     /// let set = natSet.empty();
-    /// 
+    ///
     /// Debug.print(debug_show(natSet.size(set))); // => 0
     /// ```
-    /// 
+    ///
     /// Cost of empty set creation
     /// Runtime: `O(1)`.
     /// Space: `O(1)`
     public func empty() : Set<T> = { root = #leaf; size = 0 };
 
     /// Returns the number of elements in the set.
-    /// 
+    ///
     /// Example:
     /// ```motoko
     /// import Set "mo:base/OrderedSet";
     /// import Nat "mo:base/Nat";
     /// import Iter "mo:base/Iter";
     /// import Debug "mo:base/Debug";
-    /// 
+    ///
     /// let natSet = Set.Make<Nat>(Nat.compare);
     /// let set = natSet.fromIter(Iter.fromArray([0, 2, 1]));
-    /// 
+    ///
     /// Debug.print(debug_show(natSet.size(set))); // => 3
     /// ```
-    /// 
+    ///
     /// | Runtime     | Space         |
     /// |-------------|---------------|
     /// | `O(1)` | `O(1)` |
@@ -573,23 +573,23 @@ module {
     /// Collapses the elements in `set` into a single value by starting with `base`
     /// and progessively combining elements into `base` with `combine`. Iteration runs
     /// left to right.
-    /// 
+    ///
     /// Example:
     /// ```motoko
     /// import Set "mo:base/OrderedSet";
     /// import Nat "mo:base/Nat";
     /// import Iter "mo:base/Iter";
     /// import Debug "mo:base/Debug";
-    /// 
+    ///
     /// let natSet = Set.Make<Nat>(Nat.compare);
     /// let set = natSet.fromIter(Iter.fromArray([0, 2, 1]));
-    /// 
+    ///
     /// func folder(accum : Nat, val : Nat) : Nat = val + accum;
-    /// 
+    ///
     /// Debug.print(debug_show(natSet.foldLeft(set, 0, folder)));
     /// // 3
     /// ```
-    /// 
+    ///
 
     /// | Runtime | Space                        |
     /// |---------|------------------------------|
@@ -603,23 +603,23 @@ module {
     /// Collapses the elements in `set` into a single value by starting with `base`
     /// and progessively combining elements into `base` with `combine`. Iteration runs
     /// right to left.
-    /// 
+    ///
     /// Example:
     /// ```motoko
     /// import Set "mo:base/OrderedSet";
     /// import Nat "mo:base/Nat";
     /// import Iter "mo:base/Iter";
     /// import Debug "mo:base/Debug";
-    /// 
+    ///
     /// let natSet = Set.Make<Nat>(Nat.compare);
     /// let set = natSet.fromIter(Iter.fromArray([0, 2, 1]));
-    /// 
+    ///
     /// func folder(val : Nat, accum : Nat) : Nat = val + accum;
-    /// 
+    ///
     /// Debug.print(debug_show(natSet.foldRight(set, 0, folder)));
     /// // 3
     /// ```
-    /// 
+    ///
 
     /// | Runtime | Space                        |
     /// |---------|------------------------------|
@@ -631,19 +631,19 @@ module {
     ) : Accum = Internal.foldRight(set.root, base, combine);
 
     /// Test if the given set `s` is empty.
-    /// 
+    ///
     /// Example:
     /// ```motoko
     /// import Set "mo:base/OrderedSet";
     /// import Nat "mo:base/Nat";
     /// import Debug "mo:base/Debug";
-    /// 
+    ///
     /// let natSet = Set.Make<Nat>(Nat.compare);
     /// let set = natSet.empty();
-    /// 
+    ///
     /// Debug.print(debug_show(natSet.isEmpty(set))); // => true
     /// ```
-    /// 
+    ///
     /// Runtime: `O(1)`.
     /// Space: `O(1)`.
     public func isEmpty(s : Set<T>) : Bool {
@@ -654,46 +654,46 @@ module {
     };
 
     /// Test whether all values in the set `s` satisfy a given predicate `pred`.
-    /// 
+    ///
     /// Example:
     /// ```motoko
     /// import Set "mo:base/OrderedSet";
     /// import Nat "mo:base/Nat";
     /// import Iter "mo:base/Iter";
     /// import Debug "mo:base/Debug";
-    /// 
+    ///
     /// let natSet = Set.Make<Nat>(Nat.compare);
     /// let set = natSet.fromIter(Iter.fromArray([0, 2, 1]));
-    /// 
+    ///
     /// Debug.print(debug_show(natSet.all(set, func (v) = (v < 10))));
     /// // true
     /// Debug.print(debug_show(natSet.all(set, func (v) = (v < 2))));
     /// // false
     /// ```
-    /// 
+    ///
     /// | Runtime | Space                        |
     /// |---------|------------------------------|
     /// | `O(n)`  | `O(n)` |
     public func all(s : Set<T>, pred : T -> Bool) : Bool = Internal.all(s.root, pred);
 
     /// Test if there exists an element in the set `s` satisfying the given predicate `pred`.
-    /// 
+    ///
     /// Example:
     /// ```motoko
     /// import Set "mo:base/OrderedSet";
     /// import Nat "mo:base/Nat";
     /// import Iter "mo:base/Iter";
     /// import Debug "mo:base/Debug";
-    /// 
+    ///
     /// let natSet = Set.Make<Nat>(Nat.compare);
     /// let set = natSet.fromIter(Iter.fromArray([0, 2, 1]));
-    /// 
+    ///
     /// Debug.print(debug_show(natSet.some(set, func (v) = (v >= 3))));
     /// // false
     /// Debug.print(debug_show(natSet.some(set, func (v) = (v >= 0))));
     /// // true
     /// ```
-    /// 
+    ///
     /// | Runtime | Space                        |
     /// |---------|------------------------------|
     /// | `O(n)`  | `O(1)` |
@@ -1205,12 +1205,12 @@ module {
 
   /// Create `OrderedSet.Operations` object capturing element type `T` and `compare` function.
   /// It is an alias for the `Operations` constructor.
-  /// 
+  ///
   /// Example:
   /// ```motoko
   /// import Set "mo:base/OrderedSet";
   /// import Nat "mo:base/Nat";
-  /// 
+  ///
   /// actor {
   ///   let natSet = Set.Make<Nat>(Nat.compare);
   ///   stable var set : Set.Set<Nat> = natSet.empty();

--- a/src/Prelude.mo
+++ b/src/Prelude.mo
@@ -9,9 +9,9 @@ module {
   /// :::warning
   /// Not yet implemented
   /// :::
-  /// 
+  ///
   /// Mark incomplete code with the `nyi` and `xxx` functions.
-  /// 
+  ///
   /// Each have calls that are well-typed in all typing contexts, which
   /// trap in all execution contexts.
   public func nyi() : None {
@@ -23,7 +23,7 @@ module {
   };
 
   /// Mark unreachable code with the `unreachable` function.
-  /// 
+  ///
   /// Calls are well-typed in all typing contexts, and they
   /// trap in all execution contexts.
   public func unreachable() : None {

--- a/src/Principal.mo
+++ b/src/Principal.mo
@@ -1,35 +1,35 @@
 /// Module for interacting with Principals (users, canisters, or other entities).
-/// 
+///
 /// Principals are used to identify entities that can interact with the Internet
 /// Computer including users or canisters.
-/// 
+///
 /// Example textual representation of Principals:
-/// 
+///
 /// `un4fu-tqaaa-aaaab-qadjq-cai`
-/// 
+///
 /// In Motoko, there is a primitive Principal type called `Principal`. As an example
 /// of where you might see Principals, you can access the Principal of the
 /// caller of your shared function.
-/// 
+///
 /// ```motoko no-repl
 /// shared(msg) func foo() {
 ///  let caller : Principal = msg.caller;
 /// };
 /// ```
-/// 
+///
 /// Then, you can use this module to work with the `Principal`.
-/// 
+///
 /// :::note Comparison usage
-/// 
+///
 /// These functions are defined in this library in addition to the existing comparison operators so that they can be passed as function values to higher-order functions. It is currently not possible to use operators such as `==`, `!=`, `<`, `<=`, `>`, or `>=` as function values directly.
 /// :::
-/// 
+///
 /// Import from the base library to use this module.
-/// 
+///
 /// ```motoko name=import
 /// import Principal "mo:base/Principal";
 /// ```
-/// 
+///
 
 import Prim "mo:⛔";
 import Blob "Blob";
@@ -45,7 +45,7 @@ module {
   public type Principal = Prim.Types.Principal;
 
   /// Get the `Principal` identifier of an actor.
-  /// 
+  ///
   /// Example:
   /// ```motoko include=import no-repl
   /// actor MyCanister {
@@ -57,7 +57,7 @@ module {
   public func fromActor(a : actor {}) : Principal = Prim.principalOfActor a;
 
   /// Compute the Ledger account identifier of a principal. Optionally specify a sub-account.
-  /// 
+  ///
   /// Example:
   /// ```motoko include=import
   /// let principal = Principal.fromText("un4fu-tqaaa-aaaab-qadjq-cai");
@@ -88,7 +88,7 @@ module {
   };
 
   /// Convert a `Principal` to its `Blob` (bytes) representation.
-  /// 
+  ///
   /// Example:
   /// ```motoko include=import
   /// let principal = Principal.fromText("un4fu-tqaaa-aaaab-qadjq-cai");
@@ -97,7 +97,7 @@ module {
   public func toBlob(p : Principal) : Blob = Prim.blobOfPrincipal p;
 
   /// Converts a `Blob` (bytes) representation of a `Principal` to a `Principal` value.
-  /// 
+  ///
   /// Example:
   /// ```motoko include=import
   /// let blob = "\00\00\00\00\00\30\00\D3\01\01" : Blob;
@@ -107,7 +107,7 @@ module {
   public func fromBlob(b : Blob) : Principal = Prim.principalOfBlob b;
 
   /// Converts a `Principal` to its `Text` representation.
-  /// 
+  ///
   /// Example:
   /// ```motoko include=import
   /// let principal = Principal.fromText("un4fu-tqaaa-aaaab-qadjq-cai");
@@ -116,7 +116,7 @@ module {
   public func toText(p : Principal) : Text = debug_show (p);
 
   /// Converts a `Text` representation of a `Principal` to a `Principal` value.
-  /// 
+  ///
   /// Example:
   /// ```motoko include=import
   /// let principal = Principal.fromText("un4fu-tqaaa-aaaab-qadjq-cai");
@@ -127,7 +127,7 @@ module {
   private let anonymousPrincipal : Blob = "\04";
 
   /// Checks if the given principal represents an anonymous user.
-  /// 
+  ///
   /// Example:
   /// ```motoko include=import
   /// let principal = Principal.fromText("un4fu-tqaaa-aaaab-qadjq-cai");
@@ -136,7 +136,7 @@ module {
   public func isAnonymous(p : Principal) : Bool = Prim.blobOfPrincipal p == anonymousPrincipal;
 
   /// Checks if the given principal can control this canister.
-  /// 
+  ///
   /// Example:
   /// ```motoko include=import
   /// let principal = Principal.fromText("un4fu-tqaaa-aaaab-qadjq-cai");
@@ -145,7 +145,7 @@ module {
   public func isController(p : Principal) : Bool = Prim.isController p;
 
   /// Hashes the given principal by hashing its `Blob` representation.
-  /// 
+  ///
   /// Example:
   /// ```motoko include=import
   /// let principal = Principal.fromText("un4fu-tqaaa-aaaab-qadjq-cai");
@@ -156,7 +156,7 @@ module {
   /// General purpose comparison function for `Principal`. Returns the `Order` (
   /// either `#less`, `#equal`, or `#greater`) of comparing `principal1` with
   /// `principal2`.
-  /// 
+  ///
   /// Example:
   /// ```motoko include=import
   /// let principal1 = Principal.fromText("un4fu-tqaaa-aaaab-qadjq-cai");
@@ -179,7 +179,7 @@ module {
 
   /// Equality function for Principal types.
   /// This is equivalent to `principal1 == principal2`.
-  /// 
+  ///
   /// Example:
   /// ```motoko include=import
   /// let principal1 = Principal.fromText("un4fu-tqaaa-aaaab-qadjq-cai");
@@ -187,13 +187,13 @@ module {
   /// ignore Principal.equal(principal1, principal2);
   /// principal1 == principal2 // => true
   /// ```
-  /// 
+  ///
 
-  /// 
+  ///
   /// Example:
   /// ```motoko include=import
   /// import Buffer "mo:base/Buffer";
-  /// 
+  ///
   /// let buffer1 = Buffer.Buffer<Principal>(3);
   /// let buffer2 = Buffer.Buffer<Principal>(3);
   /// Buffer.equal(buffer1, buffer2, Principal.equal) // => true
@@ -204,7 +204,7 @@ module {
 
   /// Inequality function for Principal types.
   /// This is equivalent to `principal1 != principal2`.
-  /// 
+  ///
   /// Example:
   /// ```motoko include=import
   /// let principal1 = Principal.fromText("un4fu-tqaaa-aaaab-qadjq-cai");
@@ -212,7 +212,7 @@ module {
   /// ignore Principal.notEqual(principal1, principal2);
   /// principal1 != principal2 // => false
   /// ```
-  /// 
+  ///
 
   public func notEqual(principal1 : Principal, principal2 : Principal) : Bool {
     principal1 != principal2
@@ -220,7 +220,7 @@ module {
 
   /// "Less than" function for Principal types.
   /// This is equivalent to `principal1 < principal2`.
-  /// 
+  ///
   /// Example:
   /// ```motoko include=import
   /// let principal1 = Principal.fromText("un4fu-tqaaa-aaaab-qadjq-cai");
@@ -228,7 +228,7 @@ module {
   /// ignore Principal.less(principal1, principal2);
   /// principal1 < principal2 // => false
   /// ```
-  /// 
+  ///
 
   public func less(principal1 : Principal, principal2 : Principal) : Bool {
     principal1 < principal2
@@ -236,7 +236,7 @@ module {
 
   /// "Less than or equal to" function for Principal types.
   /// This is equivalent to `principal1 <= principal2`.
-  /// 
+  ///
   /// Example:
   /// ```motoko include=import
   /// let principal1 = Principal.fromText("un4fu-tqaaa-aaaab-qadjq-cai");
@@ -244,7 +244,7 @@ module {
   /// ignore Principal.lessOrEqual(principal1, principal2);
   /// principal1 <= principal2 // => true
   /// ```
-  /// 
+  ///
 
   public func lessOrEqual(principal1 : Principal, principal2 : Principal) : Bool {
     principal1 <= principal2
@@ -252,7 +252,7 @@ module {
 
   /// "Greater than" function for Principal types.
   /// This is equivalent to `principal1 > principal2`.
-  /// 
+  ///
   /// Example:
   /// ```motoko include=import
   /// let principal1 = Principal.fromText("un4fu-tqaaa-aaaab-qadjq-cai");
@@ -260,7 +260,7 @@ module {
   /// ignore Principal.greater(principal1, principal2);
   /// principal1 > principal2 // => false
   /// ```
-  /// 
+  ///
 
   public func greater(principal1 : Principal, principal2 : Principal) : Bool {
     principal1 > principal2
@@ -268,7 +268,7 @@ module {
 
   /// "Greater than or equal to" function for Principal types.
   /// This is equivalent to `principal1 >= principal2`.
-  /// 
+  ///
   /// Example:
   /// ```motoko include=import
   /// let principal1 = Principal.fromText("un4fu-tqaaa-aaaab-qadjq-cai");
@@ -276,7 +276,7 @@ module {
   /// ignore Principal.greaterOrEqual(principal1, principal2);
   /// principal1 >= principal2 // => true
   /// ```
-  /// 
+  ///
 
   public func greaterOrEqual(principal1 : Principal, principal2 : Principal) : Bool {
     principal1 >= principal2

--- a/src/RBTree.mo
+++ b/src/RBTree.mo
@@ -1,19 +1,19 @@
 /// Key-value map implemented as a red-black tree (RBTree) with nodes storing key-value pairs.
-/// 
+///
 /// A red-black tree is a balanced binary search tree ordered by the keys.
-/// 
+///
 /// The tree data structure internally colors each of its nodes either red or black,
 /// and uses this information to balance the tree during the modifying operations.
-/// 
+///
 /// Creation:
 /// Instantiate class `RBTree<K, V>` that provides a map from keys of type `K` to values of type `V`.
-/// 
+///
 /// Example:
 /// ```motoko
 /// import RBTree "mo:base/RBTree";
 /// import Nat "mo:base/Nat";
 /// import Debug "mo:base/Debug";
-/// 
+///
 /// let tree = RBTree.RBTree<Nat, Text>(Nat.compare); // Create a new red-black tree mapping Nat to Text
 /// tree.put(1, "one");
 /// tree.put(2, "two");
@@ -22,21 +22,21 @@
 ///   Debug.print("Entry key=" # debug_show(entry.0) # " value=\"" # entry.1 #"\"");
 /// }
 /// ```
-/// 
+///
 /// :::note Performance
 /// * Runtime: `O(log(n))` worst case cost per insertion, removal, and retrieval operation.
 /// * Heap space: `O(n)` for storing the entire tree.
 /// * Stack space: `O(log(n)) for storing the entire tree.
 /// `n` denotes the number of key-value entries (i.e. nodes) stored in the tree.
 /// :::
-/// 
+///
 /// :::note
 /// Tree insertion, replacement, and removal produce `O(log(n))` garbage objects.
 /// :::
-/// 
+///
 /// :::info Credits
 /// The core of this implementation is derived from:
-/// 
+///
 /// * Ken Friis Larsen's [RedBlackMap.sml](https://github.com/kfl/mosml/blob/master/src/mosmllib/Redblackmap.sml), which itself is based on:
 /// * Stefan Kahrs, "Red-black trees with types", Journal of Functional Programming, 11(4): 425-432 (2001), [version 1 in web appendix](http://www.cs.ukc.ac.uk/people/staff/smk/redblack/rb.html).
 /// :::
@@ -73,21 +73,21 @@ module {
 
   /// A map from keys of type `K` to values of type `V` implemented as a red-black tree.
   /// The entries of key-value pairs are ordered by `compare` function applied to the keys.
-  /// 
+  ///
   /// The class enables imperative usage in object-oriented-style.
   /// However, internally, the class uses a functional implementation.
-  /// 
+  ///
   /// The `compare` function should implement a consistent total order among all possible values of `K` and
   /// for efficiency, only involves `O(1)` runtime costs without space allocation.
-  /// 
+  ///
   /// Example:
   /// ```motoko name=initialize
   /// import RBTree "mo:base/RBTree";
   /// import Nat "mo:base/Nat";
-  /// 
+  ///
   /// let tree = RBTree.RBTree<Nat, Text>(Nat.compare); // Create a map of `Nat` to `Text` using the `Nat.compare` order
   /// ```
-  /// 
+  ///
   /// | Runtime        | Space (Heap) | Space (Stack) |
   /// |----------------|--------------|----------------|
   /// | `O(1)`  | `O(1))`        | `O(1))`    |
@@ -97,8 +97,8 @@ module {
 
     /// Return a snapshot of the internal functional tree representation as sharable data.
     /// The returned tree representation is not affected by subsequent changes of the `RBTree` instance.
-    /// 
-    /// 
+    ///
+    ///
     /// Example:
     /// ```motoko include=initialize
     /// tree.put(1, "one");
@@ -106,10 +106,10 @@ module {
     /// tree.put(2, "second");
     /// RBTree.size(treeSnapshot) // => 1 (Only the first insertion is part of the snapshot.)
     /// ```
-    /// 
+    ///
     /// Useful for storing the state of a tree object as a stable variable, determining its size, pretty-printing, and sharing it across async function calls,
     /// i.e. passing it in async arguments or async results.
-    /// 
+    ///
     /// | Runtime        | Space (Heap) | Space (Stack) |
     /// |----------------|--------------|----------------|
     /// | `O(1)`  | `O(1))`        | `O(1))`    |
@@ -118,20 +118,20 @@ module {
     };
 
     /// Reset the current state of the tree object from a functional tree representation.
-    /// 
+    ///
     /// Example:
     /// ```motoko include=initialize
     /// import Iter "mo:base/Iter";
-    /// 
+    ///
     /// tree.put(1, "one");
     /// let snapshot = tree.share(); // save the current state of the tree object in a snapshot
     /// tree.put(2, "two");
     /// tree.unshare(snapshot); // restore the tree object from the snapshot
     /// Iter.toArray(tree.entries()) // => [(1, "one")]
     /// ```
-    /// 
+    ///
     /// Useful for restoring the state of a tree object from stable data, saved, for example, in a stable variable.
-    /// 
+    ///
     /// | Runtime        | Space (Heap) | Space (Stack) |
     /// |----------------|--------------|----------------|
     /// | `O(1)`  | `O(1))`       | `O(1))`    |
@@ -141,16 +141,16 @@ module {
 
     /// Retrieve the value associated with a given key, if present. Returns `null`, if the key is absent.
     /// The key is searched according to the `compare` function defined on the class instantiation.
-    /// 
+    ///
     /// Example:
     /// ```motoko include=initialize
-    /// 
+    ///
     /// tree.put(1, "one");
     /// tree.put(2, "two");
-    /// 
+    ///
     /// tree.get(1) // => ?"one"
     /// ```
-    /// 
+    ///
     /// | Runtime        | Space (Heap) | Space (Stack) |
     /// |----------------|--------------|----------------|
     /// | `O(log(n))`  | `O(1))` retained + garbage        | `O(log(n))`    |
@@ -160,21 +160,21 @@ module {
 
     /// Replace the value associated with a given key, if the key is present.
     /// Otherwise, if the key does not yet exist, insert the key-value entry.
-    /// 
+    ///
     /// Returns the previous value of the key, if the key already existed.
     /// Otherwise, `null`, if the key did not yet exist before.
-    /// 
+    ///
     /// Example:
     /// ```motoko include=initialize
     /// import Iter "mo:base/Iter";
-    /// 
+    ///
     /// tree.put(1, "old one");
     /// tree.put(2, "two");
-    /// 
+    ///
     /// ignore tree.replace(1, "new one");
     /// Iter.toArray(tree.entries()) // => [(1, "new one"), (2, "two")]
     /// ```
-    /// 
+    ///
     /// | Runtime        | Space (Heap) | Space (Stack) |
     /// |----------------|--------------|----------------|
     /// | `O(log(n))`  | `O(1))` retained + garbage        | `O(log(n))`    |
@@ -185,17 +185,17 @@ module {
     };
 
     /// Insert a key-value entry in the tree. If the key already exists, it overwrites the associated value.
-    /// 
+    ///
     /// Example:
     /// ```motoko include=initialize
     /// import Iter "mo:base/Iter";
-    /// 
+    ///
     /// tree.put(1, "one");
     /// tree.put(2, "two");
     /// tree.put(3, "three");
     /// Iter.toArray(tree.entries()) // now contains three entries
     /// ```
-    /// 
+    ///
     /// | Runtime        | Space (Heap) | Space (Stack) |
     /// |----------------|--------------|----------------|
     /// | `O(log(n))`  | `O(1))` retained + garbage        | `O(log(n))`    |
@@ -207,18 +207,18 @@ module {
     /// Delete the entry associated with a given key, if the key exists.
     /// No effect if the key is absent. Same as `remove(key)` except that it
     /// does not have a return value.
-    /// 
+    ///
     /// Example:
     /// ```motoko include=initialize
     /// import Iter "mo:base/Iter";
-    /// 
+    ///
     /// tree.put(1, "one");
     /// tree.put(2, "two");
-    /// 
+    ///
     /// tree.delete(1);
     /// Iter.toArray(tree.entries()) // => [(2, "two")].
     /// ```
-    /// 
+    ///
     /// | Runtime        | Space (Heap) | Space (Stack) |
     /// |----------------|--------------|----------------|
     /// | `O(log(n))`  | `O(1))` retained + garbage        | `O(log(n))`    |
@@ -229,18 +229,18 @@ module {
 
     /// Remove the entry associated with a given key, if the key exists, and return the associated value.
     /// Returns `null` without any other effect if the key is absent.
-    /// 
+    ///
     /// Example:
     /// ```motoko include=initialize
     /// import Iter "mo:base/Iter";
-    /// 
+    ///
     /// tree.put(1, "one");
     /// tree.put(2, "two");
-    /// 
+    ///
     /// ignore tree.remove(1);
     /// Iter.toArray(tree.entries()) // => [(2, "two")].
     /// ```
-    /// 
+    ///
     /// | Runtime        | Space (Heap) | Space (Stack) |
     /// |----------------|--------------|----------------|
     /// | `O(log(n))`  | `O(1))` retained + garbage        | `O(log(n))`    |
@@ -252,24 +252,24 @@ module {
 
     /// An iterator for the key-value entries of the map, in ascending key order.
     /// The iterator takes a snapshot view of the tree and is not affected by concurrent modifications.
-    /// 
+    ///
     /// Example:
     /// ```motoko include=initialize
     /// import Debug "mo:base/Debug";
-    /// 
+    ///
     /// tree.put(1, "one");
     /// tree.put(2, "two");
     /// tree.put(3, "two");
-    /// 
+    ///
     /// for (entry in tree.entries()) {
     ///   Debug.print("Entry key=" # debug_show(entry.0) # " value=\"" # entry.1 #"\"");
     /// }
-    /// 
+    ///
     /// // Entry key=1 value="one"
     /// // Entry key=2 value="two"
     /// // Entry key=3 value="three"
     /// ```
-    /// 
+    ///
 
     /// | Runtime        | Space (Heap) | Space (Stack) |
     /// |----------------|--------------|----------------|
@@ -278,25 +278,25 @@ module {
 
     /// An iterator for the key-value entries of the map, in descending key order.
     /// The iterator takes a snapshot view of the tree and is not affected by concurrent modifications.
-    /// 
+    ///
     /// Example:
     /// ```motoko include=initialize
     /// import Debug "mo:base/Debug";
-    /// 
+    ///
     /// let tree = RBTree.RBTree<Nat, Text>(Nat.compare);
     /// tree.put(1, "one");
     /// tree.put(2, "two");
     /// tree.put(3, "two");
-    /// 
+    ///
     /// for (entry in tree.entriesRev()) {
     ///   Debug.print("Entry key=" # debug_show(entry.0) # " value=\"" # entry.1 #"\"");
     /// }
-    /// 
+    ///
     /// // Entry key=3 value="three"
     /// // Entry key=2 value="two"
     /// // Entry key=1 value="one"
     /// ```
-    /// 
+    ///
 
     /// | Runtime        | Space (Heap) | Space (Stack) |
     /// |----------------|--------------|----------------|
@@ -309,27 +309,27 @@ module {
 
   /// Get an iterator for the entries of the `tree`, in ascending (`#fwd`) or descending (`#bwd`) order as specified by `direction`.
   /// The iterator takes a snapshot view of the tree and is not affected by concurrent modifications.
-  /// 
+  ///
   /// Example:
   /// ```motoko
   /// import RBTree "mo:base/RBTree";
   /// import Nat "mo:base/Nat";
   /// import Debug "mo:base/Debug";
-  /// 
+  ///
   /// let tree = RBTree.RBTree<Nat, Text>(Nat.compare);
   /// tree.put(1, "one");
   /// tree.put(2, "two");
   /// tree.put(3, "two");
-  /// 
+  ///
   /// for (entry in RBTree.iter(tree.share(), #bwd)) { // backward iteration
   ///   Debug.print("Entry key=" # debug_show(entry.0) # " value=\"" # entry.1 #"\"");
   /// }
-  /// 
+  ///
   /// // Entry key=3 value="three"
   /// // Entry key=2 value="two"
   /// // Entry key=1 value="one"
   /// ```
-  /// 
+  ///
 
   /// | Runtime        | Space (Heap) | Space (Stack) |
   /// |----------------|--------------|----------------|
@@ -384,20 +384,20 @@ module {
   };
 
   /// Determine the size of the tree as the number of key-value entries.
-  /// 
+  ///
   /// Example:
   /// ```motoko
   /// import RBTree "mo:base/RBTree";
   /// import Nat "mo:base/Nat";
-  /// 
+  ///
   /// let tree = RBTree.RBTree<Nat, Text>(Nat.compare);
   /// tree.put(1, "one");
   /// tree.put(2, "two");
   /// tree.put(3, "three");
-  /// 
+  ///
   /// RBTree.size(tree.share()) // 3 entries
   /// ```
-  /// 
+  ///
   /// | Runtime        | Space (Heap) | Space (Stack) |
   /// |----------------|--------------|----------------|
   /// | `O(log(n))`  | `O(1)`         | `O(log(n))`    |

--- a/src/Random.mo
+++ b/src/Random.mo
@@ -1,12 +1,12 @@
 /// A module for obtaining randomness on the Internet Computer (IC).
-/// 
+///
 /// This module provides the fundamentals for user abstractions to build on.
-/// 
+///
 /// Dealing with randomness on a deterministic computing platform, such
 /// as the IC, is intricate. Some basic rules need to be followed by the
 /// user of this module to obtain (and maintain) the benefits of crypto-
 /// graphic randomness:
-/// 
+///
 /// - Cryptographic entropy (randomness source) is only obtainable
 ///   asyncronously in discrete chunks of 256 bits (32-byte sized `Blob`s).
 /// - All bets must be closed *before* entropy is being asked for in
@@ -14,15 +14,15 @@
 /// - This implies that the same entropy (i.e. `Blob`) - or surplus entropy
 ///   not utilised yet - cannot be used for a new round of bets without
 ///   losing the cryptographic guarantees.
-/// 
+///
 /// Concretely, the below class `Finite`, as well as the
 /// `*From` methods risk the carrying-over of state from previous rounds.
 /// These are provided for performance (and convenience) reasons, and need
 /// special care when used. Similar caveats apply for user-defined (pseudo)
 /// random number generators.
-/// 
+///
 /// Usage:
-/// 
+///
 /// ```motoko no-repl
 /// import Random "mo:base/Random";
 /// ```
@@ -36,7 +36,7 @@ module {
   let raw_rand = (actor "aaaaa-aa" : actor { raw_rand : () -> async Blob }).raw_rand;
 
   /// Obtains a full blob (32 bytes) worth of fresh entropy.
-  /// 
+  ///
   /// Example:
   /// ```motoko no-repl
   /// let random = Random.Finite(await Random.blob());
@@ -49,13 +49,13 @@ module {
   /// stated for each method. The uniformity of outcomes is
   /// guaranteed only when the supplied entropy is originally obtained
   /// by the `blob()` call, and is never reused.
-  /// 
+  ///
   /// Example:
   /// ```motoko no-repl
   /// import Random "mo:base/Random";
-  /// 
+  ///
   /// let random = Random.Finite(await Random.blob());
-  /// 
+  ///
   /// let seed : Blob = "\14\C9\72\09\03\D4\D5\72\82\95\E5\43\AF\FA\A9\44\49\2F\25\56\13\F3\6E\C7\B0\87\DC\76\08\69\14\CF";
   /// let seedRandom = Random.Finite(seed);
   /// ```
@@ -64,7 +64,7 @@ module {
 
     /// Uniformly distributes outcomes in the numeric range [0 .. 255].
     /// Consumes 1 byte of entropy.
-    /// 
+    ///
     /// Example:
     /// ```motoko no-repl
     /// let seed : Blob = "\14\C9\72\09\03\D4\D5\72\82\95\E5\43\AF\FA\A9\44\49\2F\25\56\13\F3\6E\C7\B0\87\DC\76\08\69\14\CF";
@@ -99,7 +99,7 @@ module {
 
     /// Simulates a coin toss. Both outcomes have equal probability.
     /// Consumes 1 bit of entropy (amortised).
-    /// 
+    ///
     /// Example:
     /// ```motoko no-repl
     /// let seed : Blob = "\14\C9\72\09\03\D4\D5\72\82\95\E5\43\AF\FA\A9\44\49\2F\25\56\13\F3\6E\C7\B0\87\DC\76\08\69\14\CF";
@@ -112,7 +112,7 @@ module {
 
     /// Uniformly distributes outcomes in the numeric range [0 .. 2^p - 1].
     /// Consumes ⌈p/8⌉ bytes of entropy.
-    /// 
+    ///
     /// Example:
     /// ```motoko no-repl
     /// let seed : Blob = "\14\C9\72\09\03\D4\D5\72\82\95\E5\43\AF\FA\A9\44\49\2F\25\56\13\F3\6E\C7\B0\87\DC\76\08\69\14\CF";
@@ -139,7 +139,7 @@ module {
 
     /// Counts the number of heads in `n` fair coin tosses.
     /// Consumes ⌈n/8⌉ bytes of entropy.
-    /// 
+    ///
     /// Example:
     /// ```motoko no-repl
     /// let seed : Blob = "\14\C9\72\09\03\D4\D5\72\82\95\E5\43\AF\FA\A9\44\49\2F\25\56\13\F3\6E\C7\B0\87\DC\76\08\69\14\CF";
@@ -167,7 +167,7 @@ module {
 
   /// Distributes outcomes in the numeric range [0 .. 255].
   /// Seed blob must contain at least a byte.
-  /// 
+  ///
   /// Example:
   /// ```motoko no-repl
   /// let seed : Blob = "\14\C9\72\09\03\D4\D5\72\82\95\E5\43\AF\FA\A9\44\49\2F\25\56\13\F3\6E\C7\B0\87\DC\76\08\69\14\CF";
@@ -182,7 +182,7 @@ module {
 
   /// Simulates a coin toss.
   /// Seed blob must contain at least a byte.
-  /// 
+  ///
   /// Example:
   /// ```motoko no-repl
   /// let seed : Blob = "\14\C9\72\09\03\D4\D5\72\82\95\E5\43\AF\FA\A9\44\49\2F\25\56\13\F3\6E\C7\B0\87\DC\76\08\69\14\CF";
@@ -197,7 +197,7 @@ module {
 
   /// Distributes outcomes in the numeric range [0 .. 2^p - 1].
   /// Seed blob must contain at least ((p+7) / 8) bytes.
-  /// 
+  ///
   /// Example:
   /// ```motoko no-repl
   /// let seed : Blob = "\14\C9\72\09\03\D4\D5\72\82\95\E5\43\AF\FA\A9\44\49\2F\25\56\13\F3\6E\C7\B0\87\DC\76\08\69\14\CF";
@@ -230,7 +230,7 @@ module {
 
   /// Counts the number of heads in `n` coin tosses.
   /// Seed blob must contain at least ((n+7) / 8) bytes.
-  /// 
+  ///
   /// Example:
   /// ```motoko no-repl
   /// let seed : Blob = "\14\C9\72\09\03\D4\D5\72\82\95\E5\43\AF\FA\A9\44\49\2F\25\56\13\F3\6E\C7\B0\87\DC\76\08\69\14\CF";

--- a/src/Region.mo
+++ b/src/Region.mo
@@ -1,49 +1,49 @@
 /// Byte-level access to isolated, (virtual) stable memory _regions_.
-/// 
+///
 /// This is a moderately lightweight abstraction over IC _stable memory_ and supports persisting
 /// regions of binary data across Motoko upgrades.
 /// Use of this module is fully compatible with Motoko's use of
 /// _stable variables_, whose persistence mechanism also uses (real) IC stable memory internally, but does not interfere with this API.
 /// It is also fully compatible with existing uses of the `ExperimentalStableMemory` library, which has a similar interface, but,
 /// only supported a single memory region, without isolation between different applications.
-/// 
+///
 /// The `Region` type is stable and can be used in stable data structures.
-/// 
+///
 /// A new, empty `Region` is allocated using function `new()`.
-/// 
+///
 /// Regions are stateful objects and can be distinguished by the numeric identifier returned by function `id(region)`.
 /// Every region owns an initially empty, but growable sequence of virtual IC stable memory pages.
 /// The current size, in pages, of a region is returned by function `size(region)`.
 /// The size of a region determines the range, [ 0, ..., size(region)*2^16 ), of valid byte-offsets into the region; these offsets are used as the source and destination of `load`/`store` operations on the region.
-/// 
+///
 /// Memory is allocated to a region, using function `grow(region, pages)`, sequentially and on demand, in units of 64KiB logical pages, starting with 0 allocated pages.
 /// A call to `grow` may succeed, returning the previous size of the region, or fail, returning a sentinel value. New pages are zero initialized.
-/// 
+///
 /// A size of a region can only grow and never shrink.
 /// In addition, the stable memory pages allocated to a region will *not* be reclaimed by garbage collection, even
 /// if the region object itself becomes unreachable.
-/// 
+///
 /// Growth is capped by a soft limit on physical page count controlled by compile-time flag
 /// `--max-stable-pages <n>` (the default is 65536, or 4GiB).
-/// 
+///
 /// Each `load` operation loads from region relative byte address `offset` in little-endian
 /// format using the natural bit-width of the type in question.
 /// The operation traps if attempting to read beyond the current region size.
-/// 
+///
 /// Each `store` operation stores to region relative byte address `offset` in little-endian format using the natural bit-width of the type in question.
 /// The operation traps if attempting to write beyond the current region size.
-/// 
+///
 /// Text values can be handled by using `Text.decodeUtf8` and `Text.encodeUtf8`, in conjunction with `loadBlob` and `storeBlob`.
-/// 
+///
 /// The current region allocation and region contents are preserved across upgrades.
-/// 
+///
 /// NB: The IC's actual stable memory size (`ic0.stable_size`) may exceed the
 /// total page size reported by summing all regions sizes.
 /// This (and the cap on growth) are to accommodate Motoko's stable variables and bookkeeping for regions.
 /// Applications that plan to use Motoko stable variables sparingly or not at all can
 /// increase `--max-stable-pages` as desired, approaching the IC maximum (initially 8GiB, then 32Gib, currently 64Gib).
 /// All applications should reserve at least one page for stable variable data, even when no stable variables are used.
-/// 
+///
 /// Usage:
 /// ```motoko no-repl
 /// import Region "mo:base/Region";
@@ -58,9 +58,9 @@ module {
   public type Region = Prim.Types.Region;
 
   /// Allocate a new, isolated Region of size 0.
-  /// 
+  ///
   /// Example:
-  /// 
+  ///
   /// ```motoko no-repl
   /// let region = Region.new();
   /// assert Region.size(region) == 0;
@@ -72,9 +72,9 @@ module {
   /// NB: Regions returned by `new()` are numbered from 16
   /// (regions 0..15 are currently reserved for internal use).
   /// Allocate a new, isolated Region of size 0.
-  /// 
+  ///
   /// Example:
-  /// 
+  ///
   /// ```motoko no-repl
   /// let region = Region.new();
   /// assert Region.id(region) == 16;
@@ -86,7 +86,7 @@ module {
   /// Initially `0`.
   /// Preserved across upgrades, together with contents of allocated
   /// stable memory.
-  /// 
+  ///
   /// Example:
   /// ```motoko no-repl
   /// let region = Region.new();
@@ -104,11 +104,11 @@ module {
   /// Every new page is zero-initialized, containing byte 0x00 at every offset.
   /// Function `grow` is capped by a soft limit on `size` controlled by compile-time flag
   ///  `--max-stable-pages <n>` (the default is 65536, or 4GiB).
-  /// 
+  ///
   /// Example:
   /// ```motoko no-repl
   /// import Error "mo:base/Error";
-  /// 
+  ///
   /// let region = Region.new();
   /// let beforeSize = Region.grow(region, 10);
   /// if (beforeSize == 0xFFFF_FFFF_FFFF_FFFF) {
@@ -121,7 +121,7 @@ module {
 
   /// Within `region`, load a `Nat8` value from `offset`.
   /// Traps on an out-of-bounds access.
-  /// 
+  ///
   /// Example:
   /// ```motoko no-repl
   /// let region = Region.new();
@@ -134,7 +134,7 @@ module {
 
   /// Within `region`, store a `Nat8` value at `offset`.
   /// Traps on an out-of-bounds access.
-  /// 
+  ///
   /// Example:
   /// ```motoko no-repl
   /// let region = Region.new();
@@ -147,7 +147,7 @@ module {
 
   /// Within `region`, load a `Nat16` value from `offset`.
   /// Traps on an out-of-bounds access.
-  /// 
+  ///
   /// Example:
   /// ```motoko no-repl
   /// let region = Region.new();
@@ -160,7 +160,7 @@ module {
 
   /// Within `region`, store a `Nat16` value at `offset`.
   /// Traps on an out-of-bounds access.
-  /// 
+  ///
   /// Example:
   /// ```motoko no-repl
   /// let region = Region.new();
@@ -173,7 +173,7 @@ module {
 
   /// Within `region`, load a `Nat32` value from `offset`.
   /// Traps on an out-of-bounds access.
-  /// 
+  ///
   /// Example:
   /// ```motoko no-repl
   /// let region = Region.new();
@@ -186,7 +186,7 @@ module {
 
   /// Within `region`, store a `Nat32` value at `offset`.
   /// Traps on an out-of-bounds access.
-  /// 
+  ///
   /// Example:
   /// ```motoko no-repl
   /// let region = Region.new();
@@ -199,7 +199,7 @@ module {
 
   /// Within `region`, load a `Nat64` value from `offset`.
   /// Traps on an out-of-bounds access.
-  /// 
+  ///
   /// Example:
   /// ```motoko no-repl
   /// let region = Region.new();
@@ -212,7 +212,7 @@ module {
 
   /// Within `region`, store a `Nat64` value at `offset`.
   /// Traps on an out-of-bounds access.
-  /// 
+  ///
   /// Example:
   /// ```motoko no-repl
   /// let region = Region.new();
@@ -225,7 +225,7 @@ module {
 
   /// Within `region`, load a `Int8` value from `offset`.
   /// Traps on an out-of-bounds access.
-  /// 
+  ///
   /// Example:
   /// ```motoko no-repl
   /// let region = Region.new();
@@ -238,7 +238,7 @@ module {
 
   /// Within `region`, store a `Int8` value at `offset`.
   /// Traps on an out-of-bounds access.
-  /// 
+  ///
   /// Example:
   /// ```motoko no-repl
   /// let region = Region.new();
@@ -251,7 +251,7 @@ module {
 
   /// Within `region`, load a `Int16` value from `offset`.
   /// Traps on an out-of-bounds access.
-  /// 
+  ///
   /// Example:
   /// ```motoko no-repl
   /// let region = Region.new();
@@ -264,7 +264,7 @@ module {
 
   /// Within `region`, store a `Int16` value at `offset`.
   /// Traps on an out-of-bounds access.
-  /// 
+  ///
   /// Example:
   /// ```motoko no-repl
   /// let region = Region.new();
@@ -277,7 +277,7 @@ module {
 
   /// Within `region`, load a `Int32` value from `offset`.
   /// Traps on an out-of-bounds access.
-  /// 
+  ///
   /// Example:
   /// ```motoko no-repl
   /// let region = Region.new();
@@ -290,7 +290,7 @@ module {
 
   /// Within `region`, store a `Int32` value at `offset`.
   /// Traps on an out-of-bounds access.
-  /// 
+  ///
   /// Example:
   /// ```motoko no-repl
   /// let region = Region.new();
@@ -303,7 +303,7 @@ module {
 
   /// Within `region`, load a `Int64` value from `offset`.
   /// Traps on an out-of-bounds access.
-  /// 
+  ///
   /// Example:
   /// ```motoko no-repl
   /// let region = Region.new();
@@ -316,7 +316,7 @@ module {
 
   /// Within `region`, store a `Int64` value at `offset`.
   /// Traps on an out-of-bounds access.
-  /// 
+  ///
   /// Example:
   /// ```motoko no-repl
   /// let region = Region.new();
@@ -329,7 +329,7 @@ module {
 
   /// Within `region`, loads a `Float` value from the given `offset`.
   /// Traps on an out-of-bounds access.
-  /// 
+  ///
   /// Example:
   /// ```motoko no-repl
   /// let region = Region.new();
@@ -342,7 +342,7 @@ module {
 
   /// Within `region`, store float `value` at the given `offset`.
   /// Traps on an out-of-bounds access.
-  /// 
+  ///
   /// Example:
   /// ```motoko no-repl
   /// let region = Region.new();
@@ -355,11 +355,11 @@ module {
 
   /// Within `region,` load `size` bytes starting from `offset` as a `Blob`.
   /// Traps on an out-of-bounds access.
-  /// 
+  ///
   /// Example:
   /// ```motoko no-repl
   /// import Blob "mo:base/Blob";
-  /// 
+  ///
   /// let region = Region.new();
   /// let offset = 0;
   /// let value = Blob.fromArray([1, 2, 3]);
@@ -371,11 +371,11 @@ module {
 
   /// Within `region, write `blob.size()` bytes of `blob` beginning at `offset`.
   /// Traps on an out-of-bounds access.
-  /// 
+  ///
   /// Example:
   /// ```motoko no-repl
   /// import Blob "mo:base/Blob";
-  /// 
+  ///
   /// let region = Region.new();
   /// let offset = 0;
   /// let value = Blob.fromArray([1, 2, 3]);

--- a/src/Result.mo
+++ b/src/Result.mo
@@ -9,9 +9,9 @@ module {
   /// `Result<Ok, Err>` is the type used for returning and propagating errors. It
   /// is a type with the variants, `#ok(Ok)`, representing success and containing
   /// a value, and `#err(Err)`, representing error and containing an error value.
-  /// 
+  ///
   /// The simplest way of working with `Result`s is to pattern match on them:
-  /// 
+  ///
   /// For example, given a function `createUser(user : User) : Result<Id, String>`
   /// where `String` is an error message we could use it like so:
   /// ```motoko no-repl
@@ -70,13 +70,13 @@ module {
   /// type Result<T,E> = Result.Result<T, E>;
   /// func largerThan10(x : Nat) : Result<Nat, Text> =
   ///   if (x > 10) { #ok(x) } else { #err("Not larger than 10.") };
-  /// 
+  ///
   /// func smallerThan20(x : Nat) : Result<Nat, Text> =
   ///   if (x < 20) { #ok(x) } else { #err("Not smaller than 20.") };
-  /// 
+  ///
   /// func between10And20(x : Nat) : Result<Nat, Text> =
   ///   Result.chain(largerThan10(x), smallerThan20);
-  /// 
+  ///
   /// assert(between10And20(15) == #ok(15));
   /// assert(between10And20(9) == #err("Not larger than 10."));
   /// assert(between10And20(21) == #err("Not smaller than 20."));
@@ -92,7 +92,7 @@ module {
   };
 
   /// Flattens a nested `Result`.
-  /// 
+  ///
   /// ```motoko
   /// import Result "mo:base/Result";
   /// assert(Result.flatten<Nat, Text>(#ok(#ok(10))) == #ok(10));
@@ -158,7 +158,7 @@ module {
 
   /// Applies a function to a successful value, but discards the result. Use
   /// `iterate` if you're only interested in the side effect `f` produces.
-  /// 
+  ///
   /// ```motoko
   /// import Result "mo:base/Result";
   /// var counter : Nat = 0;

--- a/src/Stack.mo
+++ b/src/Stack.mo
@@ -1,11 +1,11 @@
 /// Class `Stack<X>` provides a minimal LIFO stack of elements of type `X`.
-/// 
+///
 /// See library `Deque` for mixed LIFO/FIFO behavior.
-/// 
+///
 /// Example:
 /// ```motoko name=initialize
 /// import Stack "mo:base/Stack";
-/// 
+///
 /// let stack = Stack.Stack<Nat>(); // create a stack
 /// ```
 /// | Runtime   | Space     |
@@ -21,7 +21,7 @@ module {
     var stack : List.List<T> = List.nil<T>();
 
     /// Push an element on the top of the stack.
-    /// 
+    ///
     /// Example:
     /// ```motoko include=initialize
     /// stack.push(1);
@@ -37,12 +37,12 @@ module {
     };
 
     /// True when the stack is empty and false otherwise.
-    /// 
+    ///
     /// Example:
     /// ```motoko include=initialize
     /// stack.isEmpty();
     /// ```
-    /// 
+    ///
     /// | Runtime   | Space     |
     /// |-----------|-----------|
     /// | `O(1)` | `O(1)` |
@@ -51,7 +51,7 @@ module {
     };
 
     /// Return (without removing) the top element, or return null if the stack is empty.
-    /// 
+    ///
     /// Example:
     /// ```motoko include=initialize
     /// stack.push(1);
@@ -59,7 +59,7 @@ module {
     /// stack.push(3);
     /// stack.peek();
     /// ```
-    /// 
+    ///
     /// | Runtime   | Space     |
     /// |-----------|-----------|
     /// | `O(1)` | `O(1)` |
@@ -71,14 +71,14 @@ module {
     };
 
     /// Remove and return the top element, or return null if the stack is empty.
-    /// 
+    ///
     /// Example:
     /// ```motoko include=initialize
     /// stack.push(1);
     /// ignore stack.pop();
     /// stack.isEmpty();
     /// ```
-    /// 
+    ///
     /// | Runtime   | Space     |
     /// |-----------|-----------|
     /// | `O(1)` | `O(1)` |

--- a/src/Text.mo
+++ b/src/Text.mo
@@ -1,22 +1,22 @@
 /// Utility functions for `Text` values.
-/// 
+///
 /// A `Text` value represents human-readable text as a sequence of characters of type `Char`.
-/// 
+///
 /// ```motoko
 /// let text = "Hello!";
 /// let size = text.size(); // 6
 /// let iter = text.chars(); // iterator ('H', 'e', 'l', 'l', 'o', '!')
 /// let concat = text # " 👋"; // "Hello! 👋"
 /// ```
-/// 
+///
 /// The `"mo:base/Text"` module defines additional operations on `Text` values.
-/// 
+///
 /// Import the module from the base library:
-/// 
+///
 /// ```motoko name=import
 /// import Text "mo:base/Text";
 /// ```
-/// 
+///
 /// :::note
 /// `Text` values are represented as ropes of UTF-8 character sequences with O(1) concatenation.
 /// :::
@@ -31,7 +31,7 @@ import Prim "mo:⛔";
 module {
 
   /// The type corresponding to primitive `Text` values.
-  /// 
+  ///
   /// ```motoko
   /// let hello = "Hello!";
   /// let emoji = "👋";
@@ -40,41 +40,41 @@ module {
   public type Text = Prim.Types.Text;
 
   /// Converts the given `Char` to a `Text` value.
-  /// 
+  ///
   /// ```motoko include=import
   /// let text = Text.fromChar('A'); // "A"
   /// ```
   public let fromChar : (c : Char) -> Text = Prim.charToText;
 
   /// Converts the given `[Char]` to a `Text` value.
-  /// 
+  ///
   /// ```motoko include=import
   /// let text = Text.fromArray(['A', 'v', 'o', 'c', 'a', 'd', 'o']); // "Avocado"
   /// ```
-  /// 
+  ///
 /// | Runtime   | Space     |
 /// |-----------|-----------|
 /// | O(a.size()) | O(a.size()) |
   public func fromArray(a : [Char]) : Text = fromIter(a.vals());
 
   /// Converts the given `[var Char]` to a `Text` value.
-  /// 
+  ///
   /// ```motoko include=import
   /// let text = Text.fromVarArray([var 'E', 'g', 'g', 'p', 'l', 'a', 'n', 't']); // "Eggplant"
   /// ```
-  /// 
+  ///
 /// | Runtime   | Space     |
 /// |-----------|-----------|
 /// | O(a.size()) | O(a.size()) |
   public func fromVarArray(a : [var Char]) : Text = fromIter(a.vals());
 
   /// Iterates over each `Char` value in the given `Text`.
-  /// 
+  ///
   /// Equivalent to calling the `t.chars()` method where `t` is a `Text` value.
-  /// 
+  ///
   /// ```motoko include=import
   /// import { print } "mo:base/Debug";
-  /// 
+  ///
   /// for (c in Text.toIter("abc")) {
   ///   print(debug_show c);
   /// }
@@ -82,13 +82,13 @@ module {
   public func toIter(t : Text) : Iter.Iter<Char> = t.chars();
 
   /// Creates a new `Array` containing characters of the given `Text`.
-  /// 
+  ///
   /// Equivalent to `Iter.toArray(t.chars())`.
-  /// 
+  ///
   /// ```motoko include=import
   /// assert Text.toArray("Café") == ['C', 'a', 'f', 'é'];
   /// ```
-  /// 
+  ///
 /// | Runtime   | Space     |
 /// |-----------|-----------|
 /// | O(t.size()) | O(t.size()) |
@@ -108,13 +108,13 @@ module {
   };
 
   /// Creates a new mutable `Array` containing characters of the given `Text`.
-  /// 
+  ///
   /// Equivalent to `Iter.toArrayMut(t.chars())`.
-  /// 
+  ///
   /// ```motoko include=import
   /// assert Text.toVarArray("Café") == [var 'C', 'a', 'f', 'é'];
   /// ```
-  /// 
+  ///
 /// | Runtime   | Space     |
 /// |-----------|-----------|
 /// | O(t.size()) | O(t.size()) |
@@ -133,7 +133,7 @@ module {
   };
 
   /// Creates a `Text` value from a `Char` iterator.
-  /// 
+  ///
   /// ```motoko include=import
   /// let text = Text.fromIter(['a', 'b', 'c'].vals()); // "abc"
   /// ```
@@ -151,7 +151,7 @@ module {
   /// fromList(?('H', ?('e', ?('l', ?('l', ?('o', null))))));
   /// // => "Hello"
   /// ```
-  /// 
+  ///
 /// | Runtime   | Space     |
 /// |-----------|-----------|
 /// | O(size cs) | O(size cs) |
@@ -163,7 +163,7 @@ module {
   /// toList("Hello");
   /// // => ?('H', ?('e', ?('l', ?('l', ?('o', null)))))
   /// ```
-  /// 
+  ///
 /// | Runtime   | Space     |
 /// |-----------|-----------|
 /// | O(t.size()) | O(t.size()) |
@@ -176,20 +176,20 @@ module {
   };
 
   /// Returns the number of characters in the given `Text`.
-  /// 
+  ///
   /// Equivalent to calling `t.size()` where `t` is a `Text` value.
-  /// 
+  ///
   /// ```motoko include=import
   /// let size = Text.size("abc"); // 3
   /// ```
   public func size(t : Text) : Nat { t.size() };
 
   /// Returns a hash obtained by using the `djb2` algorithm ([more details](http://www.cse.yorku.ca/~oz/hash.html)).
-  /// 
+  ///
   /// ```motoko include=import
   /// let hash = Text.hash("abc");
   /// ```
-  /// 
+  ///
   /// :::info
   /// This algorithm is intended for use in data structures rather than as a cryptographic hash function.
   /// :::
@@ -203,7 +203,7 @@ module {
   };
 
   /// Returns `t1 # t2`, where `#` is the `Text` concatenation operator.
-  /// 
+  ///
   /// ```motoko include=import
   /// let a = "Hello";
   /// let b = "There";
@@ -232,10 +232,10 @@ module {
   public func greaterOrEqual(t1 : Text, t2 : Text) : Bool { t1 >= t2 };
 
   /// Compares `t1` and `t2` lexicographically.
-  /// 
+  ///
   /// ```motoko include=import
   /// import { print } "mo:base/Debug";
-  /// 
+  ///
   /// print(debug_show Text.compare("abc", "abc")); // #equal
   /// print(debug_show Text.compare("abc", "def")); // #less
   /// print(debug_show Text.compare("abc", "ABC")); // #greater
@@ -268,7 +268,7 @@ module {
   };
 
   /// Join an iterator of `Text` values with a given delimiter.
-  /// 
+  ///
   /// ```motoko include=import
   /// let joined = Text.join(", ", ["a", "b", "c"].vals()); // "a, b, c"
   /// ```
@@ -299,7 +299,7 @@ module {
   };
 
   /// Applies a function to each character in a `Text` value, returning the concatenated `Char` results.
-  /// 
+  ///
   /// ```motoko include=import
   /// // Replace all occurrences of '?' with '!'
   /// let result = Text.map("Motoko?", func(c) {
@@ -316,7 +316,7 @@ module {
   };
 
   /// Returns the result of applying `f` to each character in `ts`, concatenating the intermediate text values.
-  /// 
+  ///
   /// ```motoko include=import
   /// // Replace all occurrences of '?' with "!!"
   /// let result = Text.translate("Motoko?", func(c) {
@@ -333,13 +333,13 @@ module {
   };
 
   /// A pattern `p` describes a sequence of characters. A pattern has one of the following forms:
-  /// 
+  ///
   /// * `#char c` matches the single character sequence, `c`.
   /// * `#text t` matches multi-character text sequence `t`.
   /// * `#predicate p` matches any single character sequence `c` satisfying predicate `p(c)`.
-  /// 
+  ///
   /// A _match_ for `p` is any sequence of characters matching the pattern `p`.
-  /// 
+  ///
   /// ```motoko include=import
   /// let charPattern = #char 'A';
   /// let textPattern = #text "phrase";
@@ -470,9 +470,9 @@ module {
   };
 
   /// Splits the input `Text` with the specified `Pattern`.
-  /// 
+  ///
   /// Two fields are separated by exactly one match.
-  /// 
+  ///
   /// ```motoko include=import
   /// let words = Text.split("This is a sentence.", #char ' ');
   /// Text.join("|", words) // "This|is|a|sentence."
@@ -535,7 +535,7 @@ module {
   /// Returns a sequence of tokens from the input `Text` delimited by the specified `Pattern`, derived from start to end.
   /// A "token" is a non-empty maximal subsequence of `t` not containing a match for pattern `p`.
   /// Two tokens may be separated by one or more matches of `p`.
-  /// 
+  ///
   /// ```motoko include=import
   /// let tokens = Text.tokens("this needs\n an   example", #predicate (func(c) { c == ' ' or c == '\n' }));
   /// Text.join("|", tokens) // "this|needs|an|example"
@@ -553,7 +553,7 @@ module {
   };
 
   /// Returns `true` if the input `Text` contains a match for the specified `Pattern`.
-  /// 
+  ///
   /// ```motoko include=import
   /// Text.contains("Motoko", #text "oto") // true
   /// ```
@@ -582,7 +582,7 @@ module {
   };
 
   /// Returns `true` if the input `Text` starts with a prefix matching the specified `Pattern`.
-  /// 
+  ///
   /// ```motoko include=import
   /// Text.startsWith("Motoko", #text "Mo") // true
   /// ```
@@ -596,7 +596,7 @@ module {
   };
 
   /// Returns `true` if the input `Text` ends with a suffix matching the specified `Pattern`.
-  /// 
+  ///
   /// ```motoko include=import
   /// Text.endsWith("Motoko", #char 'o') // true
   /// ```
@@ -619,7 +619,7 @@ module {
   };
 
   /// Returns the input text `t` with all matches of pattern `p` replaced by text `r`.
-  /// 
+  ///
   /// ```motoko include=import
   /// let result = Text.replace("abcabc", #char 'a', "A"); // "AbcAbc"
   /// ```
@@ -660,7 +660,7 @@ module {
 
   /// Strips one occurrence of the given `Pattern` from the beginning of the input `Text`.
   /// If you want to remove multiple instances of the pattern, use `Text.trimStart()` instead.
-  /// 
+  ///
   /// ```motoko include=import
   /// // Try to strip a nonexistent character
   /// let none = Text.stripStart("abc", #char '-'); // null
@@ -680,7 +680,7 @@ module {
 
   /// Strips one occurrence of the given `Pattern` from the end of the input `Text`.
   /// If you want to remove multiple instances of the pattern, use `Text.trimEnd()` instead.
-  /// 
+  ///
   /// ```motoko include=import
   /// // Try to strip a nonexistent character
   /// let none = Text.stripEnd("xyz", #char '-'); // null
@@ -707,7 +707,7 @@ module {
 
   /// Trims the given `Pattern` from the start of the input `Text`.
   /// If you only want to remove a single instance of the pattern, use `Text.stripStart()` instead.
-  /// 
+  ///
   /// ```motoko include=import
   /// let trimmed = Text.trimStart("---abc", #char '-'); // "abc"
   /// ```
@@ -742,7 +742,7 @@ module {
 
   /// Trims the given `Pattern` from the end of the input `Text`.
   /// If you only want to remove a single instance of the pattern, use `Text.stripEnd()` instead.
-  /// 
+  ///
   /// ```motoko include=import
   /// let trimmed = Text.trimEnd("xyz---", #char '-'); // "xyz"
   /// ```
@@ -774,7 +774,7 @@ module {
   };
 
   /// Trims the given `Pattern` from both the start and end of the input `Text`.
-  /// 
+  ///
   /// ```motoko include=import
   /// let trimmed = Text.trim("---abcxyz---", #char '-'); // "abcxyz"
   /// ```
@@ -823,10 +823,10 @@ module {
   };
 
   /// Compares `t1` and `t2` using the provided character-wise comparison function.
-  /// 
+  ///
   /// ```motoko include=import
   /// import Char "mo:base/Char";
-  /// 
+  ///
   /// Text.compareWith("abc", "ABC", func(c1, c2) { Char.compare(c1, c2) }) // #greater
   /// ```
   public func compareWith(
@@ -852,7 +852,7 @@ module {
   };
 
   /// Returns a UTF-8 encoded `Blob` from the given `Text`.
-  /// 
+  ///
   /// ```motoko include=import
   /// let blob = Text.encodeUtf8("Hello");
   /// ```
@@ -860,18 +860,18 @@ module {
 
   /// Tries to decode the given `Blob` as UTF-8.
   /// Returns `null` if the blob is not valid UTF-8.
-  /// 
+  ///
   /// ```motoko include=import
   /// let text = Text.decodeUtf8("\48\65\6C\6C\6F"); // ?"Hello"
   /// ```
   public let decodeUtf8 : Blob -> ?Text = Prim.decodeUtf8;
 
   /// Returns the text argument in lowercase.
-  /// 
+  ///
   /// :::warning Compliance
   /// Unicode compliant only when compiled, not interpreted.
   /// :::
-  /// 
+  ///
   /// ```motoko include=import
   /// let text = Text.toLowercase("Good Day"); // ?"good day"
   /// ```
@@ -881,7 +881,7 @@ module {
   /// :::warning Compliance
   /// Unicode compliant only when compiled, not interpreted.
   /// :::
-  /// 
+  ///
   /// ```motoko include=import
   /// let text = Text.toUppercase("Good Day"); // ?"GOOD DAY"
   /// ```

--- a/src/Time.mo
+++ b/src/Time.mo
@@ -1,3 +1,4 @@
+/// System time
 
 import Prim "mo:⛔";
 module {
@@ -6,23 +7,23 @@ module {
   public type Time = Int;
 
   /// Current system time given as nanoseconds since 1970-01-01. The system guarantees that:
-  /// 
+  ///
   /// * The time, as observed by the canister smart contract, is monotonically increasing, even across canister upgrades.
   /// * Within an invocation of one entry point, the time is constant.
-  /// 
+  ///
   /// The system times of different canisters are unrelated, and calls from one canister to another may appear to travel "backwards in time"
-  /// 
+  ///
   /// :::note Accuracy guarantee
   /// While an implementation will likely try to keep the system time close to the real time, this is not formally guaranteed.
   /// :::
   public let now : () -> Time = func() : Int = Prim.nat64ToNat(Prim.time());
-  /// 
+  ///
   /// The following example illustrates using the system time:
-  /// 
+  ///
   /// ```motoko
   /// import Int = "mo:base/Int";
   /// import Time = "mo:base/Time";
-  /// 
+  ///
   /// actor {
   ///   var lastTime = Time.now();
   ///   public func greet(name : Text) : async Text {

--- a/src/Timer.mo
+++ b/src/Timer.mo
@@ -1,40 +1,40 @@
 /// Timers for one-off or periodic tasks. Applicable as part of the default mechanism.
-/// 
+///
 /// :::note Timer resolution
-/// 
+///
 /// The resolution of the timers is in the order of the block rate,
 /// so durations should be chosen well above that. For frequent
 /// canister wake-ups the heartbeat mechanism should be considered.
 /// :::
-/// 
+///
 /// :::note Overriding system function
-/// 
+///
 /// The functionality described below is enabled only when the actor does not override it by declaring an explicit `system func timer`.
 /// :::
-/// 
+///
 /// :::note Upgrade persistence
-/// 
+///
 /// Timers are _not_ persisted across upgrades. One possible strategy
 /// to re-establish timers after an upgrade is to walk stable variables
 /// in the `post_upgrade` hook and distill necessary timer information
 /// from there.
 /// :::
-/// 
+///
 /// :::note Security warning
-/// 
+///
 /// Basing security (e.g. access control) on timers is almost always the wrong choice.
 /// Be sure to inform yourself about state-of-the-art dApp security.
 /// If you _must use_ timers for security controls, be sure to consider reentrancy issues,
 /// and the vanishing of timers on upgrades and reinstalls.
 /// :::
-/// 
+///
 /// :::note Further information
-/// 
+///
 /// [Further usage information for timers](https://internetcomputer.org/docs/current/developer-docs/backend/periodic-tasks#timers-library-limitations).
 /// :::
-/// 
+///
 /// :::note Compilation flag
-/// 
+///
 /// If `moc` is invoked with `-no-timer`, the importing will fail.
 /// :::
 import { setTimer = setTimerNano; cancelTimer = cancel } = "mo:⛔";
@@ -54,7 +54,7 @@ module {
 
   /// Installs a one-off timer that upon expiration after given duration `d`
   /// executes the future `job()`.
-  /// 
+  ///
   /// ```motoko no-repl
   /// let now = Time.now();
   /// let thirtyMinutes = 1_000_000_000 * 60 * 30;
@@ -69,11 +69,11 @@ module {
 
   /// Installs a recurring timer that upon expiration after given duration `d`
   /// executes the future `job()` and reinserts itself for another expiration.
-  /// 
+  ///
   /// :::info
   /// A duration of 0 will only expire once.
   /// :::
-  /// 
+  ///
   /// ```motoko no-repl
   /// func checkAndWaterPlants() : async () {
   ///   // ...
@@ -86,7 +86,7 @@ module {
 
   /// Cancels a still active timer with `(id : TimerId)`. For expired timers
   /// and not recognized `id`s nothing happens.
-  /// 
+  ///
   /// ```motoko no-repl
   /// func deleteAppointment(appointment : Appointment) {
   ///   cancelTimer (appointment.reminder);

--- a/src/Trie.mo
+++ b/src/Trie.mo
@@ -1,39 +1,39 @@
 /// Functional key-value hash map.
-/// 
+///
 /// Provides an applicative (purely functional) hash map, called a *trie*, where each operation returns a new version of the structure without mutating the original.
-/// 
+///
 /// Operations use `Key` records that group the key value with its precomputed hash.
-/// 
+///
 /// For imperative or object-oriented alternatives, see [`TrieMap`](../TrieMap) or [`HashMap`](../HashMap).
-/// 
+///
 /// :::warning Hash collision limit
 /// Each trie node supports at most 8 distinct keys with the same hash (`MAX_LEAF_SIZE = 8`). Exceeding this will cause a trap.
 /// :::
-/// 
+///
 /// :::info Credits
 /// Based on Section 6 of ["Incremental computation via function caching", Pugh & Teitelbaum](https://dl.acm.org/citation.cfm?id=75305).
 /// :::
-/// 
+///
 /// Example:
-/// 
+///
 /// ```motoko
 /// import Trie "mo:base/Trie";
 /// import Text "mo:base/Text";
-/// 
+///
 /// // we do this to have shorter type names and thus
 /// // better readability
 /// type Trie<K, V> = Trie.Trie<K, V>;
 /// type Key<K> = Trie.Key<K>;
-/// 
+///
 /// // we have to provide `put`, `get` and `remove` with
 /// // a record of type `Key<K> = { hash : Hash.Hash; key : K }`;
 /// // thus we define the following function that takes a value of type `K`
 /// // (in this case `Text`) and returns a `Key<K>` record.
 /// func key(t: Text) : Key<Text> { { hash = Text.hash t; key = t } };
-/// 
+///
 /// // we start off by creating an empty `Trie`
 /// let t0 : Trie<Text, Nat> = Trie.empty();
-/// 
+///
 /// // `put` requires 4 arguments:
 /// // - the trie we want to insert the value into,
 /// // - the key of the value we want to insert (note that we use the `key` function defined above),
@@ -45,7 +45,7 @@
 /// // and assign it to `t1` and `t2` respectively.
 /// let t1 : Trie<Text, Nat> = Trie.put(t0, key "hello", Text.equal, 42).0;
 /// let t2 : Trie<Text, Nat> = Trie.put(t1, key "world", Text.equal, 24).0;
-/// 
+///
 /// // If for a given key there already was a value in the trie, `put` returns
 /// // that previous value as the second element of the tuple.
 /// // in our case we have already inserted the value 42 for the key "hello", so
@@ -57,7 +57,7 @@
 ///  0,
 /// );
 /// assert (n == ?42);
-/// 
+///
 /// // `get` requires 3 arguments:
 /// // - the trie we want to get the value from
 /// // - the key of the value we want to get (note that we use the `key` function defined above)
@@ -68,7 +68,7 @@
 /// assert(value == ?0);
 /// value := Trie.get(t3, key "universe", Text.equal); // Returns `null`
 /// assert(value == null);
-/// 
+///
 /// // `remove` requires 3 arguments:
 /// // - the trie we want to remove the value from,
 /// // - the key of the value we want to remove (note that we use the `key` function defined above), and
@@ -84,7 +84,7 @@
 ///  Text.equal,
 /// ).1;
 /// assert (removedValue == ?0);
-/// 
+///
 /// // To iterate over the Trie, we use the `iter` function that takes a trie
 /// // of type `Trie<K,V>` and returns an iterator of type `Iter<(K,V)>`:
 /// var sum : Nat = 0;
@@ -185,18 +185,18 @@ module {
   public type Trie3D<K1, K2, K3, V> = Trie<K1, Trie2D<K2, K3, V>>;
 
   /// An empty trie. This is usually the starting point for building a trie.
-  /// 
+  ///
   /// Example:
   /// ```motoko name=initialize
   /// import { print } "mo:base/Debug";
   /// import Trie "mo:base/Trie";
   /// import Text "mo:base/Text";
-  /// 
+  ///
   /// // we do this to have shorter type names and thus
   /// // better readibility
   /// type Trie<K, V> = Trie.Trie<K, V>;
   /// type Key<K> = Trie.Key<K>;
-  /// 
+  ///
   /// // We have to provide `put`, `get` and `remove` with
   /// // a function of return type `Key<K> = { hash : Hash.Hash; key : K }`
   /// func key(t: Text) : Key<Text> { { hash = Text.hash t; key = t } };
@@ -206,8 +206,8 @@ module {
   public func empty<K, V>() : Trie<K, V> = #empty;
 
   /// Get the size in O(1) time.
-  /// 
-  /// 
+  ///
+  ///
   /// Example:
   /// ```motoko include=initialize
   /// var size = Trie.size(trie); // Returns 0, as `trie` is empty
@@ -232,7 +232,7 @@ module {
   };
 
   /// Construct a leaf node, computing the size stored there.
-  /// 
+  ///
   /// This helper function automatically enforces the MAX_LEAF_SIZE
   /// by constructing branches as necessary; to do so, it also needs the bitpos
   /// of the leaf.
@@ -292,7 +292,7 @@ module {
   };
 
   /// Clone the trie efficiently, via sharing.
-  /// 
+  ///
   /// Purely-functional representation permits _O(1)_ copy, via persistent sharing.
   public func clone<K, V>(t : Trie<K, V>) : Trie<K, V> = t;
 
@@ -324,11 +324,11 @@ module {
   /// Replace the given key's value option with the given value, returning the modified trie.
   /// Also returns the replaced value if the key existed and `null` otherwise.
   /// Compares keys using the provided function `k_eq`.
-  /// 
+  ///
   /// :::note
   /// Replacing a key's value by `null` removes the key and also shrinks the trie.
   /// :::
-  /// 
+  ///
   /// Example:
   /// ```motoko include=initialize
   /// trie := Trie.put(trie, key "test", Text.equal, 1).0;
@@ -367,8 +367,8 @@ module {
   };
 
   /// Put the given key's value in the trie; return the new trie, and the previous value associated with the key, if any.
-  /// 
-  /// 
+  ///
+  ///
   /// Example:
   /// ```motoko include=initialize
   /// trie := Trie.put(trie, key "hello", Text.equal, 42).0;
@@ -378,8 +378,8 @@ module {
   public func put<K, V>(t : Trie<K, V>, k : Key<K>, k_eq : (K, K) -> Bool, v : V) : (Trie<K, V>, ?V) = replace(t, k, k_eq, ?v);
 
   /// Get the value of the given key in the trie, or return null if nonexistent.
-  /// 
-  /// 
+  ///
+  ///
   /// Example:
   /// ```motoko include=initialize
   /// trie := Trie.put(trie, key "hello", Text.equal, 42).0;
@@ -391,8 +391,8 @@ module {
   public func get<K, V>(t : Trie<K, V>, k : Key<K>, k_eq : (K, K) -> Bool) : ?V = find(t, k, k_eq);
 
   /// Find the given key's value in the trie, or return `null` if nonexistent
-  /// 
-  /// 
+  ///
+  ///
   /// Example:
   /// ```motoko include=initialize
   /// trie := Trie.put(trie, key "hello", Text.equal, 42).0;
@@ -440,13 +440,13 @@ module {
 
   /// Merge tries, preferring the left trie where there are collisions
   /// in common keys.
-  /// 
+  ///
   /// :::note
   /// The `disj` operation generalizes this `merge`
   /// operation in various ways, and does not (in general) lose
   /// information; this operation is a simpler, special case.
   /// :::
-  /// 
+  ///
   /// Example:
   /// ```motoko include=initialize
   /// trie := Trie.put(trie, key "hello", Text.equal, 42).0;
@@ -500,11 +500,11 @@ module {
   };
 
   /// <a name="mergedisjoint"></a>
-  /// 
+  ///
   /// Merge tries like `merge`, but traps if there are collisions in common keys between the
   /// left and right inputs.
-  /// 
-  /// 
+  ///
+  ///
   /// Example:
   /// ```motoko include=initialize
   /// trie := Trie.put(trie, key "hello", Text.equal, 42).0;
@@ -557,8 +557,8 @@ module {
   /// Difference of tries. The output consists of pairs of
   /// the left trie whose keys are not present in the right trie; the
   /// values of the right trie are irrelevant.
-  /// 
-  /// 
+  ///
+  ///
   /// Example:
   /// ```motoko include=initialize
   /// trie := Trie.put(trie, key "hello", Text.equal, 42).0;
@@ -607,19 +607,19 @@ module {
   };
 
   /// Map disjunction.
-  /// 
+  ///
   /// This operation generalizes the notion of "set union" to finite maps.
-  /// 
+  ///
   /// Produces a "disjunctive image" of the two tries, where the values of
   /// matching keys are combined with the given binary operator.
-  /// 
+  ///
   /// For unmatched key-value pairs, the operator is still applied to
   /// create the value in the image.  To accomodate these various
   /// situations, the operator accepts optional values, but is never
   /// applied to (null, null).
-  /// 
+  ///
   /// Implements the database idea of an ["outer join"](https://stackoverflow.com/questions/38549/what-is-the-difference-between-inner-join-and-outer-join).
-  /// 
+  ///
   public func disj<K, V, W, X>(
     tl : Trie<K, V>,
     tr : Trie<K, W>,
@@ -684,13 +684,13 @@ module {
   };
 
   /// Map join.
-  /// 
+  ///
   /// Implements the database idea of an ["inner join"](https://stackoverflow.com/questions/38549/what-is-the-difference-between-inner-join-and-outer-join).
-  /// 
+  ///
   /// This operation generalizes the notion of "set intersection" to
   /// finite maps.  The values of matching keys are combined with the given binary
   /// operator, and unmatched key-value pairs are not present in the output.
-  /// 
+  ///
   public func join<K, V, W, X>(
     tl : Trie<K, V>,
     tr : Trie<K, W>,
@@ -744,16 +744,16 @@ module {
   };
 
   /// Map product.
-  /// 
+  ///
   /// Conditional _catesian product_, where the given
   /// operation `op` _conditionally_ creates output elements in the
   /// resulting trie.
-  /// 
+  ///
   /// The keyed structure of the input tries are not relevant for this
   /// operation: all pairs are considered, regardless of keys matching or
   /// not.  Moreover, the resulting trie may use keys that are unrelated to
   /// these input keys.
-  /// 
+  ///
   public func prod<K1, V1, K2, V2, K3, V3>(
     tl : Trie<K1, V1>,
     tr : Trie<K2, V2>,
@@ -782,10 +782,10 @@ module {
   };
 
   /// Returns an iterator of type `Iter` over the key-value entries of the trie.
-  /// 
+  ///
   /// Each iterator gets a _persistent view_ of the mapping, independent of concurrent updates to the iterated map.
-  /// 
-  /// 
+  ///
+  ///
   /// Example:
   /// ```motoko include=initialize
   /// trie := Trie.put(trie, key "hello", Text.equal, 42).0;
@@ -830,22 +830,22 @@ module {
   };
 
   /// Represent the construction of tries as data.
-  /// 
+  ///
   /// This module provides optimized variants of normal tries, for
   /// more efficient join queries.
-  /// 
+  ///
   /// The central insight is that for (unmaterialized) join query results, we
   /// do not need to actually build any resulting trie of the resulting
   /// data, but rather, just need a collection of what would be in that
   /// trie.  Since query results can be large (quadratic in the DB size),
   /// avoiding the construction of this trie provides a considerable savings.
-  /// 
+  ///
   /// To get this savings, we use an ADT for the operations that _would_ build this trie,
   /// if evaluated. This structure specializes a rope: a balanced tree representing a
   /// sequence.  It is only as balanced as the tries from which we generate
   /// these build ASTs.  They have no intrinsic balance properties of their
   /// own.
-  /// 
+  ///
   public module Build {
     /// The build of a trie, as an AST for a simple DSL.
     public type Build<K, V> = {
@@ -901,7 +901,7 @@ module {
     };
 
     /// Project the nth key-value pair from the trie build.
-    /// 
+    ///
     /// This position is meaningful only when the build contains multiple uses of one or more keys, otherwise it is not.
     public func nth<K, V>(tb : Build<K, V>, i : Nat) : ?(K, ?Hash.Hash, V) {
       func rec(tb : Build<K, V>, i : Nat) : ?(K, ?Hash.Hash, V) = switch tb {
@@ -958,8 +958,8 @@ module {
 
   /// Fold over the key-value pairs of the trie, using an accumulator.
   /// The key-value pairs have no reliable or meaningful ordering.
-  /// 
-  /// 
+  ///
+  ///
   /// Example:
   /// ```motoko include=initialize
   /// trie := Trie.put(trie, key "hello", Text.equal, 42).0;
@@ -988,8 +988,8 @@ module {
   };
 
   /// Test whether a given key-value pair is present, or not.
-  /// 
-  /// 
+  ///
+  ///
   /// Example:
   /// ```motoko include=initialize
   /// trie := Trie.put(trie, key "hello", Text.equal, 42).0;
@@ -1023,8 +1023,8 @@ module {
   };
 
   /// Test whether all key-value pairs have a given property.
-  /// 
-  /// 
+  ///
+  ///
   /// Example:
   /// ```motoko include=initialize
   /// trie := Trie.put(trie, key "hello", Text.equal, 42).0;
@@ -1060,12 +1060,12 @@ module {
   };
 
   /// Project the nth key-value pair from the trie.
-  /// 
+  ///
   /// :::note
   /// This position is not meaningful; it's only here so that we
   /// can inject tries into arrays using functions like `Array.tabulate`.
   /// :::
-  /// 
+  ///
   /// Example:
   /// ```motoko include=initialize
   /// import Array "mo:base/Array";
@@ -1103,8 +1103,8 @@ module {
   };
 
   /// Gather the collection of key-value pairs into an array of a (possibly-distinct) type.
-  /// 
-  /// 
+  ///
+  ///
   /// Example:
   /// ```motoko include=initialize
   /// trie := Trie.put(trie, key "hello", Text.equal, 42).0;
@@ -1136,8 +1136,8 @@ module {
   public func isEmpty<K, V>(t : Trie<K, V>) : Bool = size(t) == 0;
 
   /// Filter the key-value pairs by a given predicate.
-  /// 
-  /// 
+  ///
+  ///
   /// Example:
   /// ```motoko include=initialize
   /// trie := Trie.put(trie, key "hello", Text.equal, 42).0;
@@ -1174,8 +1174,8 @@ module {
   };
 
   /// Map and filter the key-value pairs by a given predicate.
-  /// 
-  /// 
+  ///
+  ///
   /// Example:
   /// ```motoko include=initialize
   /// trie := Trie.put(trie, key "hello", Text.equal, 42).0;
@@ -1249,8 +1249,8 @@ module {
   /// Replace the given key's value in the trie,
   /// and only if successful, do the success continuation,
   /// otherwise, return the failure value
-  /// 
-  /// 
+  ///
+  ///
   /// Example:
   /// ```motoko include=initialize
   /// trie := Trie.put(trie, key "hello", Text.equal, 42).0;
@@ -1296,7 +1296,7 @@ module {
   };
 
   /// Put the given key's value in the trie; return the new trie; assert that no prior value is associated with the key.
-  /// 
+  ///
   /// Example:
   /// ```motoko include=initialize
   /// // note that compared to `put`, `putFresh` does not return a tuple
@@ -1369,11 +1369,11 @@ module {
   /// Remove the entry for the given key from the trie, by returning the reduced trie.
   /// Also returns the removed value if the key existed and `null` otherwise.
   /// Compares keys using the provided function `k_eq`.
-  /// 
-  /// :::note 
+  ///
+  /// :::note
   /// The removal of an existing key shrinks the trie.
   /// :::
-  /// 
+  ///
   /// Example:
   /// ```motoko include=initialize
   /// trie := Trie.put(trie, key "hello", Text.equal, 42).0;

--- a/src/TrieMap.mo
+++ b/src/TrieMap.mo
@@ -1,40 +1,40 @@
 /// Class `TrieMap<K, V>` provides a map from keys of type `K` to values of type `V`.
 /// The class wraps and manipulates an underlying hash trie, found in the `Trie` module.
 /// The trie is a binary tree where element positions are determined using the hash of the keys.
-/// 
+///
 /// :::warning Limitations
-/// 
+///
 /// This data structure allows at most `MAX_LEAF_SIZE = 8` hash collisions.
 /// Attempts to insert more than 8 keys (whether directly via `put` or indirectly via other operations) with the same hash value will trap.
 /// This limitation is inherited from the underlying `Trie` data structure.
 /// :::
-/// 
+///
 /// :::note Interface compatibility
-/// 
+///
 /// The `class` `TrieMap` exposes the same interface as `HashMap`.
 /// :::
-/// 
+///
 /// :::note Assumptions
-/// 
+///
 /// Runtime and space complexity assumes that `hash`, `equal`, and other function parameters execute in `O(1)` time and space.
 /// Where applicable, runtimes also assume the trie is reasonably balanced.
 /// :::
-/// 
+///
 /// :::note Iterator performance
-/// 
+///
 /// All iterator-related runtime and space costs refer to iterator construction.
 /// The iteration itself takes linear time and logarithmic space to execute.
 /// :::
-/// 
+///
 /// Creating a map:
 /// The equality function is used to compare keys, and the hash function is used to hash keys. See the example below.
-/// 
+///
 /// ```motoko name=initialize
 /// import TrieMap "mo:base/TrieMap";
 /// import Nat "mo:base/Nat";
 /// import Hash "mo:base/Hash";
 /// import Iter "mo:base/Iter";
-/// 
+///
 /// let map = TrieMap.TrieMap<Nat, Nat>(Nat.equal, Hash.hash)
 /// ```
 
@@ -50,12 +50,12 @@ module {
     var _size : Nat = 0;
 
     /// Returns the number of entries in the map.
-    /// 
+    ///
     /// Example:
     /// ```motoko include=initialize
     /// map.size()
     /// ```
-    /// 
+    ///
     /// | Runtime        | Space         |
     /// |----------------|---------------|
     /// | `O(1)`   | `O(log(1))`  |
@@ -63,14 +63,14 @@ module {
 
     /// Maps `key` to `value`, and overwrites the old entry if the key
     /// was already present.
-    /// 
+    ///
     /// Example:
     /// ```motoko include=initialize
     /// map.put(0, 10);
     /// map.put(2, 12);
     /// Iter.toArray(map.entries())
     /// ```
-    /// 
+    ///
     /// | Runtime        | Space         |
     /// |----------------|---------------|
     /// | `O(log(size))`   | `O(log(size))`  |
@@ -78,13 +78,13 @@ module {
 
     /// Maps `key` to `value`. Overwrites _and_ returns the old entry as an
     /// option if the key was already present, and `null` otherwise.
-    /// 
+    ///
     /// Example:
     /// ```motoko include=initialize
     /// map.put(0, 10);
     /// map.replace(0, 20)
     /// ```
-    /// 
+    ///
     /// | Runtime        | Space         |
     /// |----------------|---------------|
     /// | `O(log(size))`   | `O(log(size))`  |
@@ -101,13 +101,13 @@ module {
 
     /// Gets the value associated with the key `key` in an option, or `null` if it
     /// doesn't exist.
-    /// 
+    ///
     /// Example:
     /// ```motoko include=initialize
     /// map.put(0, 10);
     /// map.get(0)
     /// ```
-    /// 
+    ///
     /// | Runtime        | Space         |
     /// |----------------|---------------|
     /// | `O(log(size))`   | `O(log(size))`  |
@@ -118,18 +118,18 @@ module {
 
     /// Delete the entry associated with key `key`, if it exists. If the key is
     /// absent, there is no effect.
-    /// 
+    ///
     /// :::note
     /// The deletion of an existing key shrinks the trie map.
     /// :::
-    /// 
+    ///
     /// Example:
     /// ```motoko include=initialize
     /// map.put(0, 10);
     /// map.delete(0);
     /// map.get(0)
     /// ```
-    /// 
+    ///
     /// | Runtime        | Space         |
     /// |----------------|---------------|
     /// | `O(log(size))`   | `O(log(size))`  |
@@ -137,17 +137,17 @@ module {
 
     /// Delete the entry associated with key `key`. Return the deleted value
     /// as an option if it exists, and `null` otherwise.
-    /// 
+    ///
     /// :::note
     /// The deletion of an existing key shrinks the trie map.
     /// :::
-    /// 
+    ///
     /// Example:
     /// ```motoko include=initialize
     /// map.put(0, 10);
     /// map.remove(0)
     /// ```
-    /// 
+    ///
     /// | Runtime        | Space         |
     /// |----------------|---------------|
     /// | `O(log(size))`   | `O(log(size))`  |
@@ -163,16 +163,16 @@ module {
     };
 
     /// Returns an iterator over the keys of the map.
-    /// 
+    ///
     /// Each iterator gets a _snapshot view_ of the mapping, and is unaffected
     /// by concurrent updates to the iterated map.
-    /// 
+    ///
     /// Example:
     /// ```motoko include=initialize
     /// map.put(0, 10);
     /// map.put(1, 11);
     /// map.put(2, 12);
-    /// 
+    ///
     /// // find the sum of all the keys
     /// var sum = 0;
     /// for (key in map.keys()) {
@@ -181,7 +181,7 @@ module {
     /// // 0 + 1 + 2
     /// sum
     /// ```
-    /// 
+    ///
     /// | Runtime | Space |
     /// |---------|--------|
     /// | `O(1)`    | `O(1)`   |
@@ -190,16 +190,16 @@ module {
     };
 
     /// Returns an iterator over the values in the map.
-    /// 
+    ///
     /// Each iterator gets a _snapshot view_ of the mapping, and is unaffected
     /// by concurrent updates to the iterated map.
-    /// 
+    ///
     /// Example:
     /// ```motoko include=initialize
     /// map.put(0, 10);
     /// map.put(1, 11);
     /// map.put(2, 12);
-    /// 
+    ///
     /// // find the sum of all the values
     /// var sum = 0;
     /// for (key in map.vals()) {
@@ -208,7 +208,7 @@ module {
     /// // 10 + 11 + 12
     /// sum
     /// ```
-    /// 
+    ///
     /// | Runtime | Space |
     /// |---------|--------|
     /// | `O(1)`   | `O(1)`  |
@@ -217,16 +217,16 @@ module {
     };
 
     /// Returns an iterator over the entries (key-value pairs) in the map.
-    /// 
+    ///
     /// Each iterator gets a _snapshot view_ of the mapping, and is unaffected
     /// by concurrent updates to the iterated map.
-    /// 
+    ///
     /// Example:
     /// ```motoko include=initialize
     /// map.put(0, 10);
     /// map.put(1, 11);
     /// map.put(2, 12);
-    /// 
+    ///
     /// // find the sum of all the products of key-value pairs
     /// var sum = 0;
     /// for ((key, value) in map.entries()) {
@@ -235,7 +235,7 @@ module {
     /// // (0 * 10) + (1 * 11) + (2 * 12)
     /// sum
     /// ```
-    /// 
+    ///
     /// | Runtime | Space |
     /// |---------|--------|
     /// | `O(1)`    | `O(1)`   |
@@ -273,7 +273,7 @@ module {
 
   /// Produce a copy of `map`, using `keyEq` to compare keys and `keyHash` to
   /// hash keys.
-  /// 
+  ///
   /// Example:
   /// ```motoko include=initialize
   /// map.put(0, 10);
@@ -283,7 +283,7 @@ module {
   /// let mapCopy = TrieMap.clone(map, Nat.equal, Hash.hash);
   /// Iter.toArray(mapCopy.entries())
   /// ```
-  /// 
+  ///
   /// | Runtime             | Space    |
   /// |---------------------|----------|
   /// | `O(size * log(size))` | `O(size)`  |
@@ -301,14 +301,14 @@ module {
 
   /// Create a new map from the entries in `entries`, using `keyEq` to compare
   /// keys and `keyHash` to hash keys.
-  /// 
+  ///
   /// Example:
   /// ```motoko include=initialize
   /// let entries = [(0, 10), (1, 11), (2, 12)];
   /// let newMap = TrieMap.fromEntries<Nat, Nat>(entries.vals(), Nat.equal, Hash.hash);
   /// newMap.get(2)
   /// ```
-  /// 
+  ///
   /// | Runtime             | Space    |
   /// |---------------------|----------|
   /// | `O(size * log(size))` | `O(size)`  |
@@ -326,7 +326,7 @@ module {
 
   /// Transform (map) the values in `map` using function `f`, retaining the keys.
   /// Uses `keyEq` to compare keys and `keyHash` to hash keys.
-  /// 
+  ///
   /// Example:
   /// ```motoko include=initialize
   /// map.put(0, 10);
@@ -336,7 +336,7 @@ module {
   /// let newMap = TrieMap.map<Nat, Nat, Nat>(map, Nat.equal, Hash.hash, func(key, value) = value * 2);
   /// Iter.toArray(newMap.entries())
   /// ```
-  /// 
+  ///
   /// | Runtime             | Space    |
   /// |---------------------|----------|
   /// | `O(size * log(size))` | `O(size)`  |
@@ -357,7 +357,7 @@ module {
   /// Transform (map) the values in `map` using function `f`, discarding entries
   /// for which `f` evaluates to `null`. Uses `keyEq` to compare keys and
   /// `keyHash` to hash keys.
-  /// 
+  ///
   /// Example:
   /// ```motoko include=initialize
   /// map.put(0, 10);
@@ -373,7 +373,7 @@ module {
   ///   );
   /// Iter.toArray(newMap.entries())
   /// ```
-  /// 
+  ///
   /// | Runtime             | Space    |
   /// |---------------------|----------|
   /// | `O(size * log(size))` | `O(size)`

--- a/src/TrieSet.mo
+++ b/src/TrieSet.mo
@@ -1,14 +1,14 @@
-/// 
+///
 /// Sets are partial maps from element type to unit type,
 /// i.e., the partial map represents the set with its domain.
-/// 
+///
 /// :::warning Limitations
-/// 
+///
 /// This data structure allows at most `MAX_LEAF_SIZE = 8` hash collisions.
 /// Attempts to insert more than 8 elements with the same hash value—either directly via `put` or indirectly via other operations—will trap.
 /// This limitation is inherited from the underlying `Trie` data structure.
 /// :::
-/// 
+///
 
 // TODO-Matthew:
 // ---------------
@@ -114,7 +114,7 @@ module {
   /// :::warning Deprecated function
   /// Use `TrieSet.contains()` instead.
   /// :::
-  /// 
+  ///
   /// Test if a set contains a given element.
   public func mem<T>(s : Set<T>, x : T, xh : Hash, eq : (T, T) -> Bool) : Bool {
     contains(s, x, xh, eq)


### PR DESCRIPTION
 restore deprecations (so compiler will still warn)
 remove trailing whitespace
 fix Buffer.toVarArray