### PR TITLE
feat: bring motoko-base in line with moc

### DIFF
--- a/test/Makefile
+++ b/test/Makefile
@@ -21,8 +21,8 @@ STDLIB_FILES= $(wildcard $(STDLIB)/*.mo)
 VESSEL_PKGS= $(shell vessel sources)
 
 MOC_COMMON_FLAGS=-c --package base $(STDLIB) $(VESSEL_PKGS) -wasi-system-api
-MOC_CLASSICAL=$(MOC) $(MOC_COMMON_FLAGS)
-MOC_ENHANCED=$(MOC) $(MOC_COMMON_FLAGS) --enhanced-orthogonal-persistence
+MOC_CLASSICAL=$(MOC) $(MOC_COMMON_FLAGS) --legacy-persistence
+MOC_ENHANCED=$(MOC) $(MOC_COMMON_FLAGS)
 
 $(OUTDIR):
 	@mkdir $@


### PR DESCRIPTION
A new `moc` [version](https://github.com/dfinity/motoko/pull/5305) will have `--enhanced-orthogonal-persistence` behavior default (and the flag will be optional). Furthermore, all classical persistence behavior and old GCs will be only available under `--legacy-persistence`.
