### PR TITLE
fix: update CI and repository URLs for `caffeinelabs` org

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
       - master
   pull_request:
 
+permissions:
+  contents: write
+
 # Remember to update me in package-set.yml as well
 env:
   vessel_version: "v0.7.0"
@@ -56,9 +59,8 @@ jobs:
         popd
         python3 doc/module_nav.py > doc/modules/base-libraries/lib-nav.adoc
     - name: Upload docs
-      uses: JamesIves/github-pages-deploy-action@releases/v3
+      uses: JamesIves/github-pages-deploy-action@v4
       if: github.ref == 'refs/heads/master'
       with:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        BRANCH: doc-pages
-        FOLDER: doc/
+        branch: doc-pages
+        folder: doc/

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ If you build your project using the [Vessel package manager] your package-set mo
 ```
   {
     name = "base",
-    repo = "https://github.com/dfinity/motoko-base",
+    repo = "https://github.com/caffeinelabs/motoko-base",
     version = "master",
     dependencies = [] : List Text
   }
@@ -46,7 +46,7 @@ Run the following commands to configure your local development branch:
 
 ```sh
 # First-time setup
-git clone https://github.com/dfinity/motoko-base
+git clone https://github.com/caffeinelabs/motoko-base
 cd motoko-base
 npm install
 

--- a/doc/README.md
+++ b/doc/README.md
@@ -13,5 +13,5 @@ Requires Python3 and Graphviz, then follow the instructions in `module_graph.py`
 
 ## Deploy to SDK website
 
-Library docs are auto-generated to [`doc-pages`](https://github.com/dfinity/motoko-base/tree/doc-pages) branch for every PR merged in `master`.
+Library docs are auto-generated to [`doc-pages`](https://github.com/caffeinelabs/motoko-base/tree/doc-pages) branch for every PR merged in `master`.
 The SDK playbook fetches the docs from `doc-pages` for each release.

--- a/doc/modules/base-libraries/pages/stdlib-intro.adoc
+++ b/doc/modules/base-libraries/pages/stdlib-intro.adoc
@@ -27,7 +27,7 @@ import Types "./types";
 
 == Viewing the base library modules
 
-You can find source code and documentation for {proglang} base modules in the link:https://github.com/dfinity/motoko-base[motoko-base] open source repository.
+You can find source code and documentation for {proglang} base modules in the link:https://github.com/caffeinelabs/motoko-base[motoko-base] open source repository.
 There are instructions in the repository for generating a local copy of the current documentation for the {proglang} base library.
 
 You can also search for documentation by using Search in any page of the Developer Center.

--- a/mops.toml
+++ b/mops.toml
@@ -2,7 +2,7 @@
 name = "base"
 version = "0.16.2"
 description = "The Motoko base library"
-repository = "https://github.com/dfinity/motoko-base"
+repository = "https://github.com/caffeinelabs/motoko-base"
 keywords = [ "base" ]
 license = "Apache-2.0"
 

--- a/package.json
+++ b/package.json
@@ -12,15 +12,15 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/dfinity/motoko-base.git"
+    "url": "git+https://github.com/caffeinelabs/motoko-base.git"
   },
   "keywords": [],
   "author": "",
   "license": "ISC",
   "bugs": {
-    "url": "https://github.com/dfinity/motoko-base/issues"
+    "url": "https://github.com/caffeinelabs/motoko-base/issues"
   },
-  "homepage": "https://github.com/dfinity/motoko-base#readme",
+  "homepage": "https://github.com/caffeinelabs/motoko-base#readme",
   "devDependencies": {
     "execa": "^4.1.0",
     "fast-glob": "^3.2.12",

--- a/src/List.mo
+++ b/src/List.mo
@@ -380,7 +380,7 @@ module {
   /// |-------------|-------------|
   /// | `O(size*size)`  | `O(size*size)`  |
   public func flatten<T>(l : List<List<T>>) : List<T> {
-    //FIXME: this is quadratic, not linear https://github.com/dfinity/motoko-base/issues/459
+    //FIXME: this is quadratic, not linear https://github.com/caffeinelabs/motoko-base/issues/459
     foldLeft<List<T>, List<T>>(l, null, func(a, b) { append<T>(a, b) })
   };
 

--- a/test/js/validate/checkReferences.js
+++ b/test/js/validate/checkReferences.js
@@ -1,6 +1,6 @@
 "use strict";
 
-// Detect "mo:base/..." imports within the base library itself (https://github.com/dfinity/motoko-base/pull/487)
+// Detect "mo:base/..." imports within the base library itself (https://github.com/caffeinelabs/motoko-base/pull/487)
 
 const { join } = require("path");
 const { readFileSync } = require("fs");


### PR DESCRIPTION
Fixes CI on the master branch ([example output](https://github.com/caffeinelabs/motoko-base/actions/runs/23853438377/job/69542576422)).