### PR TITLE
chore: pin GitHub Actions to commit SHAs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,8 +19,8 @@ jobs:
     if: github.ref != 'refs/heads/next-moc' && github.base_ref != 'refs/heads/next-moc'
     runs-on: ubuntu-24.04
     steps:
-    - uses: actions/checkout@v4
-    - uses: actions/setup-node@v4
+    - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+    - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
       with:
         node-version: 18
     - run: npm ci
@@ -28,7 +28,7 @@ jobs:
       run: npm run validate
     - name: Check if Git tag exists
       run: echo "name=HEAD_TAG::$(git tag --points-at HEAD)" >> $GITHUB_ENV
-    - uses: cachix/install-nix-action@v22
+    - uses: cachix/install-nix-action@6ed004b9ccb68dbc28e7c85bee15fa93dbd214ac # v22
       with:
         nix_path: nixpkgs=channel:nixos-22.11
     - name: "install dependencies"
@@ -59,7 +59,7 @@ jobs:
         popd
         python3 doc/module_nav.py > doc/modules/base-libraries/lib-nav.adoc
     - name: Upload docs
-      uses: JamesIves/github-pages-deploy-action@v4
+      uses: JamesIves/github-pages-deploy-action@d92aa235d04922e8f08b40ce78cc5442fcfbfa2f # v4.8.0
       if: github.ref == 'refs/heads/master'
       with:
         branch: doc-pages

--- a/.github/workflows/mops-publish.yml
+++ b/.github/workflows/mops-publish.yml
@@ -11,8 +11,8 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
-      - uses: ZenVoich/setup-mops@v1
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - uses: ZenVoich/setup-mops@3e94e453352269b34137b5ce49f09a8df81bed7d # v1.4.1
         with:
           # Make sure you set the MOPS_IDENTITY_PEM secret in your repository settings https://docs.github.com/en/actions/security-guides/using-secrets-in-github-actions#creating-secrets-for-a-repository
           identity-pem: ${{ secrets.MOPS_IDENTITY_PEM }}

--- a/.github/workflows/package-set.yml
+++ b/.github/workflows/package-set.yml
@@ -15,12 +15,12 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
     - name: Checking out motoko-base
-      uses: actions/checkout@v4
+      uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
       with:
         fetch-depth: 0
         path: base-checkout
     - name: Checking out vessel-package-set
-      uses: actions/checkout@v4
+      uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
       with:
         repository: dfinity/vessel-package-set
         path: vessel-package-set

--- a/.github/workflows/prettier.yml
+++ b/.github/workflows/prettier.yml
@@ -16,9 +16,9 @@ jobs:
         os: [ubuntu-24.04]
         node: [18]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
       - name: Use Node.js ${{ matrix.node }}
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: ${{ matrix.node }}
       - run: npm install -g npm

--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -7,9 +7,9 @@ jobs:
   sync-branch:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
       - name: Merge master -> next-moc
-        uses: devmasx/merge-branch@v1.3.1
+        uses: devmasx/merge-branch@a1752b9ba42bb417ec19be7dc974e2faf77d3ef2 # v1.3.1
         with:
           type: now
           from_branch: master


### PR DESCRIPTION
## Pin GitHub Actions to commit SHAs

GitHub Actions referenced by tag (e.g. `actions/checkout@v4`) use a mutable pointer — the tag owner can move it to a different commit at any time, including a malicious one. This is the attack vector used in the tj-actions/changed-files incident (CVE-2025-30066).

Pinning to a full 40-character commit SHA makes the reference immutable. The `# tag` comment preserves human readability so reviewers can tell which version is pinned.

Important: a SHA can also originate from a forked repository. A malicious actor can fork an action, push a compromised commit to the fork, and the SHA will resolve — but it won't exist in the upstream canonical repo. Each SHA in this PR was verified against the action's canonical repository (not a fork).

### Changes

- `actions/checkout@v4` -> `actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1`
  - Version: v4.3.1 | Latest: v6.0.2 | Release age: 90d
  - Commit: https://github.com/actions/checkout/commit/34e114876b0b11c390a56381ad16ebd13914f8d5

- `actions/setup-node@v4` -> `actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0`
  - Version: v4.4.0 | Latest: v6.3.0 | Release age: 37d
  - Commit: https://github.com/actions/setup-node/commit/49933ea5288caeca8642d1e84afbd3f7d6820020

- `cachix/install-nix-action@v22` -> `cachix/install-nix-action@6ed004b9ccb68dbc28e7c85bee15fa93dbd214ac # v22`
  - Version: v22 | Latest: v31.10.4 | Release age: 396d
  - Commit: https://github.com/cachix/install-nix-action/commit/6ed004b9ccb68dbc28e7c85bee15fa93dbd214ac
  - Warnings: Latest release v31.10.4 is only 1 day(s) old (< 7 days). Using previous safe release.

- `JamesIves/github-pages-deploy-action@v4` -> `JamesIves/github-pages-deploy-action@d92aa235d04922e8f08b40ce78cc5442fcfbfa2f # v4.8.0`
  - Version: v4.8.0 | Latest: v4.8.0 | Release age: 90d
  - Commit: https://github.com/JamesIves/github-pages-deploy-action/commit/d92aa235d04922e8f08b40ce78cc5442fcfbfa2f

- `ZenVoich/setup-mops@v1` -> `ZenVoich/setup-mops@3e94e453352269b34137b5ce49f09a8df81bed7d # v1.4.1`
  - Version: v1.4.1 | Latest: v1.4.1 | Release age: 569d
  - Commit: https://github.com/ZenVoich/setup-mops/commit/3e94e453352269b34137b5ce49f09a8df81bed7d

- `devmasx/merge-branch@v1.3.1` -> `devmasx/merge-branch@a1752b9ba42bb417ec19be7dc974e2faf77d3ef2 # v1.3.1`
  - Version: v1.3.1 | Latest: 1.4.0 | Release age: 1684d
  - Commit: https://github.com/devmasx/merge-branch/commit/a1752b9ba42bb417ec19be7dc974e2faf77d3ef2


### Files modified

- `.github/workflows/ci.yml`
- `.github/workflows/mops-publish.yml`
- `.github/workflows/package-set.yml`
- `.github/workflows/prettier.yml`
- `.github/workflows/sync.yml`

### Security warnings

- Latest release v31.10.4 is only 1 day(s) old (< 7 days). Using previous safe release.