### PR TITLE
chore: bump `install-nix-action` to v31.10.6 and channel to `nixos-25.11`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,8 +33,7 @@ jobs:
         nix_path: nixpkgs=channel:nixos-25.11
     - name: "install dependencies"
       run: |
-        nix-env --install wasmtime --file '<nixpkgs>'
-        nix-env --install graphviz --file '<nixpkgs>'
+        nix-env -iA nixpkgs.wasmtime nixpkgs.graphviz
     - name: "install Motoko binaries"
       run: |
        wget https://github.com/dfinity/motoko/releases/download/${{ env.moc_version }}/motoko-Linux-x86_64-${{ env.moc_version }}.tar.gz

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ permissions:
 # Remember to update me in package-set.yml as well
 env:
   vessel_version: "v0.7.0"
-  moc_version: "0.16.2"
+  moc_version: "1.8.0"
 
 jobs:
   tests:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
         nix_path: nixpkgs=channel:nixos-25.11
     - name: "install dependencies"
       run: |
-        nix-env -iA nixpkgs.wasmtime nixpkgs.graphviz
+        nix-env -iA wasmtime graphviz -f '<nixpkgs>'
     - name: "install Motoko binaries"
       run: |
        wget https://github.com/dfinity/motoko/releases/download/${{ env.moc_version }}/motoko-Linux-x86_64-${{ env.moc_version }}.tar.gz

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
     - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
-    - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+    - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
       with:
         node-version: 24
     - run: npm ci

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,9 +28,9 @@ jobs:
       run: npm run validate
     - name: Check if Git tag exists
       run: echo "name=HEAD_TAG::$(git tag --points-at HEAD)" >> $GITHUB_ENV
-    - uses: cachix/install-nix-action@6ed004b9ccb68dbc28e7c85bee15fa93dbd214ac # v22
+    - uses: cachix/install-nix-action@8aa03977d8d733052d78f4e008a241fd1dbf36b3 # v31.10.6
       with:
-        nix_path: nixpkgs=channel:nixos-22.11
+        nix_path: nixpkgs=channel:nixos-25.11
     - name: "install dependencies"
       run: |
         nix-env --install wasmtime --file '<nixpkgs>'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
     if: github.ref != 'refs/heads/next-moc' && github.base_ref != 'refs/heads/next-moc'
     runs-on: ubuntu-24.04
     steps:
-    - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
     - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
       with:
         node-version: 24

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
     - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
     - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
       with:
-        node-version: 18
+        node-version: 24
     - run: npm ci
     - name: "initial checks"
       run: npm run validate

--- a/.github/workflows/package-set.yml
+++ b/.github/workflows/package-set.yml
@@ -8,7 +8,7 @@ on:
 
 env:
   vessel_version: "v0.7.0"
-  moc_version: "0.16.2"
+  moc_version: "1.8.0"
 
 jobs:
   verify:

--- a/.github/workflows/package-set.yml
+++ b/.github/workflows/package-set.yml
@@ -15,12 +15,12 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
     - name: Checking out motoko-base
-      uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
         fetch-depth: 0
         path: base-checkout
     - name: Checking out vessel-package-set
-      uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
         repository: dfinity/vessel-package-set
         path: vessel-package-set

--- a/.github/workflows/prettier.yml
+++ b/.github/workflows/prettier.yml
@@ -14,11 +14,11 @@ jobs:
       fail-fast: true
       matrix:
         os: [ubuntu-24.04]
-        node: [18]
+        node: [24]
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Use Node.js ${{ matrix.node }}
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: ${{ matrix.node }}
       - run: npm install -g npm

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,51 @@
+## 1.8.0
+
+(nothing)
+
+## 1.7.0
+
+(nothing)
+
+## 1.6.0
+
+(nothing)
+
+## 1.5.1
+
+(nothing)
+
+## 1.5.0
+
+(nothing)
+
+## 1.4.1
+
+(nothing)
+
+## 1.4.0
+
+(nothing)
+
+## 1.3.0
+
+(nothing)
+
+## 1.2.0
+
+(nothing)
+
+## 1.1.0
+
+(nothing)
+
+## 1.0.0
+
+(nothing)
+
+## 0.16.3
+
+(nothing)
+
 ## 0.16.2
 
 (nothing)

--- a/mops.toml
+++ b/mops.toml
@@ -1,6 +1,6 @@
 [package]
 name = "base"
-version = "0.16.2"
+version = "1.8.0"
 description = "The Motoko base library"
 repository = "https://github.com/caffeinelabs/motoko-base"
 keywords = [ "base" ]
@@ -11,5 +11,5 @@ matchers = "https://github.com/kritzcreek/motoko-matchers#v2.1.0@781eb4980bf4238
 core = "https://github.com/dfinity/motoko-core"
 
 [toolchain]
-moc = "0.16.2"
+moc = "1.8.0"
 wasmtime = "35.0.0"

--- a/mops.toml
+++ b/mops.toml
@@ -12,4 +12,4 @@ core = "https://github.com/dfinity/motoko-core"
 
 [toolchain]
 moc = "1.8.0"
-wasmtime = "35.0.0"
+wasmtime = "44.0.1"

--- a/src/Buffer.mo
+++ b/src/Buffer.mo
@@ -2622,7 +2622,7 @@ module {
     let size = buffer.size();
     let newBuffer = Buffer<X>(size);
 
-    var i = 0;
+    let i = 0;
     var take = false;
     label iter for (element in buffer.vals()) {
       if (not (take or predicate element)) {

--- a/src/Text.mo
+++ b/src/Text.mo
@@ -443,7 +443,7 @@ module {
 
   private class CharBuffer(cs : Iter.Iter<Char>) : Iter.Iter<Char> = {
 
-    var stack : Stack.Stack<(Iter.Iter<Char>, Char)> = Stack.Stack();
+    let stack : Stack.Stack<(Iter.Iter<Char>, Char)> = Stack.Stack();
 
     public func pushBack(cs0 : Iter.Iter<Char>, c : Char) {
       stack.push((cs0, c))
@@ -587,7 +587,7 @@ module {
   /// Text.startsWith("Motoko", #text "Mo") // true
   /// ```
   public func startsWith(t : Text, p : Pattern) : Bool {
-    var cs = t.chars();
+    let cs = t.chars();
     let match = matchOfPattern(p);
     switch (match(cs)) {
       case (#success) { true };
@@ -606,7 +606,7 @@ module {
     let s1 = t.size();
     if (s2 > s1) return false;
     let match = matchOfPattern(p);
-    var cs1 = t.chars();
+    let cs1 = t.chars();
     var diff : Nat = s1 - s2;
     while (diff > 0) {
       ignore cs1.next();
@@ -670,7 +670,7 @@ module {
   public func stripStart(t : Text, p : Pattern) : ?Text {
     let s = sizeOfPattern(p);
     if (s == 0) return ?t;
-    var cs = t.chars();
+    let cs = t.chars();
     let match = matchOfPattern(p);
     switch (match(cs)) {
       case (#success) return ?fromIter(cs);
@@ -693,7 +693,7 @@ module {
     let s1 = t.size();
     if (s2 > s1) return null;
     let match = matchOfPattern(p);
-    var cs1 = t.chars();
+    let cs1 = t.chars();
     var diff : Nat = s1 - s2;
     while (diff > 0) {
       ignore cs1.next();


### PR DESCRIPTION
The pinned `cachix/install-nix-action@v22` and `nixpkgs=channel:nixos-22.11` (Nov 2022) in CI are over three years old. Bump to match what `dfinity/motoko` itself uses (v31.10.6) and the current stable channel (nixos-25.11). The channel is only used to `nix-env --install wasmtime graphviz`.